### PR TITLE
Rename kargs to args

### DIFF
--- a/galgebra/ga.py
+++ b/galgebra/ga.py
@@ -351,12 +351,12 @@ class Ga(metric.Metric):
         return half * (A * B - B * A)
 
     @staticmethod
-    def build(*kargs, **kwargs):
+    def build(*args, **kwargs):
         """
         Static method to instantiate geometric algebra and return geometric
         algebra, basis vectors, and grad operator as a tuple.
         """
-        GA = Ga(*kargs, **kwargs)
+        GA = Ga(*args, **kwargs)
         basis = list(GA.mv())
         return tuple([GA] + basis)
 
@@ -369,7 +369,7 @@ class Ga(metric.Metric):
         X = symbols(set_lst[0], real=True)
         g = eval(set_lst[1])
         simps = eval(set_lst[2])
-        kargs = [root]
+        args = [root]
         kwargs = {'g': g, 'coords': X, 'debug': debug, 'I': True, 'gsym': False}
 
         if len(set_lst) > 3:
@@ -379,7 +379,7 @@ class Ga(metric.Metric):
                 kwargs[name] = eval(value)
 
         Ga.set_simp(*simps)
-        return Ga(*kargs, **kwargs)
+        return Ga(*args, **kwargs)
 
     def __eq__(self, ga):
         if self.name == ga.name:
@@ -466,7 +466,7 @@ class Ga(metric.Metric):
 
         self.a = []  # List of dummy vectors for Mlt calculations
         self.agrads = {}  # Gradient operator with respect to vector a
-        self.dslot = -1  # kargs slot for dervative, -1 for coordinates
+        self.dslot = -1  # args slot for dervative, -1 for coordinates
         self.XOX = self.mv('XOX','vector')  # Versor test vector
 
     def make_grad(self, a, cmpflg=False):  # make gradient operator with respect to vector a
@@ -507,7 +507,7 @@ class Ga(metric.Metric):
     def sdop(self, coefs, pdiffs=None):
         return mv.Sdop(coefs, pdiffs, ga=self)
 
-    def mv(self, root=None, *kargs, **kwargs):
+    def mv(self, root=None, *args, **kwargs):
         """
         Instanciate and return a multivector for this, 'self',
         geometric algebra.
@@ -522,18 +522,18 @@ class Ga(metric.Metric):
         kwargs['ga'] = self
 
         if not utils.isstr(root):
-            return mv.Mv(root, *kargs, **kwargs)
+            return mv.Mv(root, *args, **kwargs)
 
-        if ' ' in root and ' ' not in kargs[0]:
+        if ' ' in root and ' ' not in args[0]:
             root_lst = root.split(' ')
             mv_lst = []
             for root in root_lst:
-                mv_lst.append(mv.Mv(root, *kargs, **kwargs))
+                mv_lst.append(mv.Mv(root, *args, **kwargs))
             return tuple(mv_lst)
 
-        if ' ' in root and ' ' in kargs[0]:
+        if ' ' in root and ' ' in args[0]:
             root_lst = root.split(' ')
-            mvtype_lst = kargs[0].split(' ')
+            mvtype_lst = args[0].split(' ')
             if len(root_lst) != len(mvtype_lst):
                 raise ValueError('In Ga.mv() for multiple multivectors and ' +
                                   'multivector types incompatible args ' +
@@ -541,13 +541,13 @@ class Ga(metric.Metric):
 
             mv_lst = []
             for (root, mv_type) in zip(root_lst, mvtype_lst):
-                kargs = list(kargs)
-                kargs[0] = mv_type
-                kargs = tuple(kargs)
-                mv_lst.append(mv.Mv(root, *kargs, **kwargs))
+                args = list(args)
+                args[0] = mv_type
+                args = tuple(args)
+                mv_lst.append(mv.Mv(root, *args, **kwargs))
             return tuple(mv_lst)
 
-        return mv.Mv(root, *kargs, **kwargs)
+        return mv.Mv(root, *args, **kwargs)
 
     def mvr(self,norm=True):
         r"""
@@ -602,15 +602,15 @@ class Ga(metric.Metric):
         self.rgrad = mv.Dop(r_basis, pdx, ga=self, cmpflg=True)
         return self.grad, self.rgrad
 
