### PR TITLE
Simplify `er_blade`

### DIFF
--- a/galgebra/ga.py
+++ b/galgebra/ga.py
@@ -1650,22 +1650,10 @@ class Ga(metric.Metric):
 
         .. math:: e^{j}*(e_{i_{1}}\wedge ...\wedge e_{i_{r}})
         """
-        if mode == '*':
-            base = self.blade_to_base_rep(blade)
-            if left:
-                return self.base_to_blade_rep(self.mul(er, base))
-            else:
-                return self.base_to_blade_rep(self.mul(base, er))
-        elif mode == '^':
-            if left:
-                return self.wedge(er, blade)
-            else:
-                return self.wedge(blade, er)
+        if left:
+            return self.Mul(er, blade, mode=mode)
         else:
-            if left:
-                return self.Mul(er, blade, mode=mode)
-            else:
-                return self.Mul(blade, er, mode=mode)
+            return self.Mul(blade, er, mode=mode)
 
     def blade_derivation(self, blade, ib):
         """


### PR DESCRIPTION
This function did two things unnecessarily:

* Convert blade reps to base rep before calling mul. This is already handled within `mul`, so there's no need to do it again at the call site.
* Branch depending on the mode string - this branching is already handled by `Mul`

This function is called only by `Ga.connection`, which is not tested anywhere, so has no code coverage.