### PR TITLE
galgebra_guide.ipynb: some fixes in lead paragraph

### DIFF
--- a/doc/galgebra_guide.ipynb
+++ b/doc/galgebra_guide.ipynb
@@ -60,7 +60,7 @@
     "Basics of Geometric Algebra\n",
     "---------------------------\n",
     "\n",
-    "Geometric algebra is the Clifford algebra of a real finite dimensional vector space or the algebra that results when the vector space is extended with a product of vectors (geometric product) that is associative, left and right distributive, and yields a real number for the square (geometric product) of any vector , . The elements of the geometric algebra are called multivectors and consist of the linear combination of scalars, vectors, and the geometric product of two or more vectors. The additional axioms for the geometric algebra are that for any vectors $a$, $b$, and $c$ in the base vector space (,p85):\n",
+    "Geometric algebra is the Clifford algebra of a real finite dimensional vector space, or the algebra that results when the vector space is extended with a product of vectors (the **geometric product**) that is associative, left- and right-distributive, and yields a real number for the square of any vector (i.e. the geometric product with itself). The elements of the geometric algebra are called **multivectors**, and consist of the linear combination of scalars, vectors, and the geometric product of two or more vectors. The additional axioms for the geometric algebra are that for any vectors $a$, $b$, and $c$ in the base vector space (,p85):\n",
     "\n",
     "$$\\begin{array}{c}\n",
     "  a\\lp bc \\rp = \\lp ab \\rp c \\\\\n",


### PR DESCRIPTION
Btw, it looks like the end of the line, where it says `(,p85)`, was meant to be a reference + page number, but only the page number remains. That appears to be the case in several places throughout the document, and potentially elsewhere.