### PR TITLE
Extract the differential operators to their own (private) file

### DIFF
--- a/galgebra/__init__.py
+++ b/galgebra/__init__.py
@@ -16,6 +16,7 @@ Submodules
     ga
     mv
     lt
+    dop
     printer
     utils
 """

--- a/galgebra/dop.py
+++ b/galgebra/dop.py
@@ -1,0 +1,435 @@
+"""
+Differential operators, for all sympy expressions
+
+For multivector-customized differential operators, see :class:`galgebra.mv.Dop`.
+"""
+import copy
+import numbers
+import warnings
+
+from sympy import Symbol, S, Add, simplify, diff, Expr
+
+from . import printer
+from . import metric
+from . import mv
+from .printer import ZERO_STR
+
+
+def _consolidate_terms(terms):
+    """
+    Remove zero coefs and consolidate coefs with repeated pdiffs.
+    """
+    new_coefs = []
+    new_pdiffs = []
+    for (coef, pd) in terms:
+        if coef != S(0):
+            if pd in new_pdiffs:
+                index = new_pdiffs.index(pd)
+                new_coefs[index] += coef
+            else:
+                new_coefs.append(coef)
+                new_pdiffs.append(pd)
+    return tuple(zip(new_coefs, new_pdiffs))
+
+
+def _merge_terms(terms1, terms2):
+    """ Concatenate and consolidate two sets of already-consolidated terms """
+    pdiffs1 = [pdiff for _, pdiff in terms1]
+    pdiffs2 = [pdiff for _, pdiff in terms2]
+
+    pdiffs = pdiffs1 + [x for x in pdiffs2 if x not in pdiffs1]
+    coefs = len(pdiffs) * [S(0)]
+
+    for coef, pdiff in terms1:
+        index = pdiffs.index(pdiff)
+        coefs[index] += coef
+
+    for coef, pdiff in terms2:
+        index = pdiffs.index(pdiff)
+        coefs[index] += coef
+
+    # remove zeros
+    return [(coef, pdiff) for coef, pdiff in zip(coefs, pdiffs) if coef != S(0)]
+
+
+################ Scalar Partial Differential Operator Class ############
+
+class Sdop(object):
+    """
+    Scalar differential operator is of the form (Einstein summation)
+
+    .. math:: D = c_{i}*D_{i}
+
+    where the :math:`c_{i}`'s are scalar coefficient (they could be functions)
+    and the :math:`D_{i}`'s are partial differential operators (:class:`Pdop`).
+
+    Attributes
+    ----------
+    terms : tuple of tuple
+        the structure :math:`((c_{1},D_{1}),(c_{2},D_{2}), ...)`
+    """
+
+    str_mode = False
+
+    def TSimplify(self):
+        return Sdop([
+            (metric.Simp.apply(coef), pdiff) for (coef, pdiff) in self.terms
+        ])
+
+    @staticmethod
+    def consolidate_coefs(sdop):
+        """
+        Remove zero coefs and consolidate coefs with repeated pdiffs.
+        """
+        if isinstance(sdop, Sdop):
+            return Sdop(_consolidate_terms(sdop.terms))
+        else:
+            return _consolidate_terms(sdop)
+
+    def simplify(self, modes=simplify):
+        return Sdop([
+            (metric.apply_function_list(modes, coef), pdiff)
+            for coef, pdiff in self.terms
+        ])
+
+    def _with_sorted_terms(self):
+        new_terms = sorted(self.terms, key=lambda term: Pdop.sort_key(term[1]))
+        return Sdop(new_terms)
+
+    def Sdop_str(self):
+        if len(self.terms) == 0:
+            return ZERO_STR
+
+        self = self._with_sorted_terms()
+        s = ''
+        for (coef, pdop) in self.terms:
+            coef_str = printer.latex(coef)
+            pd_str = printer.latex(pdop)
+
+            if coef == S(1):
+                s += pd_str
+            elif coef == S(-1):
+                s += '-' + pd_str
+            else:
+                if isinstance(coef, Add):
+                    s += '(' + coef_str + ')*' + pd_str
+                else:
+                    s += coef_str + '*' + pd_str
+            s += ' + '
+
+        s = s.replace('+ -','- ')
+        s = s[:-3]
+        if Sdop.str_mode:
+            if len(self.terms) > 1 or isinstance(self.terms[0][0], Add):
+                s = '(' + s + ')'
+        return s
+
+    def Sdop_latex_str(self):
+        if len(self.terms) == 0:
+            return ZERO_STR
+
+        self = self._with_sorted_terms()
+
+        s = ''
+        for (coef, pdop) in self.terms:
+            coef_str = printer.latex(coef)
+            pd_str = printer.latex(pdop)
+            if coef == S(1):
+                if pd_str == '':
+                    s += '1'
+                else:
+                    s += pd_str
+            elif coef == S(-1):
+                if pd_str == '':
+                    s += '-1'
+                else:
+                    s += '-' + pd_str
+            else:
+                if isinstance(coef, Add):
+                    s += r'\left ( ' + coef_str + r'\right ) ' + pd_str
+                else:
+                    s += coef_str + ' ' + pd_str
+            s += ' + '
+
+        s = s.replace('+ -','- ')
+        return s[:-3]
+
+    def _repr_latex_(self):
+        latex_str = printer.GaLatexPrinter.latex(self)
+        return ' ' + latex_str + ' '
+
+    def __str__(self):
+        if printer.GaLatexPrinter.latex_flg:
+            Printer = printer.GaLatexPrinter
+        else:
+            Printer = printer.GaPrinter
+
+        return Printer().doprint(self)
+
+    def __repr__(self):
+        return str(self)
+
+    def __init__(self, *args):
+        if len(args) == 1 and isinstance(args[0],Symbol):  # Simple Pdop of order 1
+            self.terms = ((S(1), Pdop(args[0])),)
+        else:
+            if len(args) == 2 and isinstance(args[0],list) and isinstance(args[1],list):
+                if len(args[0]) != len(args[1]):
+                    raise ValueError('In Sdop.__init__ coefficent list and Pdop list must be same length.')
+                self.terms = tuple(zip(args[0], args[1]))
+            elif len(args) == 1 and isinstance(args[0], (list, tuple)):
+                self.terms = tuple(args[0])
+            else:
+                raise ValueError('In Sdop.__init__ length of args must be 1 or 2 args = '+str(args))
+
+    def __call__(self, arg):
+        if isinstance(arg, Sdop):
+            terms = []
+            for (coef, pdiff) in self.terms:
+                new_terms = pdiff(arg.terms)
+                new_terms = [(coef * c, p) for c, p in new_terms]
+                terms += new_terms
+            product = Sdop(terms)
+            return Sdop.consolidate_coefs(product)
+        else:
+            return sum([coef * pdiff(arg) for coef, pdiff in self.terms], S(0))
+
+
+    def __neg__(self):
+        return Sdop([(-coef, pdiff) for coef, pdiff in self.terms])
+
+    @staticmethod
+    def Add(sdop1, sdop2):
+        if isinstance(sdop1, Sdop) and isinstance(sdop2, Sdop):
+            return Sdop(_merge_terms(sdop1.terms, sdop2.terms))
+        else:
+            # convert values to multiplicative operators
+            if isinstance(sdop1, Sdop):
+                sdop2 = Sdop([(sdop2, Pdop({}))])
+            elif isinstance(sdop2, Sdop):
+                sdop1 = Sdop([(sdop1, Pdop({}))])
+            else:
+                raise TypeError("Neither argument is a Dop instance")
+            return Sdop.Add(sdop1, sdop2)
+
+    def __eq__(self, other):
+        if isinstance(other, Sdop):
+            diff = self - other
+            return len(diff.terms) == 0
+        else:
+            return NotImplemented
+
+    def __add__(self, sdop):
+        return Sdop.Add(self, sdop)
+
+    def __radd__(self, sdop):
+        return Sdop.Add(sdop, self)
+
+    def __sub__(self, sdop):
+        return Sdop.Add(self, -sdop)
+
+    def __rsub__(self, sdop):
+        return Sdop.Add(-self, sdop)
+
+    def __mul__(self, sdopr):
+        # alias for applying the operator
+        return self.__call__(sdopr)
+
+    def __rmul__(self, sdop):
+        terms = [(sdop * coef, pdiff) for coef, pdiff in self.terms]
+        return Sdop(terms)
+
+#################### Partial Derivative Operator Class #################
+
+class Pdop(object):
+    r"""
+    Partial derivative operatorp.
+
+    The partial derivatives are of the form
+
+    .. math::
+        \partial_{i_{1}...i_{n}} =
+            \frac{\partial^{i_{1}+...+i_{n}}}{\partial{x_{1}^{i_{1}}}...\partial{x_{n}^{i_{n}}}}.
+
+    If :math:`i_{j} = 0` then the partial derivative does not contain the
+    :math:`x^{i_{j}}` coordinate.
+
+    Attributes
+    ----------
+    pdiffs : dict
+        A dictionary where coordinates are keys and key value are the number of
+        times one differentiates with respect to the key.
+    order : int
+        Total number of differentiations.
+        When this is zero (i.e. when :attr:`pdiffs` is ``{}``) then this object
+        is the identity operator, and returns its operand unchanged.
+    """
+
+    def sort_key(self, order=None):
+        return (
+            # lower order derivatives first
+            self.order,
+            # sorted by symbol after that, after expansion
+            sorted([
+                x.sort_key(order)
+                for x, k in self.pdiffs.items()
+                for i in range(k)
+            ])
+        )
+
+    def __eq__(self,A):
+        if isinstance(A, Pdop) and self.pdiffs == A.pdiffs:
+            return True
+        else:
+            if len(self.pdiffs) == 0 and A == S(1):
+                return True
+            return False
+
+    def __init__(self, __arg):
+        """
+        The partial differential operator is a partial derivative with
+        respect to a set of real symbols (variables).
+        """
+        # galgebra 0.4.5
+        if __arg is None:
+            warnings.warn(
+                "`Pdop(None)` is deprecated, use `Pdop({})` instead",
+                DeprecationWarning, stacklevel=2)
+            __arg = {}
+
+        if isinstance(__arg, dict):  # Pdop defined by dictionary
+            self.pdiffs = __arg
+        elif isinstance(__arg, Symbol):  # First order derivative with respect to symbol
+            self.pdiffs = {__arg: 1}
+        else:
+            raise TypeError('A dictionary or symbol is required, got {!r}'.format(__arg))
+
+        self.order = sum(self.pdiffs.values())
+
+    def factor(self):
+        """
+        If partial derivative operator self.order > 1 factor out first
+        order differential operator.  Needed for application of partial
+        derivative operator to product of sympy expression and partial
+        differential operator.  For example if ``D = Pdop({x:3})`` then::
+
+            (Pdop({x:2}), Pdop({x:1})) = D.factor()
+        """
+        if self.order == 1:
+            return S(0), self
+        else:
+            new_pdiffs = self.pdiffs.copy()
+            x, n = next(iter(new_pdiffs.items()))
+            if n == 1:
+                del new_pdiffs[x]
+            else:
+                new_pdiffs[x] -= 1
+            return Pdop(new_pdiffs), Pdop(x)
+
+    def __call__(self, arg):
+        """
+        Calculate nth order partial derivative (order defined by
+        self) of :class:`~galgebra.mv.Mv`, :class:`Dop`, :class:`Sdop` or sympy expression
+        """
+        if self.pdiffs == {}:
+            return arg  # result is Pdop identity (1)
+
+        if isinstance(arg, Pdop):  # arg is Pdop
+            if arg.pdiffs == {}:  # arg is one
+                return self
+                #return S(0)  # derivative is zero
+            else:  # arg is partial derivative
+                pdiffs = copy.copy(arg.pdiffs)
+                for key in self.pdiffs:
+                    if key in pdiffs:
+                        pdiffs[key] += self.pdiffs[key]
+                    else:
+                        pdiffs[key] = self.pdiffs[key]
+            return Pdop(pdiffs)  # result is Pdop
+
+        elif isinstance(arg, mv.Mv):  # arg is multivector
+            ga = arg.Ga
+            for x in self.pdiffs:
+                for i in range(self.pdiffs[x]):
+                    arg = ga.pDiff(arg, x)
+            return arg  # result is multivector
+
+        elif isinstance(arg, (Expr, Symbol, numbers.Number)):  # arg is sympy expression
+            for x in self.pdiffs:
+                arg = diff(arg,x,self.pdiffs[x])
+            return arg  # derivative is sympy expression
+
+        elif isinstance(arg, (list, tuple)):  # arg is list of tuples (coef, partial derivative)
+            terms = list(arg)
+            D = self
+            while True:
+                D, D0 = D.factor()
+                for k, term in enumerate(terms):
+                    dc = D0(term[0])
+                    pd = D0(term[1])
+                    #print 'D0, term, dc, pd =', D0, term, dc, pd
+                    tmp = []
+                    if dc != 0:
+                        tmp.append((dc,term[1]))
+                    if pd != 0 :
+                        tmp.append((term[0],pd))
+                    terms[k] = tmp
+                terms = [i for o in terms for i in o]  # flatten list one level
+                if D == 0:
+                    break
+            terms = Sdop.consolidate_coefs(terms)
+            return terms  # result is list of tuples (coef, partial derivative)
+        elif isinstance(arg, Sdop):  # arg is scalar differential operator
+            return self(arg.terms)  # result is list of tuples (coef, partial derivative)
+        else:
+            raise ValueError('In Pdop.__call__ type(arg) = ' + str(type(arg)) + ' not allowed.')
+
+    def __mul__(self, pdop):  # functional product of self and arg (self*arg)
+        return self(pdop)
+
+    def __rmul__(self, pdop):  # functional product of arg and self (arg*self)
+        if isinstance(pdop, Pdop):
+            return pdop(self)
+        return Sdop([(pdop, self)])
+
+    def Pdop_str(self):
+        if self.order == 0:
+            return 'D{}'
+        s = 'D'
+        for x in self.pdiffs:
+            s += '{' + str(x) + '}'
+            n = self.pdiffs[x]
+            if n > 1:
+                s += '^' + str(n)
+        return s
+
+    def Pdop_latex_str(self):
+        if self.order == 0:
+            return ''
+        s = r'\frac{\partial'
+        if self.order > 1:
+            s += '^{' + printer.latex(self.order) + '}'
+        s += '}{'
+        keys = list(self.pdiffs.keys())
+        keys.sort()
+        for key in keys:
+            i = self.pdiffs[key]
+            s += r'\partial ' + printer.latex(key)
+            if i > 1:
+                s += '^{' + printer.latex(i) + '}'
+        s += '}'
+        return s
+
+    def _repr_latex_(self):
+        latex_str = printer.GaLatexPrinter.latex(self)
+        return ' ' + latex_str + ' '
+
+    def __str__(self):
+        if printer.GaLatexPrinter.latex_flg:
+            Printer = printer.GaLatexPrinter
+        else:
+            Printer = printer.GaPrinter
+        return Printer().doprint(self)
+
+    def __repr__(self):
+        return str(self)

--- a/galgebra/ga.py
+++ b/galgebra/ga.py
@@ -18,6 +18,7 @@ from sympy import (
 from . import printer
 from . import metric
 from . import mv
+from . import dop
 from . import lt
 
 half = Rational(1, 2)
@@ -474,7 +475,7 @@ class Ga(metric.Metric):
         pdiffs = []
         for (base, coord) in zip(self.r_basis_mv, ai):
             coefs.append(base)
-            pdiffs.append(mv.Pdop({coord: 1}, ga=self))
+            pdiffs.append(dop.Pdop({coord: 1}, ga=self))
         self._agrads[a] = mv.Dop(coefs, pdiffs, ga=self, cmpflg=cmpflg)
         self.a.append(a)
         return self._agrads[a]
@@ -517,7 +518,7 @@ class Ga(metric.Metric):
         warnings.warn(
             "ga.Pdiffs[x] is deprecated, use `Pdop(x)` instead",
             DeprecationWarning, stacklevel=2)
-        return {x: mv.Pdop(x) for x in self.coords}
+        return {x: dop.Pdop(x) for x in self.coords}
 
     @property
     def sPds(self):
@@ -525,7 +526,7 @@ class Ga(metric.Metric):
         warnings.warn(
             "ga.sPds[x] is deprecated, use `Sdop(x)` instead",
             DeprecationWarning, stacklevel=2)
-        return {x: mv.Sdop(x) for x in self.coords}
+        return {x: dop.Sdop(x) for x in self.coords}
 
     @property
     def Pdop_identity(self):
@@ -533,7 +534,7 @@ class Ga(metric.Metric):
         warnings.warn(
             "ga.Pdop_identity is deprecated, use `Pdop({})` instead",
             DeprecationWarning, stacklevel=2)
-        return mv.Pdop({})
+        return dop.Pdop({})
 
     def mv(self, root=None, *args, **kwargs):
         """
