### PR TITLE
Remove Dop.blade_rep

### DIFF
--- a/galgebra/mv.py
+++ b/galgebra/mv.py
@@ -1987,17 +1987,6 @@ class Dop(object):
         """
         return Dop(_consolidate_terms(self.terms), ga=self.Ga, cmpflg=self.cmpflg)
 
-
-    def blade_rep(self):
-        N = len(self.blades)
-        coefs = N * [[]]
-        bases = N * [0]
-        for term in self.terms:
-            for coef, base in metric.linear_expand_terms(self.terms[0].obj):
-                index = self.blades.index(base)
-                coefs[index] = coef
-                bases[index] = base
-
     @staticmethod
     def Add(dop1, dop2):
 


### PR DESCRIPTION
This function doesn't do anything, and causes LGTM warnings.
API surface that doesn't work is just confusing to users.

The intention of this function was probably something like:
```python
def blade_rep(self):
    return Dop(_consolidate_terms(
        (coef.blade_rep(), pdiff) for coef, pdiff in self.terms
    ), cmpflg=self.cmpflg, ga=self.Ga)
```

However, constructing a Dop with non-blade coefficients is unlikely in the first place, so if we add this function it is very unlikely that anyone would need it.

Closes gh-147