### PR TITLE
Avoid using `dot_mode` to determine which dot product to call

### DIFF
--- a/galgebra/lt.py
+++ b/galgebra/lt.py
@@ -355,11 +355,10 @@ class Lt(object):
     def adj(self):
 
         self_adj = []
-        self.Ga.dot_mode = '|'
         for e_j in self.Ga.basis:
             s = S(0)
             for (e_i, er_i) in zip(self.Ga.basis, self.Ga.r_basis):
-                s += er_i * self.Ga.dot(e_j, self(e_i, obj=True))
+                s += er_i * self.Ga.hestenes_dot(e_j, self(e_i, obj=True))
             if self.Ga.is_ortho:
                 self_adj.append(expand(s))
             else:

--- a/galgebra/mv.py
+++ b/galgebra/mv.py
@@ -784,8 +784,6 @@ class Mv(object):
         if self.Ga.name != A.Ga.name:
             raise ValueError('In | operation Mv arguments are not from same geometric algebra')
 
-        self.Ga.dot_mode = '|'
-
         if isinstance(A, Dop):
             return A.Mul(self, A, op='|')
 
@@ -793,7 +791,7 @@ class Mv(object):
         if self.is_scalar() or A.is_scalar():
             return S(0)
         A = A.blade_rep()
-        self_dot_A = Mv(self.Ga.dot(self.obj, A.obj), ga=self.Ga)
+        self_dot_A = Mv(self.Ga.hestenes_dot(self.obj, A.obj), ga=self.Ga)
         return self_dot_A
 
     def __ror__(self, A):  # dot (|) product
@@ -831,8 +829,6 @@ class Mv(object):
         if self.Ga.name != A.Ga.name:
             raise ValueError('In < operation Mv arguments are not from same geometric algebra')
 
-        self.Ga.dot_mode = '<'
-
         if isinstance(A, Dop):
             return A.Mul(self, A, op='<')
 
@@ -846,7 +842,7 @@ class Mv(object):
                 return S(0)
         """
 
-        self_lc_A = Mv(self.Ga.dot(self.obj, A.obj), ga=self.Ga)
+        self_lc_A = Mv(self.Ga.left_contract(self.obj, A.obj), ga=self.Ga)
         return self_lc_A
 
     def __gt__(self, A):  # right contraction (>)
@@ -856,8 +852,6 @@ class Mv(object):
 
         if self.Ga.name != A.Ga.name:
             raise ValueError('In > operation Mv arguments are not from same geometric algebra')
-
-        self.Ga.dot_mode = '>'
 
         if isinstance(A, Dop):
             return A.Mul(self, A, op='>')
@@ -872,7 +866,7 @@ class Mv(object):
                 return S(0)
         """
 
-        self_rc_A = Mv(self.Ga.dot(self.obj, A.obj), ga=self.Ga)
+        self_rc_A = Mv(self.Ga.right_contract(self.obj, A.obj), ga=self.Ga)
         return self_rc_A
 
     def collect(self,deep=False):


### PR DESCRIPTION
This change leaves the behavior of `Ga.dot_mode` and `Ga.dot` alone, but replaces all the internal uses of these variables with new `left_contract`, `right_contract`, and `hestenes_dot` methods.

Passing the mode as an argument instead means that this code becomes (more) threadsafe.