@@ -619,7 +620,7 @@ class Ga(metric.Metric):
         if self.norm:
             r_basis = [x / e_norm for (x, e_norm) in zip(self.r_basis_mv, self.e_norm)]
 
-        pdx = [mv.Pdop(x) for x in self.coords]
+        pdx = [dop.Pdop(x) for x in self.coords]
 
         self.grad = mv.Dop(r_basis, pdx, ga=self)
         self.rgrad = mv.Dop(r_basis, pdx, ga=self, cmpflg=True)
@@ -630,24 +631,24 @@ class Ga(metric.Metric):
         return self.grad, self.rgrad
 
     def pdop(self, *args, **kwargs):
-        """ Shorthand to construct a :class:`~galgebra.mv.Pdop` for this algebra """
+        """ Shorthand to construct a :class:`~galgebra.dop.Pdop` """
         # galgebra 0.4.5
         warnings.warn(
             "`ga.pdop` is deprecated, use `Pdop()` directly.",
             DeprecationWarning, stacklevel=2)
-        return mv.Pdop(*args, **kwargs)
+        return dop.Pdop(*args, **kwargs)
 
     def dop(self, *args, **kwargs):
         """ Shorthand to construct a :class:`~galgebra.mv.Dop` for this algebra """
         return mv.Dop(*args, ga=self, **kwargs)
 
     def sdop(self, *args, **kwargs):
