### PR TITLE
Remove trailing empty return statements

### DIFF
--- a/galgebra/deprecated.py
+++ b/galgebra/deprecated.py
@@ -45,7 +45,7 @@ class MV(Mv):
 
     def Fmt(self, fmt=1, title=None):
         print(Mv.Fmt(self, fmt=fmt, title=title))
-        return
+
 
 def ReciprocalFrame(basis, mode='norm'):
 

--- a/galgebra/ga.py
+++ b/galgebra/ga.py
@@ -332,7 +332,6 @@ class Ga(metric.Metric):
             raise ValueError('mode = ' + mode + ' not allowed for Ga.dual_mode.')
 
         Ga.dual_mode_value = mode
-        return
 
     @staticmethod
     def com(A, B):
@@ -672,7 +671,6 @@ class Ga(metric.Metric):
 
         for (coord, par_coord) in zip(self.coords, coords):
             self.par_coords[coord] = par_coord
-        return
 
     def basis_vectors(self):
         return tuple(self.basis)
@@ -893,7 +891,6 @@ class Ga(metric.Metric):
 
         if self.debug:
             print('Exit _build_basis_product_tables.\n')
-        return
 
     def _build_connection(self):
         # Partial derivatives of multivector bases multiplied (*,^,|,<,>)
@@ -904,8 +901,6 @@ class Ga(metric.Metric):
                         ('>', False): []}
         # Partial derivatives of multivector bases
         self._dbases = {}
-
-        return
 
     ######## Functions for Calculation products of blades/bases ########
 
@@ -1183,7 +1178,6 @@ class Ga(metric.Metric):
 
         if self.debug:
             print('basic_mul_table =\n', self.basic_mul_table)
-        return
 
     def non_orthogonal_bases_products(self, base12):  # base12 = (base1,base2)
         # geometric product of bases for non-orthogonal basis vectors
@@ -1253,8 +1247,6 @@ class Ga(metric.Metric):
 
         if self.debug:
             print('base_expansion_dict =', self.base_expansion_dict)
-
-        return
 
     def base_to_blade_rep(self, A):
 
@@ -1656,7 +1648,6 @@ class Ga(metric.Metric):
                       ('<', True): [], ('>', True): [], ('*', False): [],
                       ('^', False): [], ('|', False): [], ('<', False): [],
                       ('>', False): []}
-        return
 
     def er_blade(self, er, blade, mode='*', left=True):
         r"""

--- a/galgebra/lt.py
+++ b/galgebra/lt.py
@@ -159,7 +159,6 @@ class Lt(object):
     @staticmethod
     def format(mat_fmt=False):
         Lt.mat_fmt = mat_fmt
-        return
 
     def __init__(self, *args, ga, f=False, mode='g'):
         """
@@ -566,7 +565,6 @@ class Mlt(object):
                 coefs = a.get_coefs(1)
                 Ga.pdiffs.append(coefs)
                 Ga.acoefs += coefs
-        return
 
     @staticmethod
     def extact_basis_indexes(Ga):
@@ -665,7 +663,6 @@ class Mlt(object):
                 print(title + ' = ' + latex_str)
             else:
                 print(latex_str)
-        return
 
     @staticmethod
     def expand_expr(expr,ga):

--- a/galgebra/metric.py
+++ b/galgebra/metric.py
@@ -192,7 +192,6 @@ class Simp:
     @staticmethod
     def profile(s):
         Simp.modes = s
-        return
 
     @staticmethod
     def apply(expr):
@@ -418,7 +417,6 @@ class Metric(object):
         if self.debug:
             printer.oprint('D_{i}e^{j}', de)
         self.de = de
-        return
 
     def inverse_metric(self):
 
@@ -436,7 +434,6 @@ class Metric(object):
                 self.detg = Function('|' +self.gsym +'|',real=True)(*self.coords)
                 self.g_adj = simplify(self.g.adjugate())
                 self.g_inv = self.g_adj/self.detg
-        return
 
     def Christoffel_symbols(self,mode=1):
         """
@@ -526,8 +523,6 @@ class Metric(object):
         if self.debug:
             printer.oprint('e^{i}->e^{i}/|e_{i}|', renorm)
             printer.oprint('renorm(g)', self.g)
-
-        return
 
     def signature(self):
         if self.is_ortho:

--- a/galgebra/mv.py
+++ b/galgebra/mv.py
@@ -78,7 +78,6 @@ class Mv(object):
     def Format(mode=1):
         Mv.latex_flg = True
         Mv.fmt = mode
-        return
 
     @staticmethod
     def Mul(A, B, op):
@@ -157,7 +156,6 @@ class Mv(object):
             self.i_grade = None
         self.grades = grades
         self.char_Mv = True
-        return
 
     # helper methods called by __init__. Note that these names must not change,
     # as the part of the name after `_make_` is public API via the string
@@ -1162,7 +1160,6 @@ class Mv(object):
             self.obj += (value - coefs[bases_lst.index(base)]) * base
         else:
             self.obj += value * base
-        return
 
     def Fmt(self, fmt=1, title=None):
         """

--- a/galgebra/printer.py
+++ b/galgebra/printer.py
@@ -626,7 +626,6 @@ class GaLatexPrinter(LatexPrinter):
         else:
             GaLatexPrinter.stdout = sys.stdout
             sys.stdout = io.StringIO()
-        return
 
     @staticmethod
     def restore():
