### PR TITLE
Remove the now-unused `test_init_slots`

### DIFF
--- a/galgebra/metric.py
+++ b/galgebra/metric.py
@@ -158,34 +158,6 @@ def symbols_list(s, indices=None, sub=True, commutative=False):
     return [Symbol(printer.Eprint.Base(s), commutative=commutative) for s in s_lst]
 
 
-def test_init_slots(init_slots, **kwargs):
-    """
-    Tests kwargs for allowed keyword arguments as defined by dictionary
-    init_slots.  If keyword argument defined by init_slots is not present
-    set default value asdefined by init_slots.  Allow for backward
-    compatible keyword arguments by equivalencing keywords by setting
-    default value of backward compatible keyword to new keyword and then
-    referencing new keywork (see init_slots for Metric class and equivalence
-    between keywords 'g' and 'metric')
-    """
-
-    for slot in kwargs:
-        if slot not in init_slots:
-            print('Allowed keyed input arguments')
-            for key in init_slots:
-                print(key + ': ' + init_slots[key][1])
-            raise ValueError('"' + slot + ' = " not in allowed values.')
-    for slot in init_slots:
-        if slot in kwargs:
-            if init_slots[slot][0] in init_slots:  # redirect for backward compatibility
-                kwargs[init_slots[slot][0]] = kwargs[slot]
-        else:  # use default value
-            if init_slots[slot][0] in init_slots:  # redirect for backward compatibility
-                kwargs[init_slots[slot][0]] = init_slots[init_slots[slot][0]][0]
-            kwargs[slot] = init_slots[slot][0]
-    return kwargs
-
-
 class Simp:
     modes = [simplify]
 

--- a/galgebra/mv.py
+++ b/galgebra/mv.py
@@ -1448,8 +1448,6 @@ class Sdop(object):
         the structure :math:`((c_{1},D_{1}),(c_{2},D_{2}), ...)`
     """
 
-    init_slots = {'ga': (None, 'Associated geometric algebra')}
-
     str_mode = False
 
     def TSimplify(self):
@@ -1657,8 +1655,6 @@ class Pdop(object):
         When this is zero (i.e. when :attr:`pdiffs` is ``{}``) then this object
         is the identity operator, and returns its operand unchanged.
     """
-
-    init_slots = {'ga': (None, 'Associated geometric algebra')}
 
     def sort_key(self, order=None):
         return (


### PR DESCRIPTION
In principle this is a breaking change, but I doubt anyone is using this function anyway.

We no longer use it internally.

Will need a changelog entry listing this as a removed function.