-        """ Shorthand to construct a :class:`~galgebra.mv.Sdop` for this algebra """
+        """ Shorthand to construct a :class:`~galgebra.dop.Sdop` """
         # galgebra 0.4.5
         warnings.warn(
             "`ga.sdop` is deprecated, use `Sdop()` directly.",
             DeprecationWarning, stacklevel=2)
-        return mv.Sdop(*args, **kwargs)
+        return dop.Sdop(*args, **kwargs)
 
     def lt(self, *args, **kwargs):
         """

--- a/galgebra/mv.py
+++ b/galgebra/mv.py
@@ -6,7 +6,6 @@ import copy
 import numbers
 import operator
 from functools import reduce
-import warnings
 
 from sympy import (
     Symbol, Function, S, expand, Add,
@@ -20,6 +19,7 @@ from . import printer
 from . import metric
 from .printer import ZERO_STR
 from .utils import _KwargParser
+from . import dop
 
 ONE = S(1)
 ZERO = S(0)
@@ -1359,6 +1359,7 @@ class Mv(object):
             return self.i_grade
         return -self.grades[-1]
 
+
 def compare(A,B):
     """
     Determine if ``B = c*A`` where c is a scalar.  If true return c
@@ -1389,425 +1390,6 @@ def compare(A,B):
         return c
     else:
         raise TypeError('In compare both arguments are not multivectors\n')
