### PR TITLE
Revert "Pin the version of coverage for nbval compatibility"

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -7,6 +7,3 @@ pytest-xdist
 
 # needed by pytest-xdist
 pytest >= 4.4.0
-
-# pinned until https://github.com/computationalmodelling/nbval/issues/129 is fixed
-coverage < 5


### PR DESCRIPTION
This reverts commit f307c2554b4f070daa3201efbc89bf4f6e8e070c (gh-152)

The upstream issue, https://github.com/computationalmodelling/nbval/issues/129, has been resolved.