### PR TITLE
Fix crash in Pdop.repr with multiple variables

### DIFF
--- a/galgebra/dop.py
+++ b/galgebra/dop.py
@@ -411,7 +411,7 @@ class Pdop(object):
             s += '^{' + printer.latex(self.order) + '}'
         s += '}{'
         keys = list(self.pdiffs.keys())
-        keys.sort()
+        keys.sort(key=lambda x: x.sort_key())
         for key in keys:
             i = self.pdiffs[key]
             s += r'\partial ' + printer.latex(key)


### PR DESCRIPTION
Sympy symbols are not sortable by default, they have to be sorted using the `sort_key` member.