### PR TITLE
Don't run `Mv.setup` every time an Mv is created

### DIFF
--- a/galgebra/ga.py
+++ b/galgebra/ga.py
@@ -515,6 +515,18 @@ class Ga(metric.Metric):
     def I(self):  # Noromalized pseudo-scalar
         return self.i
 
+    @property
+    def mv_I(self):
+        # This exists for backwards compatibility. Note this is not `I()`!
+        # default pseudoscalar
+        return self.E()
+
+    @property
+    def mv_x(self):
+        # This exists for backwards compatibility.
+        # testing vectors
+        return Mv('XxXx', 'vector', ga=self)
+
     def X(self):
         return self.mv(sum([coord*base for (coord, base) in zip(self.coords, self.basis)]))
 
@@ -526,8 +538,6 @@ class Ga(metric.Metric):
         Instanciate and return a multivector for this, 'self',
         geometric algebra.
         """
-        (self.mv_I, self.mv_basis, self.mv_x) = mv.Mv.setup(ga=self)
-
         if root is None:  # Return ga basis and compute grad and rgrad
             return self.mv_basis
 
@@ -815,11 +825,15 @@ class Ga(metric.Metric):
                                 'indexes_to_bases_dict', self.indexes_to_bases_dict,
                                 'bases_to_grades_dict', self.bases_to_grades_dict)
 
-        self.mv_blades_lst = []
-        for obj in self.blades_lst:
-            self.mv_blades_lst.append(self.mv(obj))
-
-        return
+        # create the Mv wrappers
+        self.mv_blades_lst = [
+            mv.Mv(obj, ga=self)
+            for obj in self.blades_lst
+        ]
+        self.mv_basis = [
+            mv.Mv(obj, ga=self)
+            for obj in self.basis
+        ]
 
     def _build_basis_product_tables(self):
         """

--- a/galgebra/mv.py
+++ b/galgebra/mv.py
@@ -77,12 +77,8 @@ class Mv(object):
         a given geometric algebra, `ga`.
         """
         Mv.fmt = 1
-
-        basis = [Mv(x, ga=ga) for x in ga.basis]
-        I = Mv(ga.iobj, ga=ga)  # default pseudoscalar
-        x = Mv('XxXx', 'vector', ga=ga)  # testing vectors
-        # return default basis vectors and grad vector if coords defined
-        return I, basis, x
+        # copy basis in case the caller wanted to change it
+        return ga.mv_I, list(ga.mv_basis), ga.mv_x
 
     @staticmethod
     def Format(mode=1):


### PR DESCRIPTION
Before this change, every call to `Ga.mv` would reassign `mv_I`, `mv_basis`, and `mv_x`. There is no reason to do this, if a user asked for `.mv('A', 'vector')` they were not expecting to get a new (but identical) `mv_I`.

Since `Ga.__init__` called `self.mv` anyway, the previous approach didn't actually result in lazy computation anyway.

This change inlines the content of `Mv.setup` into `Ga.__init__`, and changes `Mv.setup` to just pull out the properties computed by `__init__`.

---

Extracted from #76 