### PR TITLE
Remove the broken and redundant Dop.basic

### DIFF
--- a/galgebra/mv.py
+++ b/galgebra/mv.py
@@ -2378,18 +2378,6 @@ class Dop(object):
             else:
                 return s
 
-    @staticmethod
-    def basic(ga):
-        r_basis = list(ga.r_basis)
-
-        if not ga.is_ortho:
-            r_basis = [x / ga.e_sq for x in r_basis]
-        if ga.norm:
-            r_basis = [x / e_norm for (x, e_norm) in zip(r_basis, ga.e_norm)]
-
-        ga.lgrad = Dop(r_basis, ga.pdx, ga=ga)
-        ga.rgrad = Dop(r_basis, ga.pdx, ga=ga, cmpflg=true)
-        return ga.lgrad, ga.rgrad
 
 ################################# Alan Macdonald's additions #########################
 


### PR DESCRIPTION
This:

* Raises NameError, because `true` should be spelt `True`
* If fixed, raises `AttributeError` for `ga.pdx`
* Is attempting to set `ga.lgrad` as a weird alias of `ga.grad`
* Is just a weird way to spell `ga.grads()`