### PR TITLE
Fix dead links to brombo/galgebra in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Development Status
 
 ![PyPI - Status](https://img.shields.io/pypi/status/galgebra.svg) ![GitHub contributors](https://img.shields.io/github/contributors/pygae/galgebra.svg) [![Codacy Badge](https://api.codacy.com/project/badge/Grade/fe7642c639a54d909a36c75db6c2fa49)](https://app.codacy.com/app/utensilcandel/galgebra?utm_source=github.com&utm_medium=referral&utm_content=pygae/galgebra&utm_campaign=Badge_Grade_Settings) [![Codecov](https://img.shields.io/codecov/c/github/pygae/galgebra.svg)](https://codecov.io/gh/pygae/galgebra)
 
-[brombo/galgebra](https://github.com/brombo/galgebra) was originally written by Alan Bromborsky, but is no longer actively maintained.
+[brombo/galgebra][] was originally written by Alan Bromborsky, but was no longer actively maintained, and as of 2019-11-25 no longer exists.
 
 [pygae/galgebra](https://github.com/pygae/galgebra) is a community fork, maintained by [Pythonic Geometric Algebra Enthusiasts](https://github.com/pygae).
 
@@ -100,7 +100,7 @@ You may also check out more examples [here](https://github.com/pygae/galgebra/bl
 
 For detailed documentation, please visit https://galgebra.readthedocs.io/ .
 
-**NOTE:** If you are coming from [sympy.galgebra](https://docs.sympy.org/0.7.6.1/modules/galgebra/) or [brombo/galgebra](https://github.com/brombo/galgebra), please check out section [Migration Guide](#migration-guide) below.
+**NOTE:** If you are coming from [sympy.galgebra](https://docs.sympy.org/0.7.6.1/modules/galgebra/) or [brombo/galgebra][], please check out section [Migration Guide](#migration-guide) below.
 
 Installing GAlgebra
 ---------------------
@@ -176,7 +176,7 @@ Simply remove the `sympy.` prefix before `galgebra` then you are good to go:
 from galgebra.ga import *
 ```
 
-### Migrating from [brombo/galgebra](https://github.com/brombo/galgebra)
+### Migrating from [brombo/galgebra][]
 
 The `setgapth.py` way to install is now deprecated by `pip install galgebra` and all modules in GAlgebra should be imported from `galgebra`, for example:
 
@@ -194,3 +194,5 @@ Note that in the [doc/books](https://github.com/pygae/galgebra/blob/master/doc/b
 - `BookGA.pdf` which is a collection of notes on Geometric Algebra and Calculus based of "Geometric Algebra for Physicists" by Doran and Lasenby and on some papers by Lasenby and Hestenes.
 - `galgebra.pdf` which is the original main doc of GAlgebra in PDF format, while the math part is still valid, the part describing the installation and usage of GAlgebra is outdated, please read with cautious or visit https://galgebra.readthedocs.io/ instead.
 - `Macdonald` which constains bundled supplementary materials for [Linear and Geometric Algebra](http://www.faculty.luther.edu/~macdonal/laga/index.html) and [Vector and Geometric Calculus](http://www.faculty.luther.edu/~macdonal/vagc/index.html) by Alan Macdonald, see [here](https://github.com/pygae/galgebra/blob/master/doc/books/Macdonald/) and [here](https://github.com/pygae/galgebra/blob/master/examples/Macdonald/) for more information.
+
+[brombo/galgebra]: https://web.archive.org/web/20180611145113/https://github.com/brombo/galgebra


### PR DESCRIPTION
This repo no longer exists.

Replace links to that repo with waybackmachine links.

-----
[View rendered README.md](https://github.com/pygae/galgebra/blob/fix-readme-links/README.md)