-    def dop(self, *kargs, **kwargs):
+    def dop(self, *args, **kwargs):
         """
         Instanciate and return a multivector differential operator for
         this, 'self', geometric algebra.
         """
         kwargs['ga'] = self
-        return mv.Dop(*kargs, **kwargs)
+        return mv.Dop(*args, **kwargs)
 
-    def lt(self, *kargs, **kwargs):
+    def lt(self, *args, **kwargs):
         """
         Instanciate and return a linear transformation for this, 'self',
         geometric algebra.
@@ -620,15 +620,15 @@ class Ga(metric.Metric):
             (self.lt_coords, self.lt_x) = lt.Lt.setup(ga=self)
 
         kwargs['ga'] = self
-        return lt.Lt(*kargs, **kwargs)
+        return lt.Lt(*args, **kwargs)
 
-    def sm(self, *kargs, **kwargs):
+    def sm(self, *args, **kwargs):
         """
         Instanciate and return a submanifold for this
         geometric algebra.  See :class:`Sm` for instantiation inputs.
         """
         kwargs['ga'] = self
-        SM = Sm(*kargs, **kwargs)
+        SM = Sm(*args, **kwargs)
         return SM
 
     def parametric(self, coords):
@@ -1717,8 +1717,8 @@ class Ga(metric.Metric):
         self.dbases[key] = db
         return db
 
-    def pdop(self,*kargs):
-        return mv.Pdop(kargs,ga=self)
+    def pdop(self,*args):
+        return mv.Pdop(args,ga=self)
 
     def pDiff(self, A, coord):
         """
@@ -1891,8 +1891,8 @@ class Ga(metric.Metric):
 
         return tuple(rbasis)
 
-    def Mlt(self,*kargs,**kwargs):
-        return lt.Mlt(kargs[0], self, *kargs[1:], **kwargs)
+    def Mlt(self,*args,**kwargs):
+        return lt.Mlt(args[0], self, *args[1:], **kwargs)
 
 class Sm(Ga):
     """
@@ -1905,22 +1905,22 @@ class Sm(Ga):
     Parameters
     ----------
     u :
-        (``kargs[0]``) The coordinate map defining the submanifold
+        (``args[0]``) The coordinate map defining the submanifold
         which is a list of functions of coordinates of the base
         manifold in terms of the coordinates of the submanifold.
         for example if the manifold is a unit sphere then -
         ``u = [sin(u)*cos(v),sin(u)*sin(v),cos(u)]``.
 
-        Alternatively (``kargs[0]``) is a parametric vector function
+        Alternatively (``args[0]``) is a parametric vector function
         of the basis vectors of the base manifold.  The
         coefficients of the bases are functions of the coordinates
-        (``kargs[1]``).  In this case we would call the submanifold
+        (``args[1]``).  In this case we would call the submanifold
         a "vector" manifold and additional characteristics of the
         manifold can be calculated since we have given an explicit
         embedding of the manifold in the base manifold.
 
     coords :
-        (``kargs[1]``) The coordinate list for the submanifold, for
+        (``args[1]``) The coordinate list for the submanifold, for
         example ``[u, v]``.
 
     Notes
@@ -1942,7 +1942,7 @@ class Sm(Ga):
                   'norm': (False, 'Normalize basis if True'),
                   'ga': (None, 'Base Geometric Algebra')}
 
-    def __init__(self, *kargs, **kwargs):
+    def __init__(self, *args, **kwargs):
 
         #print '!!!Enter Sm!!!'
 
@@ -1951,8 +1951,8 @@ class Sm(Ga):
             Ga.restore = True
 
         kwargs = metric.test_init_slots(Sm.init_slots, **kwargs)
-        u = kargs[0]  # Coordinate map or vector embedding to define submanifold
-        coords = kargs[1]  # List of cordinates
+        u = args[0]  # Coordinate map or vector embedding to define submanifold
+        coords = args[1]  # List of cordinates
         ga = kwargs['ga']  # base geometric algebra
         if ga is None:
             raise ValueError('Base geometric algebra must be specified for submanifold.')

--- a/galgebra/lt.py
+++ b/galgebra/lt.py
@@ -130,7 +130,7 @@ class Lt(object):
         Lt.mat_fmt = mat_fmt
         return
 
-    def __init__(self, *kargs, **kwargs):
+    def __init__(self, *args, **kwargs):
         """
         Except for the spinor representation the linear transformation
         is stored as a dictionary with basis vector keys and vector
