### PR TITLE
Raise TypeError for bad arguments to `Mv`

### DIFF
--- a/galgebra/mv.py
+++ b/galgebra/mv.py
@@ -261,7 +261,7 @@ class Mv(object):
         tmp = S(0)
         for grade in ga.n_range:
             if (grade + 1) % 2 == 1:
-                tmp += Mv._make_grade(__name_or_coeffs, grade + 1, **kwargs)
+                tmp += Mv._make_grade(ga, __name_or_coeffs, grade + 1, **kwargs)
         return tmp
 
     # aliases

--- a/test/test_mv.py
+++ b/test/test_mv.py
@@ -84,3 +84,12 @@ class TestMv(unittest.TestCase):
         self.assertFalse(m0_base.is_blade_rep)  # original should not change
         self.assertTrue(m0_base_blade.is_blade_rep)
         self.assertEqual(m0, m0_base_blade)
+
+    def test_construction(self):
+        (ga, e_1, e_2, e_3) = Ga.build('e*1|2|3')
+
+        # illegal arguments
+        with self.assertRaises(TypeError):
+            ga.mv('A', 'vector', "too many arguments")
+        with self.assertRaises(TypeError):
+            ga.mv('A', 'grade')  # too few arguments

--- a/test/test_mv.py
+++ b/test/test_mv.py
@@ -88,6 +88,21 @@ class TestMv(unittest.TestCase):
     def test_construction(self):
         (ga, e_1, e_2, e_3) = Ga.build('e*1|2|3')
 
+        # non-function symbol construction
+        self.assertEqual(ga.mv('A', 'scalar').grades, [0])
+        self.assertEqual(ga.mv('A', 0).grades, [0])
+        self.assertEqual(ga.mv('A', 'vector').grades, [1])
+        self.assertEqual(ga.mv('A', 'grade', 1).grades, [1])
+        self.assertEqual(ga.mv('A', 1).grades, [1])
+        self.assertEqual(ga.mv('A', 'bivector').grades, [2])
+        self.assertEqual(ga.mv('A', 'grade2').grades, [2])
+        self.assertEqual(ga.mv('A', 2).grades, [2])
+        self.assertEqual(ga.mv('A', 'pseudo').grades, [3])
+        self.assertEqual(ga.mv('A', 'spinor').grades, [0, 2])
+        self.assertEqual(ga.mv('A', 'even').grades, [0, 2])
+        self.assertEqual(ga.mv('A', 'odd').grades, [1, 3])
+        self.assertEqual(ga.mv('A', 'mv').grades, [0, 1, 2, 3])
+
         # illegal arguments
         with self.assertRaises(TypeError):
             ga.mv('A', 'vector', "too many arguments")


### PR DESCRIPTION
If `Mv` is passed the wrong number of positional arguments, it used to either silently ignore them, or crash with an unclear message.

This would either confuse users, or mask bugs. With this change, it becomes a `TypeError` to pass either too many or too few parameters.