### PR TITLE
Add CI for python 3.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,7 @@ defaults: &defaults
         path: test-reports
 
 jobs:
+  # symengine does not seem to install correctly with Python 3.8 yet
   "python-3.7-symengine":
     <<: *defaults
     environment:
@@ -38,18 +39,19 @@ jobs:
       USE_SYMENGINE: 1
     docker:
       - image: circleci/python:3.7
+  # sympy 1.3 does not claim to support Python 3.8
   "python-3.7-sympy-1.3":
     <<: *defaults
     environment:
       PIP_EXTRA_INSTALLATION: sympy==1.3
     docker:
       - image: circleci/python:3.7
-  "python-3.7-sympy-1.4":
+
+  # make sure to keep setup.py in sync with these
+  "python-3.8":
     <<: *defaults
-    environment:
-      PIP_EXTRA_INSTALLATION: sympy==1.3
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.8
   "python-3.7":
     <<: *defaults
     docker:
@@ -62,6 +64,7 @@ jobs:
     <<: *defaults
     docker:
       - image: circleci/python:3.5
+
   "publish":
     docker:
       - image: circleci/python:3.7
@@ -76,18 +79,18 @@ workflows:
   version: 2
   build:
     jobs:
-      - "python-3.7-symengine"
-      - "python-3.7-sympy-1.3"
-      - "python-3.7-sympy-1.4"
-      - python-3.7:
+      - "python-3.8":
           filters:
             tags:
               only: /^v.*$/
+      - "python-3.7"
       - "python-3.6"
       - "python-3.5"
+      - "python-3.7-symengine"
+      - "python-3.7-sympy-1.3"
       - publish:
           requires:
-            - "python-3.7"
+            - "python-3.8"
           filters:
             branches:
               ignore: /.*/

--- a/galgebra/deprecated.py
+++ b/galgebra/deprecated.py
@@ -7,7 +7,7 @@ class MV(Mv):
 
     @staticmethod
     def convert_metric(gstr):
-        if gstr[0] is '[' and gstr[-1] is ']':
+        if gstr[0] == '[' and gstr[-1] == ']':
             gstr_lst = gstr[1:-1].split(',')
             g = []
             for x in gstr_lst:

--- a/galgebra/lt.py
+++ b/galgebra/lt.py
@@ -602,7 +602,7 @@ class Mlt(object):
             if first:
                 first = False
             else:
-                if coef_str[0].strip() is not '-' or term_add_flg:
+                if coef_str[0].strip() != '-' or term_add_flg:
                     coef_latex = ' + ' + coef_latex
             for aij in term[1]:
                 coef_latex += printer.latex(aij) + ' '

--- a/setup.py
+++ b/setup.py
@@ -32,5 +32,6 @@ setup(name='galgebra',
             'Programming Language :: Python :: 3.5',
             'Programming Language :: Python :: 3.6',
             'Programming Language :: Python :: 3.7',
+            'Programming Language :: Python :: 3.8',
             'Topic :: Scientific/Engineering :: Mathematics',
             'Topic :: Scientific/Engineering :: Physics'])


### PR DESCRIPTION
Removes the stale `python-3.7-sympy-1.4` job which was identical to `python-3.7-sympy-1.3`.