@@ -157,7 +157,7 @@ class Lt(object):
 
         kwargs = metric.test_init_slots(Lt.init_slots, **kwargs)
 
-        mat_rep = kargs[0]
+        mat_rep = args[0]
         ga = kwargs['ga']
         self.fct_flg = kwargs['f']
         self.mode = kwargs['mode']  # General g, s, or a transformation
@@ -488,7 +488,7 @@ class Lt(object):
 class Mlt(object):
     """
     A multilinear transformation (mlt) is a multilinear multivector function of
-    a list of vectors (*kargs) F(v_1,...,v_r) where for any argument slot
+    a list of vectors (*args) F(v_1,...,v_r) where for any argument slot
     j we have (a is a scalar and u_j a vector)
           F(v_1,...,a*v_j,...,v_r) = a*F(v_1,...,v_j,...,v_r)
           F(v_1,...,v_j+u_j,...,v_r) = F(v_1,...,v_j,...,v_r) + F(v_1,...,u_j,...,v_r).
@@ -729,7 +729,7 @@ class Mlt(object):
                     self.fvalue += coef * a_prod
         else:
             if isinstance(f, types.FunctionType): #  Tensor defined by general multi-linear function
-                args, _kargs, _kwargs, _defaults = inspect.getargspec(f)
+                args, _varargs, _kwargs, _defaults = inspect.getargspec(f)
                 self.nargs = len(args)
                 self.f = f
                 Mlt.increment_slots(self.nargs, Ga)
@@ -747,14 +747,14 @@ class Mlt(object):
             Printer = printer.GaPrinter
         return Printer().doprint(self)
 
-    def __call__(self, *kargs):
-        if len(kargs) == 0:
+    def __call__(self, *args):
+        if len(args) == 0:
             return self.fvalue
         if self.f is not None:
-            return self.f(*kargs)
+            return self.f(*args)
         else:
             sub_lst = []
-            for (x, ai) in zip(kargs, self.Ga.pdiffs):
+            for (x, ai) in zip(args, self.Ga.pdiffs):
                 for (r_base, aij) in zip(self.Ga.r_basis_mv, ai):
                     sub_lst.append((aij, (r_base | x).scalar()))
             return self.fvalue.subs(sub_lst,simultaneous=True)

--- a/galgebra/mv.py
+++ b/galgebra/mv.py
@@ -176,13 +176,13 @@ class Mv(object):
         self.char_Mv = True
         return
 
-    def make_grade(self, *kargs, **kwargs):
+    def make_grade(self, *args, **kwargs):
     # Called by __init__ to make a pure grade multivector.
 
-        grade = kargs[1]
+        grade = args[1]
         self.i_grade = grade
-        if utils.isstr(kargs[0]):
-            root = kargs[0] + '__'
+        if utils.isstr(args[0]):
+            root = args[0] + '__'
             if isinstance(kwargs['f'], bool) and not kwargs['f']:  #Is a constant mulitvector function
                 self.obj = sum([Symbol(root + super_script, real=True) * base
                                 for (super_script, base) in zip(self.Ga.blade_super_scripts[grade], self.Ga.blades[grade])])
@@ -195,80 +195,80 @@ class Mv(object):
                     self.obj = sum([Function(root + super_script, real=True)(*kwargs['f']) * base
                         for (super_script, base) in zip(self.Ga.blade_super_scripts[grade], self.Ga.blades[grade])])
         else:
-            if isinstance(kargs[0],(list,tuple)):
-                if len(kargs[0]) <= len(self.Ga.blades[grade]):
+            if isinstance(args[0],(list,tuple)):
+                if len(args[0]) <= len(self.Ga.blades[grade]):
                     self.obj = sum([coef * base
-                        for (coef, base) in zip(kargs[0], self.Ga.blades[grade][:len(kargs[0])])])
+                        for (coef, base) in zip(args[0], self.Ga.blades[grade][:len(args[0])])])
                 else:
                     pass
             else:
                 pass
         return
 
-    def make_scalar(self, *kargs, **kwargs):
+    def make_scalar(self, *args, **kwargs):
     # Called by __init__ to make a scalar multivector
 
-        if utils.isstr(kargs[0]):
+        if utils.isstr(args[0]):
             if 'f' in kwargs and isinstance(kwargs['f'],bool):
                 if kwargs['f']:
-                    self.obj = Function(kargs[0])(*self.Ga.coords)
+                    self.obj = Function(args[0])(*self.Ga.coords)
                 else:
-                    self.obj = Symbol(kargs[0], real=True)
+                    self.obj = Symbol(args[0], real=True)
             else:
                 if 'f' in kwargs and isinstance(kwargs['f'],tuple):
-                    self.obj = Function(kargs[0])(*kwargs['f'])
+                    self.obj = Function(args[0])(*kwargs['f'])
         else:
-            self.obj = kargs[0]
+            self.obj = args[0]
         return
 
-    def make_vector(self, *kargs, **kwargs):
+    def make_vector(self, *args, **kwargs):
     # Called by __init__ to make a vector multivector
 
-        self.make_grade(*(kargs[0], 1), **kwargs)
+        self.make_grade(*(args[0], 1), **kwargs)
         return
 
-    def make_bivector(self, *kargs, **kwargs):
+    def make_bivector(self, *args, **kwargs):
     # Called by __init__ to make a bivector multivector
 
-        self.make_grade(*(kargs[0], 2), **kwargs)
+        self.make_grade(*(args[0], 2), **kwargs)
         return
 
-    def make_pseudo_scalar(self, *kargs, **kwargs):
+    def make_pseudo_scalar(self, *args, **kwargs):
     # Called by __init__ to make a pseudo scalar multivector
 
-        self.make_grade(*(kargs[0], self.Ga.n), **kwargs)
+        self.make_grade(*(args[0], self.Ga.n), **kwargs)
         return
 
-    def make_multivector(self, *kargs, **kwargs):
+    def make_multivector(self, *args, **kwargs):
     # Called by __init__ to make a general (2**n components) multivector
 
-        self.make_scalar(kargs[0], **kwargs)
+        self.make_scalar(args[0], **kwargs)
         tmp = self.obj
         for grade in self.Ga.n_range:
-            self.make_grade(*(kargs[0], grade + 1), **kwargs)
+            self.make_grade(*(args[0], grade + 1), **kwargs)
             tmp += self.obj
         self.obj = tmp
         return
 
-    def make_spinor(self, *kargs, **kwargs):
+    def make_spinor(self, *args, **kwargs):
     # Called by __init__ to make a general even (spinor) multivector
 
-        self.make_scalar(kargs[0], **kwargs)
+        self.make_scalar(args[0], **kwargs)
         tmp = self.obj
         for grade in self.Ga.n_range:
             if (grade + 1) % 2 == 0:
-                self.make_grade(*(kargs[0], grade + 1), **kwargs)
+                self.make_grade(*(args[0], grade + 1), **kwargs)
                 tmp += self.obj
         self.obj = tmp
         return
 
-    def make_odd(self, *kargs, **kwargs):
+    def make_odd(self, *args, **kwargs):
     # Called by __init__ to make a general odd multivector
-        self.make_scalar(kargs[0], **kwargs)
+        self.make_scalar(args[0], **kwargs)
         tmp = S(0)
         for grade in self.Ga.n_range:
             if (grade + 1) % 2 == 1:
-                self.make_grade(*(kargs[0], grade + 1), **kwargs)
+                self.make_grade(*(args[0], grade + 1), **kwargs)
                 tmp += self.obj
         self.obj = tmp
         return
@@ -284,7 +284,7 @@ class Mv(object):
                  'odd': make_odd,
                  'grade': make_grade}
 
-    def __init__(self, *kargs, **kwargs):
+    def __init__(self, *args, **kwargs):
 
         if 'ga' not in kwargs:
             raise ValueError("Geometric algebra key inplut 'ga' required")
@@ -303,11 +303,11 @@ class Mv(object):
         self.coords = self.Ga.coords
         self.title = None
 
-        if len(kargs) == 0:  # default constructor 0
+        if len(args) == 0:  # default constructor 0
             self.obj = S(0)
             self.i_grade = 0
-        elif len(kargs) == 1 and not utils.isstr(kargs[0]):  # copy constructor
-            x = kargs[0]
+        elif len(args) == 1 and not utils.isstr(args[0]):  # copy constructor
+            x = args[0]
             if isinstance(x, Mv):
                 self.obj = x.obj
                 self.is_blade_rep = x.is_blade_rep
@@ -320,22 +320,22 @@ class Mv(object):
                 self.is_blade_rep = True
                 self.characterise_Mv()
         else:
-            if not isinstance(kargs[1],int):
-                if utils.isstr(kargs[1]) and kargs[1] not in Mv.init_dict:
-                    raise ValueError('"' + str(kargs[1]) + '" not an allowed multivector type.')
+            if not isinstance(args[1],int):
+                if utils.isstr(args[1]) and args[1] not in Mv.init_dict:
+                    raise ValueError('"' + str(args[1]) + '" not an allowed multivector type.')
 
-            if utils.isstr(kargs[1]):
-                mode = kargs[1]
-                kargs = [kargs[0]] + list(kargs[2:])
-                Mv.init_dict[mode](self, *kargs, **kwargs)
-            else:  # kargs[1] = r (integer) Construct grade r multivector
-                if kargs[1] == 0:
-                    Mv.init_dict['scalar'](self, *kargs, **kwargs)
+            if utils.isstr(args[1]):
+                mode = args[1]
+                args = [args[0]] + list(args[2:])
+                Mv.init_dict[mode](self, *args, **kwargs)
+            else:  # args[1] = r (integer) Construct grade r multivector
+                if args[1] == 0:
+                    Mv.init_dict['scalar'](self, *args, **kwargs)
                 else:
-                    Mv.init_dict['grade'](self, *kargs, **kwargs)
+                    Mv.init_dict['grade'](self, *args, **kwargs)
 
-            if utils.isstr(kargs[0]):
-                self.title = kargs[0]
+            if utils.isstr(args[0]):
+                self.title = args[0]
             self.characterise_Mv()
 
     ################# Multivector member functions #####################
@@ -1569,7 +1569,7 @@ class Sdop(object):
     def __repr__(self):
         return str(self)
 
-    def __init__(self, *kargs, **kwargs):
+    def __init__(self, *args, **kwargs):
         """
         The scalar differential operator structure is of the form
         (Einstein summation)
