### PR TITLE
Deprecate Pdiffs, sPds, and Pdop_identity

### DIFF
--- a/galgebra/mv.py
+++ b/galgebra/mv.py
@@ -1617,11 +1617,11 @@ class Sdop(object):
             if isinstance(sdop1, Sdop):
                 if not isinstance(sdop2, Mv):
                     sdop2 = sdop1.Ga.mv(sdop2)
-                sdop2 = Sdop([(sdop2, sdop1.Ga.Pdop_identity)], ga=sdop1.Ga)
+                sdop2 = Sdop([(sdop2, Pdop({}, ga=sdop1.Ga))], ga=sdop1.Ga)
             elif isinstance(sdop2, Sdop):
                 if not isinstance(sdop1, Mv):
                     sdop1 = sdop2.Ga.mv(sdop1)
-                sdop1 = Sdop([(sdop1, sdop2.Ga.Pdop_identity)], ga=sdop2.Ga)
+                sdop1 = Sdop([(sdop1, Pdop({}, ga=sdop2.Ga))], ga=sdop2.Ga)
             else:
                 raise TypeError("Neither argument is a Dop instance")
             return Sdop.Add(sdop1, sdop2)
@@ -1677,10 +1677,12 @@ class Pdop(object):
     Attributes
     ----------
     pdiffs : dict
-        a dictionary where coordinates are keys and key value are the number of
+        A dictionary where coordinates are keys and key value are the number of
         times one differentiates with respect to the key.
     order : int
-        total number of differentiations
+        Total number of differentiations.
+        When this is zero (i.e. when :attr:`pdiffs` is ``{}``) then this object
+        is the identity operator, and returns its operand unchanged.
     """
 
     init_slots = {'ga': (None, 'Associated geometric algebra')}
@@ -1774,7 +1776,7 @@ class Pdop(object):
                 del new_pdiffs[x]
             else:
                 new_pdiffs[x] -= 1
-            return Pdop(new_pdiffs, ga=self.Ga), self.Ga.Pdiffs[x]
+            return Pdop(new_pdiffs, ga=self.Ga), Pdop(x, ga=self.Ga)
 
     def __call__(self, arg):
         """
@@ -2019,11 +2021,11 @@ class Dop(object):
             if isinstance(dop1, Dop):
                 if not isinstance(dop2, Mv):
                     dop2 = dop1.Ga.mv(dop2)
-                dop2 = Dop([(dop2, dop1.Ga.Pdop_identity)], cmpflg=dop1.cmpflg, ga=dop1.Ga)
+                dop2 = Dop([(dop2, Pdop({}, ga=dop1.Ga))], cmpflg=dop1.cmpflg, ga=dop1.Ga)
             elif isinstance(dop2, Dop):
                 if not isinstance(dop1, Mv):
                     dop1 = dop2.Ga.mv(dop1)
-                dop1 = Dop([(dop1, dop2.Ga.Pdop_identity)], cmpflg=dop2.cmpflg, ga=dop2.Ga)
+                dop1 = Dop([(dop1, Pdop({}, ga=dop2.Ga))], cmpflg=dop2.cmpflg, ga=dop2.Ga)
             else:
                 raise TypeError("Neither argument is a Dop instance")
             return Dop.Add(dop1, dop2)

--- a/test/test_differential_ops.py
+++ b/test/test_differential_ops.py
@@ -109,6 +109,13 @@ class TestDop(object):
 
 class TestSdop(object):
 
+    def test_deprecation(self):
+        coords = x, y, z = symbols('x y z', real=True)
+        ga, ex, ey, ez = Ga.build('e*x|y|z', g=[1, 1, 1], coords=coords)
+
+        with pytest.warns(DeprecationWarning):
+            ga.sPds
+
     def test_shorthand(self):
         coords = x, y, z = symbols('x y z', real=True)
         ga, ex, ey, ez = Ga.build('e*x|y|z', g=[1, 1, 1], coords=coords)
@@ -172,6 +179,11 @@ class TestPdop(object):
         with pytest.warns(DeprecationWarning):
             p = Pdop(None, ga=ga)
         assert p == Pdop({}, ga=ga)
+
+        with pytest.warns(DeprecationWarning):
+            ga.Pdop_identity
+        with pytest.warns(DeprecationWarning):
+            ga.Pdiffs
 
     def test_misc(self):
         """ Other miscellaneous tests """


### PR DESCRIPTION
These attributes all have shorter spellings, and now that `__eq__` and `__ne__` work, there's little need to cache them.