### PR TITLE
Mask Pipe symbol in Operator Table

### DIFF
--- a/doc/galgebra.md
+++ b/doc/galgebra.md
@@ -851,7 +851,7 @@ where the $F$’s are *sympy* symbolic constants or functions of the coordinates
 |$A-B$|difference of multivectors|
 |$A*B$|geometric product of multivectors|
 |$A{\wedge}B$|outer product of multivectors|
-|$A|B$|inner product of multivectors|
+|$A\|B$|inner product of multivectors|
 |$A<B$|left contraction of multivectors|
 |$A>B$|right contraction of multivectors|
 |$A/B$|division of multivectors|


### PR DESCRIPTION
By masking the Pipe Symbol, the table of operators gets rendered as exspected.

-----
[View rendered doc/galgebra.md](https://github.com/EAR-Development/galgebra/blob/patch-1/doc/galgebra.md)