@@ -1591,19 +1591,19 @@ class Sdop(object):
             else:
                 self.Ga = Sdop.ga
 
-        if len(kargs[0]) == 0:  # identity Dop
+        if len(args[0]) == 0:  # identity Dop
             self.terms = [(S(1), self.Ga.Pdop_identity)]
-        elif len(kargs[0]) == 1 and isinstance(kargs[0],Symbol):  # Simple Pdop of order 1
-            self.terms = [(S(1), self.Ga.pdop(kargs[0]))]
+        elif len(args[0]) == 1 and isinstance(args[0],Symbol):  # Simple Pdop of order 1
+            self.terms = [(S(1), self.Ga.pdop(args[0]))]
         else:
-            if len(kargs) == 2 and isinstance(kargs[0],list) and isinstance(kargs[1],list):
-                if len(kargs[0]) != len(kargs[1]):
+            if len(args) == 2 and isinstance(args[0],list) and isinstance(args[1],list):
+                if len(args[0]) != len(args[1]):
                     raise ValueError('In Sdop.__init__ coefficent list and Pdop list must be same length.')
-                self.terms = list(zip(kargs[0],kargs[1]))
-            elif len(kargs) == 1 and isinstance(kargs[0],list):
-                self.terms = kargs[0]
+                self.terms = list(zip(args[0],args[1]))
+            elif len(args) == 1 and isinstance(args[0],list):
+                self.terms = args[0]
             else:
