### PR TITLE
Update release notes from some previous PRs

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -2,12 +2,23 @@
 Changelog
 =========
 
+- :bug:`151` ``Dop([], ga=ga)`` and ``Sdop([], ga=ga)`` now evaluate to multiplication by zero, not by one.
+  Multiplication by one can as always be spelt ``Dop([(S(1), ga.Pdop_identity)], ga=ga)``.
+- :bug:`177` :class:`~galgebra.mv.Dop` objects that evaluate to ``0`` no longer raise cryptic ``ValueError``\ s when operated on.
+- :support:`175` ``Dop.flatten_one_level`` has been removed, use ``itertools.chain.from_iterable`` for this functionality.
+- :feature:`172` :data:`galgebra.__version__` has been added, which contains the version string.
+- :feature:`164` (and :issue:`169`, :issue:`170`) Sympy 1.5 is officially supported and tested.
+- :support:`167` Python 3.4 is no longer supported.
+- :bug:`165` :func:`galgebra.metric.linear_expand` no longer accepts a mode argument, as this did not work properly.
+  For the old behavior of ``linear_expand(x, mode=True)``, use ``linear_expand_terms(x)`` instead.
+- :bug:`151` (also :issue:`150`) :class:`~galgebra.mv.Dop`, :class:`~galgebra.mv.Sdop`, and :class:`~galgebra.mv.Pdop` no longer have mutating methods.
+  This fixed issues where not only would the laplacian be sometimes calculated incorrectly, but its correctness would vary depending on whether it had been printed!
 - :bug:`134` :attr:`~galgebra.ga.Ga.dot_table_dict` now contains correct values (zero) for scalar keys
-- :bug:`90` :attr:`~galgebra.ga.Ga.blades`, :attr:`~galgebra.ga.Ga.bases`, and :attr:`~galgebra.ga.Ga.indices`
-  now reference the scalar ``S(0)`` as the single grade-0 object. Previously they listed no grade 0 objects.
-- :bug:`80` (also :issue:`57`, :issue:`58`, :issue:`97`) The :class:`galgebra.mv.Mv` constructor no longer silently accepts illegal arguments, and produces better error messages
+- :bug:`90` :attr:`~galgebra.ga.Ga.blades`, :attr:`~galgebra.ga.Ga.bases`, and :attr:`~galgebra.ga.Ga.indices` now reference the scalar ``S(0)`` as the single grade-0 object. Previously they listed no grade 0 objects.
+- :bug:`81` (also :issue:`180`) Passing coefficients as ``Mv(coefs, 'odd', ga=ga)`` is forbidden.
+- :bug:`80` (also :issue:`57`, :issue:`58`, :issue:`97`) The :class:`galgebra.mv.Mv` constructor no longer silently accepts illegal arguments, and produces better error messages.
 - :feature:`78` :meth:`~galgebra.ga.Ga.grads` now raises a better error when it fails, and is faster.
-- :support:`72` Other internal cleanup
+- :support:`72` Other internal cleanup.
 - :feature:`66` (also :issue:`67`, :issue:`71`) Remove unused code in the public API:
 
   * ``Ga.mul_table``, ``Ga.wedge_table``, ``Ga.dot_table``, ``Ga.left_contract_table``,


### PR DESCRIPTION
Continuing from #146, adding release notes for:

* #151
* #164
* #165
* #167
* #169
* #170
* #172
* #175
* #177
* #180

https://external-builds.readthedocs.io/html/galgebra/186/changelog.html