### PR TITLE
Remove `__name__ == '__main__'` check from modules

### DIFF
--- a/galgebra/ga.py
+++ b/galgebra/ga.py
@@ -2071,7 +2071,3 @@ class Sm(Ga):
         self.vpd = mv.Dop(r_basis, pdx, ga=self)
         self.rvpd = mv.Dop(r_basis, pdx, ga=self, cmpflg=True)
         return self.vpd, self.rvpd
-
-
-if __name__ == "__main__":
-    pass

--- a/galgebra/lt.py
+++ b/galgebra/lt.py
@@ -897,6 +897,3 @@ class Mlt(object):
             output += str(i)+':'+str(i_index)+':'+str(self(*e)) + '\n'
             i += 1
         return output
-
-if __name__ == "__main__":
-    pass

--- a/galgebra/metric.py
+++ b/galgebra/metric.py
@@ -751,8 +751,3 @@ class Metric(object):
 
         if self.debug:
             print('signature =', self.sig)
-
-
-if __name__ == "__main__":
-    pass
-

--- a/galgebra/mv.py
+++ b/galgebra/mv.py
@@ -2665,6 +2665,3 @@ def scalar(A):
     if not isinstance(A,Mv):
         raise ValueError('A = ' + str(A) + ' not a multivector in inv(A).')
     return A.scalar()
-
-if __name__ == "__main__":
-    pass

--- a/galgebra/printer.py
+++ b/galgebra/printer.py
@@ -1501,8 +1501,3 @@ def Fmt(obj,fmt=0):
         return
     else:
         raise TypeError(str(type(obj)) + ' not allowed arg type in Fmt')
-
-
-if __name__ == "__main__":
-
-    pass


### PR DESCRIPTION
These modules do not make sense to run from the command line, so should not have these lines.

At any rate, these lines do nothing.