### PR TITLE
Deprecate compatibility members of Ga objects

### DIFF
--- a/galgebra/ga.py
+++ b/galgebra/ga.py
@@ -484,14 +484,22 @@ class Ga(metric.Metric):
     @property
     def mv_I(self):
         # This exists for backwards compatibility. Note this is not `I()`!
+        # galgebra 0.4.5
+        warnings.warn(
+            "`ga.mv_I` is deprecated, use `ga.E()` instead, or perhaps `ga.I()`",
+            DeprecationWarning, stacklevel=2)
         # default pseudoscalar
         return self.E()
 
     @property
     def mv_x(self):
         # This exists for backwards compatibility.
+        # galgebra 0.4.5
+        warnings.warn(
+            "`ga.mv_x` is deprecated, use `ga.mv(your_name, 'vector')` instead",
+            DeprecationWarning, stacklevel=2)
         # testing vectors
-        return Mv('XxXx', 'vector', ga=self)
+        return mv.Mv('XxXx', 'vector', ga=self)
 
     def X(self):
         return self.mv(sum([coord*base for (coord, base) in zip(self.coords, self.basis)]))

--- a/galgebra/ga.py
+++ b/galgebra/ga.py
@@ -447,7 +447,7 @@ class Ga(metric.Metric):
         self.a = []  # List of dummy vectors for Mlt calculations
         self._agrads = {}  # cache of gradient operator with respect to vector a
         self.dslot = -1  # args slot for dervative, -1 for coordinates
-        self.XOX = self.mv('XOX','vector')  # Versor test vector
+        self._XOX = self.mv('XOX','vector')  # cached vector for use in is_versor
 
     def make_grad(self, a, cmpflg=False):  # make gradient operator with respect to vector a
 

--- a/galgebra/mv.py
+++ b/galgebra/mv.py
@@ -981,7 +981,7 @@ class Mv(object):
         if not test.is_scalar():
             return self.versor_flg
         # see if self*x*self.rev() returns a vector for x an arbitrary vector
-        test = self * self.Ga.XOX * self.rev()
+        test = self * self.Ga._XOX * self.rev()
         self.versor_flg = test.is_vector()
         return self.versor_flg
 

--- a/test/test_mv.py
+++ b/test/test_mv.py
@@ -1,9 +1,18 @@
 import unittest
+
+import pytest
 from sympy import Symbol
 from galgebra.ga import Ga
 from galgebra import utils
 
 class TestMv(unittest.TestCase):
+
+    def test_deprecations(self):
+        ga, e_1, e_2, e_3 = Ga.build('e*1|2|3')
+        with pytest.warns(DeprecationWarning):
+            ga.mv_x
+        with pytest.warns(DeprecationWarning):
+            ga.mv_I
 
     def test_is_base(self):
         """


### PR DESCRIPTION
Every member we can remove from `Ga` makes galgebra easier to understand