@@ -638,7 +637,6 @@ class GaLatexPrinter(LatexPrinter):
                 sys.stdout = GaLatexPrinter.stdout
             Basic.__str__ = GaLatexPrinter.Basic__str__
             Matrix.__str__ = GaLatexPrinter.Matrix__str__
-        return
 
     def _print_Pow(self, expr):
         base = self._print(expr.base)

--- a/test/test_test.py
+++ b/test/test_test.py
@@ -86,8 +86,6 @@ class TestTest(unittest.TestCase):
         assert str((A<X)) == 'A*X__x*e_x + A*X__y*e_y'
         assert str((A>X)) == 'A__xy*X__y*e_x - A__xy*X__x*e_y'
 
-        return
-
     def test_check_generalized_BAC_CAB_formulas(self):
 
         (a,b,c,d,e) = Ga('a b c d e').mv()
@@ -105,8 +103,6 @@ class TestTest(unittest.TestCase):
         assert str(((a^b)|c)|d) == '-(a.c)*(b.d) + (a.d)*(b.c)'
         assert str(Ga.com(a^b,c^d)) == '-(b.d)*a^c + (b.c)*a^d + (a.d)*b^c - (a.c)*b^d'
         assert str((a|(b^c))|(d^e)) == '(-(a.b)*(c.e) + (a.c)*(b.e))*d + ((a.b)*(c.d) - (a.c)*(b.d))*e'
-
-        return
 
     def test_derivatives_in_rectangular_coordinates(self):
 
@@ -141,8 +137,6 @@ class TestTest(unittest.TestCase):
         assert str(grad<C) == 'D{x}C__x + D{y}C__y + D{z}C__z + (-D{y}C__xy - D{z}C__xz)*e_x + (D{x}C__xy - D{z}C__yz)*e_y + (D{x}C__xz + D{y}C__yz)*e_z + D{z}C__xyz*e_x^e_y - D{y}C__xyz*e_x^e_z + D{x}C__xyz*e_y^e_z'
         assert str(grad>C) == 'D{x}C__x + D{y}C__y + D{z}C__z + D{x}C*e_x + D{y}C*e_y + D{z}C*e_z'
 
-        return
-
     def test_derivatives_in_spherical_coordinates(self):
 
         X = (r, th, phi) = symbols('r theta phi')
@@ -167,8 +161,6 @@ class TestTest(unittest.TestCase):
 
         assert str(grad^B) == '(r*D{r}B__thetaphi - B__rphi/tan(theta) + 2*B__thetaphi - D{theta}B__rphi + D{phi}B__rtheta/sin(theta))*e_r^e_theta^e_phi/r'
 
-        return
-
     def test_rounding_numerical_components(self):
 
         o3d = Ga('e_x e_y e_z', g=[1, 1, 1])
@@ -181,8 +173,6 @@ class TestTest(unittest.TestCase):
         assert str(Nga(X,2)) == '1.2*e_x + 2.3*e_y + 0.55*e_z'
         assert str(X*Y) == '12.7011000000000 + 4.02078*e_x^e_y + 6.175185*e_x^e_z + 10.182*e_y^e_z'
         assert str(Nga(X*Y,2)) == '13. + 4.0*e_x^e_y + 6.2*e_x^e_z + 10.0*e_y^e_z'
-
-        return
 
     def test_noneuclidian_distance_calculation(self):
         from sympy import solve,sqrt
@@ -283,8 +273,6 @@ class TestTest(unittest.TestCase):
         C =  solve(a*x**2+b*x+c,x)[0]
         assert str(expand(simplify(expand(C)))) == '-(X.Y)/((X.e)*(Y.e)) + 1'
 
-        return
-
     def test_conformal_representations_of_circles_lines_spheres_and_planes(self):
         global n,nbar
 
@@ -319,8 +307,6 @@ class TestTest(unittest.TestCase):
 
         assert str(L) == '-x3*e_1^e_2^e_3^n - x3*e_1^e_2^e_3^nbar + (-x1**2/2 + x1 - x2**2/2 + x2 - x3**2/2 - 1/2)*e_1^e_2^n^nbar + x3*e_1^e_3^n^nbar - x3*e_2^e_3^n^nbar'
 
-        return
-
     def test_properties_of_geometric_objects(self):
 
         global n, nbar
@@ -347,8 +333,6 @@ class TestTest(unittest.TestCase):
         delta = ((C^n)|n)|nbar
         assert str(delta) == '2*p1^p2 - 2*p1^p3 + 2*p2^p3'
         assert str((p2-p1)^(p3-p1)) == 'p1^p2 - p1^p3 + p2^p3'
-
-        return
 
     def test_extracting_vectors_from_conformal_2_blade(self):
 
@@ -377,8 +361,6 @@ class TestTest(unittest.TestCase):
 
         aB = a|B
         assert str(aB) == '-(P2.a)*P1 + (P1.a)*P2'
-
-        return
 
     def test_reciprocal_frame_test(self):
 
@@ -440,5 +422,3 @@ class TestTest(unittest.TestCase):
         w = (E3|e3)
         w = (w.expand()).scalar()
         assert str(simplify(w/Esq)) == '1'
-
-        return


### PR DESCRIPTION
A return statement on the last line of a function, with no value to return, is a no-op.

There's already a very clear indicator that the end of the function has been reached anyway - the indentation level.

Found by looking for `^ {8}return$`, and manually vetting each one for readability.
A few in nested functions remain.