### PR TITLE
Fix AttributeError in er_blade

### DIFF
--- a/galgebra/ga.py
+++ b/galgebra/ga.py
@@ -1663,9 +1663,9 @@ class Ga(metric.Metric):
                 return self.wedge(blade, er)
         else:
             if left:
-                return self._dot(er, blade, mode=mode)
+                return self.Mul(er, blade, mode=mode)
             else:
-                return self._dot(blade, er, mode=mode)
+                return self.Mul(blade, er, mode=mode)
 
     def blade_derivation(self, blade, ib):
         """


### PR DESCRIPTION
`_dot` was removed in gh-142, but when inlining, this call site was missed.

Coverage will be zero, but I'll handle adding that in #140 