### PR TITLE
Release 0.4.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ You will see:
 
 ![](https://raw.githubusercontent.com/pygae/galgebra/master/doc/images/st4_M3.svg?sanitize=true)
 
-You may also check out more examples [here](./examples/README.md).
+You may also check out more examples [here](https://github.com/pygae/galgebra/blob/master/examples/README.md).
 
 For detailed documentation, please visit https://galgebra.readthedocs.io/ .
 
@@ -189,6 +189,8 @@ from galgebra.mv import Mv, Nga
 Resources
 ------------
 
-Note that in the doc directory there is BookGA.pdf which is a collection of notes on 
-Geometric Algebra and Calculus based of "Geometric Algebra for Physicists" by Doran and 
-Lasenby and on some papers by Lasenby and Hestenes.
+Note that in the [doc/books](https://github.com/pygae/galgebra/blob/master/doc/books/) directory there are:
+
+- `BookGA.pdf` which is a collection of notes on Geometric Algebra and Calculus based of "Geometric Algebra for Physicists" by Doran and Lasenby and on some papers by Lasenby and Hestenes.
+- `galgebra.pdf` which is the original main doc of GAlgebra in PDF format, while the math part is still valid, the part describing the installation and usage of GAlgebra is outdated, please read with cautious or visit https://galgebra.readthedocs.io/ instead.
+- `Macdonald` which constains bundled supplementary materials for [Linear and Geometric Algebra](http://www.faculty.luther.edu/~macdonal/laga/index.html) and [Vector and Geometric Calculus](http://www.faculty.luther.edu/~macdonal/vagc/index.html) by Alan Macdonald, see [here](https://github.com/pygae/galgebra/blob/master/doc/books/Macdonald/README.md) and [here](https://github.com/pygae/galgebra/blob/master/examples/Macdonald/README.md) for more information.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Development Status
 
 [pygae/galgebra](https://github.com/pygae/galgebra) is a community fork, maintained by [Pythonic Geometric Algebra Enthusiasts](https://github.com/pygae).
 
-The fork supports Python 3, increases test coverage, set up CI and linters, maintains releases to [PyPI](https://pypi.org/project/galgebra/#history), improves [docs](http://galgebra.readthedocs.io) and has many bug fixes.
+The fork supports Python 3, increases test coverage, set up CI and linters, maintains releases to [PyPI](https://pypi.org/project/galgebra/#history), improves [docs](http://galgebra.readthedocs.io) and has many bug fixes, see [Changelog](https://galgebra.readthedocs.io/en/latest/changelog.html).
 
 Features
 --------------------
@@ -96,7 +96,7 @@ You will see:
 
 ![](https://raw.githubusercontent.com/pygae/galgebra/master/doc/images/st4_M3.svg?sanitize=true)
 
-You may also check out more examples [here](https://github.com/pygae/galgebra/blob/master/examples/README.md).
+You may also check out more examples [here](https://github.com/pygae/galgebra/blob/master/examples/).
 
 For detailed documentation, please visit https://galgebra.readthedocs.io/ .
 
@@ -186,11 +186,11 @@ from galgebra.ga import Ga, one, zero
 from galgebra.mv import Mv, Nga
 ```
 
-Resources
-------------
+Bundled Resources
+------------------
 
 Note that in the [doc/books](https://github.com/pygae/galgebra/blob/master/doc/books/) directory there are:
 
 - `BookGA.pdf` which is a collection of notes on Geometric Algebra and Calculus based of "Geometric Algebra for Physicists" by Doran and Lasenby and on some papers by Lasenby and Hestenes.
 - `galgebra.pdf` which is the original main doc of GAlgebra in PDF format, while the math part is still valid, the part describing the installation and usage of GAlgebra is outdated, please read with cautious or visit https://galgebra.readthedocs.io/ instead.
-- `Macdonald` which constains bundled supplementary materials for [Linear and Geometric Algebra](http://www.faculty.luther.edu/~macdonal/laga/index.html) and [Vector and Geometric Calculus](http://www.faculty.luther.edu/~macdonal/vagc/index.html) by Alan Macdonald, see [here](https://github.com/pygae/galgebra/blob/master/doc/books/Macdonald/README.md) and [here](https://github.com/pygae/galgebra/blob/master/examples/Macdonald/README.md) for more information.
+- `Macdonald` which constains bundled supplementary materials for [Linear and Geometric Algebra](http://www.faculty.luther.edu/~macdonal/laga/index.html) and [Vector and Geometric Calculus](http://www.faculty.luther.edu/~macdonal/vagc/index.html) by Alan Macdonald, see [here](https://github.com/pygae/galgebra/blob/master/doc/books/Macdonald/) and [here](https://github.com/pygae/galgebra/blob/master/examples/Macdonald/) for more information.

--- a/README.md
+++ b/README.md
@@ -96,7 +96,9 @@ You will see:
 
 ![](https://raw.githubusercontent.com/pygae/galgebra/master/doc/images/st4_M3.svg?sanitize=true)
 
-For detailed documentation and more examples, please check out https://galgebra.readthedocs.io/ .
+You may also check out more examples [here](./examples/README.md).
+
+For detailed documentation, please visit https://galgebra.readthedocs.io/ .
 
 **NOTE:** If you are coming from [sympy.galgebra](https://docs.sympy.org/0.7.6.1/modules/galgebra/) or [brombo/galgebra](https://github.com/brombo/galgebra), please check out section [Migration Guide](#migration-guide) below.
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,0 +1,47 @@
+=========
+Changelog
+=========
+
+- :release:`0.4.4 <2019.09.30>`
+- :feature:`17` Fix examples under both Python 2 & 3
+
+    * Fix `examples/*` and verify them in CI using `nbval`
+    * Test coverage increased from 48.89% to 66.52%
+    * Add README for `test` and `examples`
+
+- :feature:`9` Documentation now available at https://galgebra.readthedocs.io/
+
+    * Convert doc to Sphinx with the help of `pandoc`, `notedown <https://github.com/aaren/notedown>`_  and `nbsphinx <https://nbsphinx.readthedocs.io/en/0.3.5/>`_
+    * Add `Getting Started` guide to README
+    * Update installation instructions in README
+    * Add migration guide from `sympy.galgebra` and `brombo/galgebra`
+    * Add Changelog
+
+- :bug:`15` Fix printing of some products and inverses of multivectors
+- :bug:`18` Fix TypeError of unicode string, use `BytesIO` instead of `StringIO`
+- :bug:`26` Fix calculation of the Christoffel symbols
+- :bug:`27` Fix broken class MV
+- :bug:`29` Fix that sometimes plain text is printed with or instead of LaTeX in Jupyter Notebooks
+- :bug:`30` Fix bugs of using LaTeX as symbol name
+- :bug:`32` Fix calculation of reciprocal basis for non-orthogonal basis
+- :bug:`31` Freeze the depended version of SymPy to 1.3
+- :support:`17` Setup Circle CI to build more Python versions faster
+
+    * TravisCI build for PRs is now removed
+
+- :release:`0.4.3 <2018.02.18>`
+- :feature:`2` Support Python 3
+
+    * Convert code to be Python 3 compatible
+    * Pass tests under both Python 2 & 3
+    * Support installing from PyPI instead of setting `pth`
+    * Support importing with `from galgebra.<package name> import *`
+
+- :support:`2` Setup Travis CI
+- :support:`8` Add test coverage in CI using using `pytest <https://pytest.org/>`_ and `CodeCov <https://codecov.io/gh/pygae/galgebra>`_
+- :support:`8` Validate existing Jupyter notebooks using `nbval <https://github.com/computationalmodelling/nbval>`_
+- :support:`8` Remove NumPy dependency
+- :support:`2` Remove .pyc files and add standard .gitignore for python
+- :support:`2` Clean up obsolete code in setup.py and make it simple
+- :bug:`2` Fixes `brombo/galgebra#19 <https://github.com/brombo/galgebra/issues/19>`_: Failures in `test_noneuclidian_distance_calculation`
+- :bug:`2` Fixes `brombo/galgebra#20 <https://github.com/brombo/galgebra/issues/20>`_: Incorrect LaTeX output in `test_derivatives_in_spherical_coordinates`

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -16,6 +16,7 @@ Changelog
     * Update installation instructions in README
     * Add migration guide from `sympy.galgebra` and `brombo/galgebra`
     * Add Changelog
+    * Add doc for examples, tests and bundled resources
 
 - :bug:`15` Fix printing of some products and inverses of multivectors
 - :bug:`18` Fix TypeError of unicode string, use `BytesIO` instead of `StringIO`

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -26,11 +26,6 @@ project = 'galgebra'
 copyright = '2014-2019, Alan Bromborsky and GAlgebra team'
 author = 'Alan Bromborsky'
 
-# The short X.Y version
-version = ''
-# The full version, including alpha/beta/rc tags
-release = '0.4.4'
-
 # -- General configuration ---------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
@@ -52,7 +47,8 @@ extensions = [
     'IPython.sphinxext.ipython_directive',
     'IPython.sphinxext.ipython_console_highlighting',
     'sphinx_markdown_tables',
-    'm2r'
+    'm2r',
+    'releases'
 ]
 
 # -- nbsphinx configuration ---------------------------------------------------
@@ -119,6 +115,18 @@ exclude_patterns = ['_build', '**.ipynb_checkpoints', 'Thumbs.db', '.DS_Store']
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
 
+# If your project is hosted on Github, set the releases_github_path setting instead, 
+# to e.g. account/project. Releases will then use an appropriate Github URL for both
+# releases and issues.
+releases_github_path = 'pygae/galgebra'
+
+# You may optionally set releases_debug = True to see debug output while building your docs.
+releases_debug = True
+
+# If your changelog includes “simple” pre-1.0 releases derived from a single branch
+# (i.e. without stable release lines & semantic versioning) you may want to set 
+# releases_unstable_prehistory = True.
+releases_unstable_prehistory = True
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -29,7 +29,7 @@ author = 'Alan Bromborsky'
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '0.4.3' 
+release = '0.4.4'
 
 # -- General configuration ---------------------------------------------------
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -11,6 +11,11 @@
 
     galgebra_guide
 
+.. toctree::
+    :maxdepth: 2
+
+    changelog
+
 Indices and tables
 ==================
 

--- a/doc/readthedocs-pip-requirements.txt
+++ b/doc/readthedocs-pip-requirements.txt
@@ -12,3 +12,5 @@ recommonmark
 sphinx-markdown-tables
 notedown
 m2r
+semantic-version==2.6.0
+releases>=1.6.1

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup, find_packages
 from distutils.core import Extension
 
-VERSION = '0.4.3'
+VERSION = '0.4.4'
 LONG_DESCRIPTION = """
 Symbolic Geometric Algebra/Calculus package for SymPy. BSD License.
 """


### PR DESCRIPTION
This is a  work-in-progress for the release of 0.4.4 which is based on [Milestone 0.4.4](https://github.com/pygae/galgebra/milestone/1), with the following additional tasks to complete:

- [x] Bump version to 0.4.4
- [x] Draft a release note for both 0.4.3 and 0.4.4, and include them as part of the doc
- [x] Update the Getting Started section in README to mention the examples
- [x] Update the section Resources in README

Work after this PR:

- [ ] Changes required for releasing a Conda package for 0.4.4 to be used by GAlgebra.jl
- [ ] Post an issue on brombo/galgebra to announce the release
- [ ] Update GAlgebra.jl accordingly after release