### PR TITLE
Remove unused `flatten_one_level` function

### DIFF
--- a/galgebra/mv.py
+++ b/galgebra/mv.py
@@ -1946,10 +1946,6 @@ class Dop(object):
                   'debug': (False, 'True to print out debugging information'),
                   'fmt_dop': (1, '1 for normal dop partial derivative formating')}
 
-    @staticmethod
-    def flatten_one_level(lst):
-        return [inner for outer in lst for inner in outer]
-
     def __init__(self, *args, **kwargs):
 
         kwargs = metric.test_init_slots(Dop.init_slots, **kwargs)


### PR DESCRIPTION
This has nothing to do with differential operators, and isn't used or documented.

In the very unlikely event that anyone was using this, the builtin `itertools.chain.from_iterable` provides similar functionality.