-                raise ValueError('In Sdop.__init__ length of kargs must be 1 or 2 kargs = '+str(kargs))
+                raise ValueError('In Sdop.__init__ length of args must be 1 or 2 args = '+str(args))
 
     def __call__(self, arg):
         if isinstance(arg, Sdop):
@@ -1807,7 +1807,7 @@ class Pdop(object):
                 return True
             return False
 
-    def __init__(self, *kargs, **kwargs):
+    def __init__(self, *args, **kwargs):
         """
         The partial differential operator is a partial derivative with
         respect to a set of real symbols (variables).  The allowed
@@ -1832,14 +1832,14 @@ class Pdop(object):
             else:
                 self.Ga = Pdop.ga  # use geometric algebra of class Pdop
 
-        if kargs[0] is None:  # Pdop is the identity (1)
+        if args[0] is None:  # Pdop is the identity (1)
             self.pdiffs = {}
-        elif isinstance(kargs[0], dict):  # Pdop defined by dictionary
-            self.pdiffs = kargs[0]
-        elif isinstance(kargs[0],Symbol):  # First order derivative with respect to symbol
-            self.pdiffs = {kargs[0]:1}
+        elif isinstance(args[0], dict):  # Pdop defined by dictionary
+            self.pdiffs = args[0]
+        elif isinstance(args[0],Symbol):  # First order derivative with respect to symbol
+            self.pdiffs = {args[0]:1}
         else:
-            raise ValueError('In pdop kargs = ', str(kargs))
+            raise ValueError('In pdop args = ', str(args))
 
         for x in list(self.pdiffs.keys()):  # self.order is total number of differentiations
             self.order += self.pdiffs[x]
@@ -2036,7 +2036,7 @@ class Dop(object):
     def flatten_one_level(lst):
         return [inner for outer in lst for inner in outer]
 
-    def __init__(self, *kargs, **kwargs):
+    def __init__(self, *args, **kwargs):
 
         kwargs = metric.test_init_slots(Dop.init_slots, **kwargs)
 
@@ -2052,20 +2052,20 @@ class Dop(object):
         self.dop_fmt = kwargs['fmt_dop']  # Partial derivative output format (default 1)
         self.title = None
 
-        if len(kargs[0]) == 0:  # identity Dop
+        if len(args[0]) == 0:  # identity Dop
             self.terms = [(S(1),self.Ga.Pdop_identity)]
         else:
-            if len(kargs) == 2:
-                if len(kargs[0]) != len(kargs[1]):
+            if len(args) == 2:
+                if len(args[0]) != len(args[1]):
                     raise ValueError('In Dop.__init__ coefficent list and Pdop list must be same length.')
-                self.terms = list(zip(kargs[0],kargs[1]))
-            elif len(kargs) == 1:
-                if isinstance(kargs[0][0][0], Mv):  # Mv expansion [(Mv, Pdop)]
-                    self.terms = kargs[0]
-                elif isinstance(kargs[0][0][0], Sdop):  # Sdop expansion [(Sdop, Mv)]
+                self.terms = list(zip(args[0],args[1]))
+            elif len(args) == 1:
+                if isinstance(args[0][0][0], Mv):  # Mv expansion [(Mv, Pdop)]
+                    self.terms = args[0]
+                elif isinstance(args[0][0][0], Sdop):  # Sdop expansion [(Sdop, Mv)]
                     coefs = []
                     pdiffs = []
-                    for (sdop, mv) in kargs[0]:
+                    for (sdop, mv) in args[0]:
                         for (coef, pdiff) in sdop.terms:
                             if pdiff in pdiffs:
                                 index = pdiffs.index(pdiff)
@@ -2075,9 +2075,9 @@ class Dop(object):
                                 coefs.append(coef * mv)
                     self.terms = list(zip(coefs, pdiffs))
                 else:
-                    raise ValueError('In Dop.__init__ kargs[0] form not allowed. kargs = ' + str(kargs))
+                    raise ValueError('In Dop.__init__ args[0] form not allowed. args = ' + str(args))
             else:
-                raise ValueError('In Dop.__init__ length of kargs must be 1 or 2.')
+                raise ValueError('In Dop.__init__ length of args must be 1 or 2.')
 
 
     def simplify(self, modes=simplify):


### PR DESCRIPTION
The typical python function signature is `f(*args, **kwargs)` not `f(*kargs, **kwargs)`.

The `kw` in `kwargs` stands for `keyword`, but the first `k` doesn't mean anything.