-
-
-def _consolidate_terms(terms):
-    """
-    Remove zero coefs and consolidate coefs with repeated pdiffs.
-    """
-    new_coefs = []
-    new_pdiffs = []
-    for (coef, pd) in terms:
-        if coef != S(0):
-            if pd in new_pdiffs:
-                index = new_pdiffs.index(pd)
-                new_coefs[index] += coef
-            else:
-                new_coefs.append(coef)
-                new_pdiffs.append(pd)
-    return tuple(zip(new_coefs, new_pdiffs))
-
-
-def _merge_terms(terms1, terms2):
-    """ Concatenate and consolidate two sets of already-consolidated terms """
-    pdiffs1 = [pdiff for _, pdiff in terms1]
-    pdiffs2 = [pdiff for _, pdiff in terms2]
-
-    pdiffs = pdiffs1 + [x for x in pdiffs2 if x not in pdiffs1]
-    coefs = len(pdiffs) * [S(0)]
-
-    for coef, pdiff in terms1:
-        index = pdiffs.index(pdiff)
-        coefs[index] += coef
-
-    for coef, pdiff in terms2:
-        index = pdiffs.index(pdiff)
-        coefs[index] += coef
-
-    # remove zeros
-    return [(coef, pdiff) for coef, pdiff in zip(coefs, pdiffs) if coef != S(0)]
-
-
-################ Scalar Partial Differential Operator Class ############
-
-class Sdop(object):
-    """
-    Scalar differential operator is of the form (Einstein summation)
-
-    .. math:: D = c_{i}*D_{i}
-
-    where the :math:`c_{i}`'s are scalar coefficient (they could be functions)
-    and the :math:`D_{i}`'s are partial differential operators (:class:`Pdop`).
-
-    Attributes
-    ----------
-    terms : tuple of tuple
-        the structure :math:`((c_{1},D_{1}),(c_{2},D_{2}), ...)`
-    """
-
-    str_mode = False
-
-    def TSimplify(self):
-        return Sdop([
-            (metric.Simp.apply(coef), pdiff) for (coef, pdiff) in self.terms
-        ])
-
-    @staticmethod
-    def consolidate_coefs(sdop):
-        """
-        Remove zero coefs and consolidate coefs with repeated pdiffs.
-        """
-        if isinstance(sdop, Sdop):
-            return Sdop(_consolidate_terms(sdop.terms))
-        else:
-            return _consolidate_terms(sdop)
-
-    def simplify(self, modes=simplify):
-        return Sdop([
-            (metric.apply_function_list(modes, coef), pdiff)
-            for coef, pdiff in self.terms
-        ])
-
-    def _with_sorted_terms(self):
-        new_terms = sorted(self.terms, key=lambda term: Pdop.sort_key(term[1]))
-        return Sdop(new_terms)
-
-    def Sdop_str(self):
-        if len(self.terms) == 0:
-            return ZERO_STR
-
-        self = self._with_sorted_terms()
-        s = ''
-        for (coef, pdop) in self.terms:
-            coef_str = printer.latex(coef)
-            pd_str = printer.latex(pdop)
-
-            if coef == S(1):
-                s += pd_str
-            elif coef == S(-1):
-                s += '-' + pd_str
-            else:
-                if isinstance(coef, Add):
-                    s += '(' + coef_str + ')*' + pd_str
-                else:
-                    s += coef_str + '*' + pd_str
-            s += ' + '
-
-        s = s.replace('+ -','- ')
-        s = s[:-3]
-        if Sdop.str_mode:
-            if len(self.terms) > 1 or isinstance(self.terms[0][0], Add):
-                s = '(' + s + ')'
-        return s
-
-    def Sdop_latex_str(self):
-        if len(self.terms) == 0:
-            return ZERO_STR
-
-        self = self._with_sorted_terms()
-
-        s = ''
-        for (coef, pdop) in self.terms:
-            coef_str = printer.latex(coef)
-            pd_str = printer.latex(pdop)
-            if coef == S(1):
-                if pd_str == '':
-                    s += '1'
-                else:
-                    s += pd_str
-            elif coef == S(-1):
-                if pd_str == '':
-                    s += '-1'
-                else:
-                    s += '-' + pd_str
-            else:
-                if isinstance(coef, Add):
-                    s += r'\left ( ' + coef_str + r'\right ) ' + pd_str
-                else:
-                    s += coef_str + ' ' + pd_str
-            s += ' + '
-
-        s = s.replace('+ -','- ')
-        return s[:-3]
-
-    def _repr_latex_(self):
-        latex_str = printer.GaLatexPrinter.latex(self)
-        return ' ' + latex_str + ' '
-
-    def __str__(self):
-        if printer.GaLatexPrinter.latex_flg:
-            Printer = printer.GaLatexPrinter
-        else:
-            Printer = printer.GaPrinter
-
-        return Printer().doprint(self)
-
-    def __repr__(self):
-        return str(self)
-
-    def __init__(self, *args):
-        if len(args) == 1 and isinstance(args[0],Symbol):  # Simple Pdop of order 1
-            self.terms = ((S(1), Pdop(args[0])),)
-        else:
-            if len(args) == 2 and isinstance(args[0],list) and isinstance(args[1],list):
-                if len(args[0]) != len(args[1]):
-                    raise ValueError('In Sdop.__init__ coefficent list and Pdop list must be same length.')
-                self.terms = tuple(zip(args[0], args[1]))
-            elif len(args) == 1 and isinstance(args[0], (list, tuple)):
-                self.terms = tuple(args[0])
-            else:
-                raise ValueError('In Sdop.__init__ length of args must be 1 or 2 args = '+str(args))
-
-    def __call__(self, arg):
-        if isinstance(arg, Sdop):
-            terms = []
-            for (coef, pdiff) in self.terms:
-                new_terms = pdiff(arg.terms)
-                new_terms = [(coef * c, p) for c, p in new_terms]
-                terms += new_terms
-            product = Sdop(terms)
-            return Sdop.consolidate_coefs(product)
-        else:
-            return sum([coef * pdiff(arg) for coef, pdiff in self.terms], S(0))
-
-
-    def __neg__(self):
-        return Sdop([(-coef, pdiff) for coef, pdiff in self.terms])
-
-    @staticmethod
-    def Add(sdop1, sdop2):
-        if isinstance(sdop1, Sdop) and isinstance(sdop2, Sdop):
-            return Sdop(_merge_terms(sdop1.terms, sdop2.terms))
-        else:
-            # convert values to multiplicative operators
-            if isinstance(sdop1, Sdop):
-                sdop2 = Sdop([(sdop2, Pdop({}))])
-            elif isinstance(sdop2, Sdop):
-                sdop1 = Sdop([(sdop1, Pdop({}))])
-            else:
-                raise TypeError("Neither argument is a Dop instance")
-            return Sdop.Add(sdop1, sdop2)
-
-    def __eq__(self, other):
-        if isinstance(other, Sdop):
-            diff = self - other
-            return len(diff.terms) == 0
-        else:
-            return NotImplemented
-
-    def __add__(self, sdop):
-        return Sdop.Add(self, sdop)
-
-    def __radd__(self, sdop):
-        return Sdop.Add(sdop, self)
-
-    def __sub__(self, sdop):
-        return Sdop.Add(self, -sdop)
-
-    def __rsub__(self, sdop):
-        return Sdop.Add(-self, sdop)
-
-    def __mul__(self, sdopr):
-        # alias for applying the operator
-        return self.__call__(sdopr)
-
-    def __rmul__(self, sdop):
-        terms = [(sdop * coef, pdiff) for coef, pdiff in self.terms]
-        return Sdop(terms)
-
-#################### Partial Derivative Operator Class #################
-
-class Pdop(object):
-    r"""
-    Partial derivative class for multivectors.  The partial derivatives
-    are of the form
-
-    .. math::
-        \partial_{i_{1}...i_{n}} =
-            \frac{\partial^{i_{1}+...+i_{n}}}{\partial{x_{1}^{i_{1}}}...\partial{x_{n}^{i_{n}}}}.
-
-    If :math:`i_{j} = 0` then the partial derivative does not contain the
-    :math:`x^{i_{j}}` coordinate.
-
-    Attributes
-    ----------
-    pdiffs : dict
-        A dictionary where coordinates are keys and key value are the number of
-        times one differentiates with respect to the key.
-    order : int
-        Total number of differentiations.
-        When this is zero (i.e. when :attr:`pdiffs` is ``{}``) then this object
-        is the identity operator, and returns its operand unchanged.
-    """
-
-    def sort_key(self, order=None):
-        return (
-            # lower order derivatives first
-            self.order,
-            # sorted by symbol after that, after expansion
-            sorted([
-                x.sort_key(order)
-                for x, k in self.pdiffs.items()
-                for i in range(k)
-            ])
-        )
-
-    def __eq__(self,A):
-        if isinstance(A, Pdop) and self.pdiffs == A.pdiffs:
-            return True
-        else:
-            if len(self.pdiffs) == 0 and A == S(1):
-                return True
-            return False
-
-    def __init__(self, __arg):
-        """
-        The partial differential operator is a partial derivative with
-        respect to a set of real symbols (variables).
-        """
-        # galgebra 0.4.5
-        if __arg is None:
-            warnings.warn(
-                "`Pdop(None)` is deprecated, use `Pdop({})` instead",
-                DeprecationWarning, stacklevel=2)
-            __arg = {}
-
-        if isinstance(__arg, dict):  # Pdop defined by dictionary
-            self.pdiffs = __arg
-        elif isinstance(__arg, Symbol):  # First order derivative with respect to symbol
-            self.pdiffs = {__arg: 1}
-        else:
-            raise TypeError('A dictionary or symbol is required, got {!r}'.format(__arg))
-
-        self.order = sum(self.pdiffs.values())
-
-    def factor(self):
-        """
-        If partial derivative operator self.order > 1 factor out first
-        order differential operator.  Needed for application of partial
-        derivative operator to product of sympy expression and partial
-        differential operator.  For example if ``D = Pdop({x:3})`` then::
-
-            (Pdop({x:2}), Pdop({x:1})) = D.factor()
-        """
-        if self.order == 1:
-            return S(0), self
-        else:
-            new_pdiffs = self.pdiffs.copy()
-            x, n = next(iter(new_pdiffs.items()))
-            if n == 1:
-                del new_pdiffs[x]
-            else:
-                new_pdiffs[x] -= 1
-            return Pdop(new_pdiffs), Pdop(x)
-
-    def __call__(self, arg):
-        """
-        Calculate nth order partial derivative (order defined by
-        self) of :class:`Mv`, :class:`Dop`, :class:`Sdop` or sympy expression
-        """
-        if self.pdiffs == {}:
-            return arg  # result is Pdop identity (1)
-
-        if isinstance(arg, Pdop):  # arg is Pdop
-            if arg.pdiffs == {}:  # arg is one
-                return self
-                #return S(0)  # derivative is zero
-            else:  # arg is partial derivative
-                pdiffs = copy.copy(arg.pdiffs)
-                for key in self.pdiffs:
-                    if key in pdiffs:
-                        pdiffs[key] += self.pdiffs[key]
-                    else:
-                        pdiffs[key] = self.pdiffs[key]
-            return Pdop(pdiffs)  # result is Pdop
-
-        elif isinstance(arg, Mv):  # arg is multivector
-            ga = arg.Ga
-            for x in self.pdiffs:
-                for i in range(self.pdiffs[x]):
-                    arg = ga.pDiff(arg, x)
-            return arg  # result is multivector
-
-        elif isinstance(arg, (Expr, Symbol, numbers.Number)):  # arg is sympy expression
-            for x in self.pdiffs:
-                arg = diff(arg,x,self.pdiffs[x])
-            return arg  # derivative is sympy expression
-
-        elif isinstance(arg, (list, tuple)):  # arg is list of tuples (coef, partial derivative)
-            terms = list(arg)
-            D = self
-            while True:
-                D, D0 = D.factor()
-                for k, term in enumerate(terms):
-                    dc = D0(term[0])
-                    pd = D0(term[1])
-                    #print 'D0, term, dc, pd =', D0, term, dc, pd
-                    tmp = []
-                    if dc != 0:
-                        tmp.append((dc,term[1]))
-                    if pd != 0 :
-                        tmp.append((term[0],pd))
-                    terms[k] = tmp
-                terms = [i for o in terms for i in o]  # flatten list one level
-                if D == 0:
-                    break
-            terms = Sdop.consolidate_coefs(terms)
-            return terms  # result is list of tuples (coef, partial derivative)
-        elif isinstance(arg, Sdop):  # arg is scalar differential operator
-            return self(arg.terms)  # result is list of tuples (coef, partial derivative)
-        else:
-            raise ValueError('In Pdop.__call__ type(arg) = ' + str(type(arg)) + ' not allowed.')
-
-    def __mul__(self, pdop):  # functional product of self and arg (self*arg)
-        return self(pdop)
-
-    def __rmul__(self, pdop):  # functional product of arg and self (arg*self)
-        if isinstance(pdop, Pdop):
-            return pdop(self)
-        return Sdop([(pdop, self)])
-
-    def Pdop_str(self):
-        if self.order == 0:
-            return 'D{}'
-        s = 'D'
-        for x in self.pdiffs:
-            s += '{' + str(x) + '}'
-            n = self.pdiffs[x]
-            if n > 1:
-                s += '^' + str(n)
-        return s
-
-    def Pdop_latex_str(self):
-        if self.order == 0:
-            return ''
-        s = r'\frac{\partial'
-        if self.order > 1:
-            s += '^{' + printer.latex(self.order) + '}'
-        s += '}{'
-        keys = list(self.pdiffs.keys())
-        keys.sort()
-        for key in keys:
-            i = self.pdiffs[key]
-            s += r'\partial ' + printer.latex(key)
-            if i > 1:
-                s += '^{' + printer.latex(i) + '}'
-        s += '}'
-        return s
-
-    def _repr_latex_(self):
-        latex_str = printer.GaLatexPrinter.latex(self)
-        return ' ' + latex_str + ' '
-
-    def __str__(self):
-        if printer.GaLatexPrinter.latex_flg:
-            Printer = printer.GaLatexPrinter
-        else:
-            Printer = printer.GaPrinter
-        return Printer().doprint(self)
-
-    def __repr__(self):
-        return str(self)
 
 ################# Multivector Differential Operator Class ##############
 
