### PR TITLE
Simplify loops using `enumerate` and `range`

### DIFF
--- a/galgebra/ga.py
+++ b/galgebra/ga.py
@@ -749,11 +749,9 @@ class Ga(metric.Metric):
         self.indexes_to_blades_dict = OrderedDict(self.indexes_to_blades)
 
         self.blades_to_grades_dict = {}
-        igrade = 0
-        for grade in self.blades:
+        for igrade, grade in enumerate(self.blades):
             for blade in grade:
                 self.blades_to_grades_dict[blade] = igrade
-            igrade += 1
 
         if not self.is_ortho:
 
@@ -779,11 +777,9 @@ class Ga(metric.Metric):
             self.indexes_to_bases_dict = OrderedDict(self.indexes_to_bases)
 
             self.bases_to_grades_dict = {}
-            igrade = 0
-            for grade in self.bases:
+            for igrade, grade in enumerate(self.bases):
                 for base in grade:
                     self.bases_to_grades_dict[base] = igrade
-                igrade += 1
 
         if self.coords is None:
             base0 = str(self.basis[0])
@@ -983,8 +979,7 @@ class Ga(metric.Metric):
         nblst = len(blst)  # number of basis vectors
         if nblst <= 1:
             return True  # a scalar or vector is already reduced
-        jstep = 1
-        while jstep < nblst:
+        for jstep in range(1, nblst):
             istep = jstep - 1
             if blst[istep] == blst[jstep]:  # basis vectorindex is repeated
                 i = blst[istep]  # save basis vector index
@@ -1006,7 +1001,7 @@ class Ga(metric.Metric):
                 else:
                     blst1_flg = False  # more revision needed
                 return a1, blst1, blst1_flg, blst
-            jstep += 1
+ 
         return True  # revision complete, blst in normal order
 
     #******************* Outer/wedge (^) product **********************#

--- a/galgebra/lt.py
+++ b/galgebra/lt.py
@@ -536,11 +536,9 @@ class Mlt(object):
         #  This is used when one wishes to substitute specific vector
         #  values into the Mlt such as the basis/reciprocal basis vectors.
         sub_lst = []
-        i = 0
-        for a in anew:
+        for i, a in enumerate(anew):
             acoefs = a.get_coefs(1)
             sub_lst += list(zip(Ga.pdiffs[i], acoefs))
-            i += 1
         return sub_lst
 
     @staticmethod
@@ -570,7 +568,7 @@ class Mlt(object):
             base_str = base_str.replace('}','')
             i = base_str.find('_') + 1
             if i == 0:
-               base_indexes.append(base_str)
+                base_indexes.append(base_str)
             else:
                 if base_str[i] == '_':
                     i += 1
@@ -888,14 +886,12 @@ class Mlt(object):
         basis = self.Ga.mv()
         rank = self.nargs
         ndim = len(basis)
-        i_indexes = rank*[list(range(ndim))]
-        indexes = rank*[basis]
-        i = 1
+        i_indexes = itertools.product(list(range(ndim)), repeat=rank)
+        indexes = itertools.product(basis, repeat=rank)
         output = ''
-        for (e,i_index) in zip(itertools.product(*indexes),itertools.product(*i_indexes)):
+        for i, (e, i_index) in enumerate(zip(indexes, i_indexes)):
             if i_index[-1] % ndim == 0: print('')
             output += str(i)+':'+str(i_index)+':'+str(self(*e)) + '\n'
-            i += 1
         return output
 
 if __name__ == "__main__":

--- a/galgebra/mv.py
+++ b/galgebra/mv.py
@@ -1885,8 +1885,7 @@ class Pdop(object):
             terms = copy.deepcopy(arg)
             while True:
                 D, D0 = D.factor()
-                k = 0
-                for term in terms:
+                for k, term in enumerate(terms):
                     dc = D0(term[0])
                     pd = D0(term[1])
                     #print 'D0, term, dc, pd =', D0, term, dc, pd
@@ -1896,7 +1895,6 @@ class Pdop(object):
                     if pd != 0 :
                         tmp.append((term[0],pd))
                     terms[k] = tmp
-                    k += 1
                 terms = [i for o in terms for i in o]  # flatten list one level
                 if D == 0:
                     break


### PR DESCRIPTION
This saves a few lines, and makes the loops easier to reason about.

Also simplifies a call to `itertools.product` to reduce the length of a long line