### PR TITLE
Remove yet more special-casing of the hestenes dot product

### DIFF
--- a/examples/ipython/inner_product.ipynb
+++ b/examples/ipython/inner_product.ipynb
@@ -81,10 +81,10 @@
     {
      "data": {
       "text/latex": [
-       "$$0$$"
+       "\\begin{equation*}  0  \\end{equation*}"
       ],
       "text/plain": [
-       "0"
+       " 0 "
       ]
      },
      "execution_count": 6,
@@ -104,10 +104,10 @@
     {
      "data": {
       "text/latex": [
-       "$$0$$"
+       "\\begin{equation*}  0  \\end{equation*}"
       ],
       "text/plain": [
-       "0"
+       " 0 "
       ]
      },
      "execution_count": 7,
@@ -127,10 +127,10 @@
     {
      "data": {
       "text/latex": [
-       "$$0$$"
+       "\\begin{equation*}  0  \\end{equation*}"
       ],
       "text/plain": [
-       "0"
+       " 0 "
       ]
      },
      "execution_count": 8,
@@ -150,10 +150,10 @@
     {
      "data": {
       "text/latex": [
-       "$$0$$"
+       "\\begin{equation*}  0  \\end{equation*}"
       ],
       "text/plain": [
-       "0"
+       " 0 "
       ]
      },
      "execution_count": 9,

--- a/galgebra/mv.py
+++ b/galgebra/mv.py
@@ -816,11 +816,8 @@ class Mv(object):
             return A.Mul(self, A, op='|')
 
         self = self.blade_rep()
-        if self.is_scalar() or A.is_scalar():
-            return S(0)
         A = A.blade_rep()
-        self_dot_A = Mv(self.Ga.hestenes_dot(self.obj, A.obj), ga=self.Ga)
-        return self_dot_A
+        return Mv(self.Ga.hestenes_dot(self.obj, A.obj), ga=self.Ga)
 
     def __ror__(self, A):  # dot (|) product
         if not isinstance(A, Mv):


### PR DESCRIPTION
Continues from #134 and 6cc530c8f323bce17cf6290a42ca1c2fd532591d

This also changes some sympy zeros to multivector zeros, which means that `(A | scalar) ^ (B | scalar)` is not a TypeError, as it was before:
```python
>>> s = g.mv(1, 'scalar')
>>> (ex | s) ^ (ey | s)
TypeError: unsupported operand type(s) for ^: 'Zero' and 'Zero'
```