@@ -1892,8 +1474,8 @@ class Dop(object):
                 self.terms = ()
             elif isinstance(arg[0][0], Mv):  # Mv expansion [(Mv, Pdop)]
                 self.terms = tuple(arg)
-            elif isinstance(arg[0][0], Sdop):  # Sdop expansion [(Sdop, Mv)]
-                self.terms = _consolidate_terms(
+            elif isinstance(arg[0][0], dop.Sdop):  # Sdop expansion [(Sdop, Mv)]
+                self.terms = dop._consolidate_terms(
                     (coef * mv, pdiff)
                     for (sdop, mv) in arg
                     for (coef, pdiff) in sdop.terms
@@ -1917,7 +1499,7 @@ class Dop(object):
         """
         Remove zero coefs and consolidate coefs with repeated pdiffs.
         """
-        return Dop(_consolidate_terms(self.terms), ga=self.Ga, cmpflg=self.cmpflg)
+        return Dop(dop._consolidate_terms(self.terms), ga=self.Ga, cmpflg=self.cmpflg)
 
     @staticmethod
     def Add(dop1, dop2):
@@ -1929,17 +1511,17 @@ class Dop(object):
             if dop1.cmpflg != dop2.cmpflg:
                 raise ValueError('In Dop.Add complement flags have different values: %s vs. %s' % (dop1.cmpflg, dop2.cmpflg))
 
-            return Dop(_merge_terms(dop1.terms, dop2.terms), cmpflg=dop1.cmpflg, ga=dop1.Ga)
+            return Dop(dop._merge_terms(dop1.terms, dop2.terms), cmpflg=dop1.cmpflg, ga=dop1.Ga)
         else:
             # convert values to multiplicative operators
             if isinstance(dop1, Dop):
                 if not isinstance(dop2, Mv):
                     dop2 = dop1.Ga.mv(dop2)
-                dop2 = Dop([(dop2, Pdop({}))], cmpflg=dop1.cmpflg, ga=dop1.Ga)
+                dop2 = Dop([(dop2, dop.Pdop({}))], cmpflg=dop1.cmpflg, ga=dop1.Ga)
             elif isinstance(dop2, Dop):
                 if not isinstance(dop1, Mv):
                     dop1 = dop2.Ga.mv(dop1)
-                dop1 = Dop([(dop1, Pdop({}))], cmpflg=dop2.cmpflg, ga=dop2.Ga)
+                dop1 = Dop([(dop1, dop.Pdop({}))], cmpflg=dop2.cmpflg, ga=dop2.Ga)
             else:
                 raise TypeError("Neither argument is a Dop instance")
             return Dop.Add(dop1, dop2)
@@ -2092,7 +1674,7 @@ class Dop(object):
 
     def components(self):
         return tuple(
-            Dop(_consolidate_terms(
+            Dop(dop._consolidate_terms(
                 (Mv(coef * base, ga=self.Ga), pdiff)
                 for (coef, pdiff) in sdop.terms
             ), ga=self.Ga)
@@ -2109,10 +1691,10 @@ class Dop(object):
                 for mv_coef, mv_base in metric.linear_expand_terms(coef.obj):
                     if mv_base in bases:
                         index = bases.index(mv_base)
-                        coefs[index] += Sdop([(mv_coef, pdiff)])
+                        coefs[index] += dop.Sdop([(mv_coef, pdiff)])
                     else:
                         bases.append(mv_base)
-                        coefs.append(Sdop([(mv_coef, pdiff)]))
+                        coefs.append(dop.Sdop([(mv_coef, pdiff)]))
             else:
                 if isinstance(coef, Mv):
                     mv_coef = coef.obj
@@ -2120,10 +1702,10 @@ class Dop(object):
                     mv_coef = coef
                 if S(1) in bases:
                     index = bases.index(S(1))
-                    coefs[index] += Sdop([(mv_coef, pdiff)])
+                    coefs[index] += dop.Sdop([(mv_coef, pdiff)])
                 else:
                     bases.append(S(1))
-                    coefs.append(Sdop([(mv_coef, pdiff)]))
+                    coefs.append(dop.Sdop([(mv_coef, pdiff)]))
         if modes is not None:
             for i in range(len(coefs)):
                 coefs[i] = coefs[i].simplify(modes)
@@ -2205,7 +1787,7 @@ class Dop(object):
             s += ' + '
 
         s = s.replace('+ -','-')
-        Sdop.str_mode = False
+        dop.Sdop.str_mode = False
         return s[:-3]
 
     def Fmt(self, fmt=1, title=None, dop_fmt=None):

--- a/test/test_differential_ops.py
+++ b/test/test_differential_ops.py
@@ -2,7 +2,8 @@ from sympy import symbols, S
 import pytest
 
 from galgebra.ga import Ga
-from galgebra.mv import Dop, Sdop, Pdop
+from galgebra.mv import Dop
+from galgebra.dop import Sdop, Pdop
 
 
 class TestDop(object):


### PR DESCRIPTION
This breaks the file roughly in two, which seems like a nice breakdown.
Splitting further is probably harmful, since these three classes are tightly related.

No code changes beyond moving lines and adjusting imports.

Things to check:

* [x] Documentation for these classes still appear
* [x] No unused imports reported from LGTM (only the ones that are false positives)
* [x] Travis passes