### PR TITLE
Fix linear transformation created with Mv matrix

### DIFF
--- a/galgebra/lt.py
+++ b/galgebra/lt.py
@@ -110,7 +110,7 @@ def Dictionary_to_Matrix(dict_rep, ga):
             element = dict_rep[e_row]
             if isinstance(element, mv.Mv):
                 element = element.obj
-            (coefs,bases) = metric.linear_expand(element)
+            coefs, bases = metric.linear_expand(element)
             for (coef,base) in zip(coefs,bases):
                 index = ga.basis.index(base)
                 lst_mat_row[index] = coef

--- a/galgebra/lt.py
+++ b/galgebra/lt.py
@@ -107,7 +107,10 @@ def Dictionary_to_Matrix(dict_rep, ga):
         lst_mat_row = n * [S(0)]
 
         if e_row in basis:  # If not in basis row all zeros
-            (coefs,bases) = metric.linear_expand(dict_rep[e_row])
+            element = dict_rep[e_row]
+            if isinstance(element, mv.Mv):
+                element = element.obj
+            (coefs,bases) = metric.linear_expand(element)
             for (coef,base) in zip(coefs,bases):
                 index = ga.basis.index(base)
                 lst_mat_row[index] = coef

--- a/galgebra/metric.py
+++ b/galgebra/metric.py
@@ -26,7 +26,7 @@ def apply_function_list(f,x):
 
 def linear_expand(expr):
     if not isinstance(expr, Expr):
-        raise TypeError(expr + 'is not a SymPy Expr')
+        raise TypeError('{!r} is not a SymPy Expr'.format(expr))
     
     expr = expand(expr)
 

--- a/galgebra/metric.py
+++ b/galgebra/metric.py
@@ -25,9 +25,11 @@ def apply_function_list(f,x):
 
 
 def linear_expand(expr):
+    if not isinstance(expr, Expr):
+        raise TypeError(expr + 'is not a SymPy Expr')
+    
+    expr = expand(expr)
 
-    if isinstance(expr, Expr):
-        expr = expand(expr)
     if expr == 0:
         coefs = [expr]
         bases = [S(1)]

--- a/test/test_lt.py
+++ b/test/test_lt.py
@@ -1,0 +1,16 @@
+import unittest
+
+import pytest
+from sympy import Symbol, symbols
+from galgebra.ga import Ga
+from galgebra import utils
+
+class TestLt(unittest.TestCase):
+
+    # reproduce gh-105
+    def test_lt_matrix(self):
+        base = Ga('a b', g=[1,1], coords=symbols('x,y',real=True))
+        a,b = base.mv()
+        A = base.lt([a+b,a-b])
+        assert str(A) == 'Lt(a) = a + b\nLt(b) = a - b'
+        assert str(A.matrix()) == 'Matrix([[1, 1], [1, -1]])'

--- a/test/test_lt.py
+++ b/test/test_lt.py
@@ -1,9 +1,7 @@
 import unittest
 
-import pytest
-from sympy import Symbol, symbols
+from sympy import symbols
 from galgebra.ga import Ga
-from galgebra import utils
 
 class TestLt(unittest.TestCase):
 
@@ -11,6 +9,6 @@ class TestLt(unittest.TestCase):
     def test_lt_matrix(self):
         base = Ga('a b', g=[1,1], coords=symbols('x,y',real=True))
         a,b = base.mv()
-        A = base.lt([a+b,a-b])
-        assert str(A) == 'Lt(a) = a + b\nLt(b) = a - b'
-        assert str(A.matrix()) == 'Matrix([[1, 1], [1, -1]])'
+        A = base.lt([a+b,2*a-b])
+        assert str(A) == 'Lt(a) = a + b\nLt(b) = 2*a - b'
+        assert str(A.matrix()) == 'Matrix([[1, 2], [1, -1]])'


### PR DESCRIPTION
Fixes #105 .

- Added tests for reproducing #105
- `linear_expand` no longer accepts `Mv` as `expr`
- `Dictionary_to_Matrix` automatically converts `Mv` to `Expr`, taking care of #105 and the test case in `examples/Terminal/lt_test.py`
