### PR TITLE
Drop support for python 3.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,10 +33,6 @@ jobs:
     <<: *defaults
     docker:
       - image: circleci/python:3.5
-  "python-3.4":
-    <<: *defaults
-    docker:
-      - image: circleci/python:3.4
   "python-2.7":
     <<: *defaults
     docker:
@@ -48,5 +44,5 @@ workflows:
     jobs:
       - "python-3.7"
       - "python-3.6"
-      - "python-3.4"
+      - "python-3.5"
       - "python-2.7"

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Installing GAlgebra
 ### Prerequisites
 
 - Works on Linux, Windows, Mac OSX
-- [Python](https://www.python.org/) 2.7 or 3
+- [Python](https://www.python.org/) 2.7 or >=3.5
 - [SymPy](https://www.sympy.org)
 
 Note: 

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,8 @@ setup(name='galgebra',
       packages=find_packages(),
       package_dir={'galgebra':'galgebra'},
       install_requires = ['sympy'],
+      # 2.7 or >=3.5
+      python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
       long_description=LONG_DESCRIPTION,
       classifiers=[
             'Development Status :: 4 - Beta',
@@ -26,6 +28,8 @@ setup(name='galgebra',
             'Natural Language :: English',
             'Operating System :: OS Independent',
             'Programming Language :: Python :: 2.7',
-            'Programming Language :: Python :: 3',
+            'Programming Language :: Python :: 3.5',
+            'Programming Language :: Python :: 3.6',
+            'Programming Language :: Python :: 3.7',
             'Topic :: Scientific/Engineering :: Mathematics',
             'Topic :: Scientific/Engineering :: Physics'])


### PR DESCRIPTION
Python 3.4 was end of life back in march, and there's little value in continuing to support it.

Removing the CI run will save some PR time and electricity :)

Also modifies the setup.py to refuse to install on 3.4.

-----
[View rendered README.md](https://github.com/eric-wieser/galgebra/blob/drop-python-3.4/README.md)