### PR TITLE
Make `blade_rep` and `base_rep` non mutating

### DIFF
--- a/galgebra/mv.py
+++ b/galgebra/mv.py
@@ -358,20 +358,24 @@ class Mv(object):
         return Rm * self * Rp
 
     def base_rep(self):
-        if self.is_blade_rep:
-            self.obj = self.Ga.blade_to_base_rep(self.obj)
-            self.is_blade_rep = False
-            return self
-        else:
+        """ Express as a linear combination of geometric products """
+        if not self.is_blade_rep:
             return self
 
+        b = copy.copy(self)
+        b.obj = self.Ga.blade_to_base_rep(self.obj)
+        b.is_blade_rep = False
+        return b
+
     def blade_rep(self):
+        """ Express as a linear combination of blades """
         if self.is_blade_rep:
             return self
-        else:
-            self.obj = self.Ga.base_to_blade_rep(self.obj)
-            self.is_blade_rep = True
-            return self
+
+        b = copy.copy(self)
+        b.obj = self.Ga.base_to_blade_rep(self.obj)
+        b.is_blade_rep = True
+        return b
 
     def __ne__(self, A):
         if isinstance(A, Mv):
@@ -508,30 +512,24 @@ class Mv(object):
 
             selfxA = Mv(self.Ga.mul(self.obj, A.obj), ga=self.Ga)
             selfxA.is_blade_rep = False
-            selfxA = selfxA.blade_rep()
+            return selfxA.blade_rep()
 
-            self = self.blade_rep()
-            A = A.blade_rep()
         elif self.is_blade_rep:
             self = self.base_rep()
 
             selfxA = Mv(self.Ga.mul(self.obj, A.obj), ga=self.Ga)
             selfxA.is_blade_rep = False
-            selfxA = selfxA.blade_rep()
+            return selfxA.blade_rep()
 
-            self = self.blade_rep()
         elif A.is_blade_rep:
             A = A.base_rep()
 
             selfxA = Mv(self.Ga.mul(self.obj, A.obj), ga=self.Ga)
             selfxA.is_blade_rep = False
-            selfxA = selfxA.blade_rep()
-
-            A = A.blade_rep()
+            return selfxA.blade_rep()
         else:
-            selfxA = Mv(self.Ga.mul(self.obj, A.obj), ga=self.Ga)
+            return Mv(self.Ga.mul(self.obj, A.obj), ga=self.Ga)
 
-        return selfxA
 
     def __rmul__(self, A):
             return Mv(expand(A * self.obj), ga=self.Ga)

--- a/test/test_mv.py
+++ b/test/test_mv.py
@@ -60,3 +60,27 @@ class TestMv(unittest.TestCase):
         self.assertRaises(ValueError, lambda: m1.blade_coefs([e_1, e_2 ^ e_1]))
         self.assertRaises(ValueError, lambda: m1.blade_coefs([a * e_1]))
         self.assertRaises(ValueError, lambda: m1.blade_coefs([3 * e_3]))
+
+    def test_rep_switching(self):
+        # this ga has a non-diagonal metric
+        (_g3d, e_1, e_2, e_3) = Ga.build('e*1|2|3')
+
+        m0 =  2 * e_1 + e_2 - e_3 + 3 * (e_1 ^ e_3) + (e_1 ^ e_3) + (e_2 ^ (3 * e_3))
+        m1 = (-4*(e_1 | e_3)-3*(e_2 | e_3))+2*e_1+e_2-e_3+4*e_1*e_3+3*e_2*e_3
+        # m1 was chosen to make this true
+        self.assertEqual(m0, m1)
+
+        # all objects start off in blade rep
+        self.assertTrue(m0.is_blade_rep)
+
+        # convert to base rep
+        m0_base = m0.base_rep()
+        self.assertTrue(m0.is_blade_rep)  # original should not change
+        self.assertFalse(m0_base.is_blade_rep)
+        self.assertEqual(m0, m0_base)
+
+        # convert back
+        m0_base_blade = m0_base.blade_rep()
+        self.assertFalse(m0_base.is_blade_rep)  # original should not change
+        self.assertTrue(m0_base_blade.is_blade_rep)
+        self.assertEqual(m0, m0_base_blade)


### PR DESCRIPTION
Previously this would cause weird and surprising swaps between basis representations.