### PR TITLE
Run flake8 against the source, with a very generous ignore list

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,20 @@ defaults: &defaults
         path: test-reports
 
 jobs:
+  "flake8":
+    steps:
+      - checkout
+      - run:
+          name: Install
+          command: |
+            sudo pip install flake8
+      - run:
+          name: Lint
+          command: |
+            flake8
+    docker:
+      - image: circleci/python:3.8
+
   # symengine does not seem to install correctly with Python 3.8 yet
   "python-3.7-symengine":
     <<: *defaults
@@ -79,15 +93,27 @@ workflows:
   version: 2
   build:
     jobs:
+      - "flake8":
+          filters:
+            tags:
+              only: /^v.*$/
+
       - "python-3.8":
           filters:
             tags:
               only: /^v.*$/
-      - "python-3.7"
-      - "python-3.6"
-      - "python-3.5"
-      - "python-3.7-symengine"
-      - "python-3.7-sympy-1.3"
+          requires: ["flake8"]
+      - "python-3.7":
+          requires: ["flake8"]
+      - "python-3.6":
+          requires: ["flake8"]
+      - "python-3.5":
+          requires: ["flake8"]
+      - "python-3.7-symengine":
+          requires: ["flake8"]
+      - "python-3.7-sympy-1.3":
+          requires: ["flake8"]
+
       - publish:
           requires:
             - "python-3.8"

--- a/galgebra/__init__.py
+++ b/galgebra/__init__.py
@@ -21,4 +21,4 @@ Submodules
     utils
 """
 
-from ._version import __version__
+from ._version import __version__  # noqa: F401

--- a/galgebra/utils.py
+++ b/galgebra/utils.py
@@ -5,12 +5,13 @@ Utility Classes
 import sys
 import collections
 
+from io import StringIO  # noqa: F401
+
 # From https://github.com/benjaminp/six/blob/master/six.py
 PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3
 
 string_types = str
-from io import StringIO
 
 # https://stackoverflow.com/questions/16176742/python-3-replacement-for-deprecated-compiler-ast-flatten-function
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,116 @@
 [test]
 test_suite = test
+
+[flake8]
+
+# for now, just check the main code
+filename =
+    setup.py
+    galgebra/*.py
+
+ignore =
+    # flake8 defaults
+    E121
+    E123
+    E126
+    E226
+    E24
+    E704
+    W503
+    W504
+
+    # long lines
+    E501
+
+    # allow the use of `I` and `i` as variable names
+    E741
+    E743
+
+per-file-ignores =
+    # E231 missing whitespace after ','
+    # E266 too many leading '#' for block comment
+    # E302 expected 2 blank lines, found 1
+    # E303 too many blank lines (2)
+    galgebra\deprecated.py:E231,E266,E302,E303
+
+    # E203 whitespace before ':'
+    # E231 missing whitespace after ','
+    # E265 block comment should start with '# '
+    # E266 too many leading '#' for block comment
+    galgebra\dop.py:E203,E231,E265,E266
+
+    # E225 missing whitespace around operator
+    # E231 missing whitespace after ','
+    # E231 missing whitespace after ':'
+    # E261 at least two spaces before inline comment
+    # E262 inline comment should start with '# '
+    # E265 block comment should start with '# '
+    # E266 too many leading '#' for block comment
+    # E302 expected 2 blank lines, found 1
+    # E303 too many blank lines (2)
+    # E743 ambiguous function definition 'I'
+    # W293 blank line contains whitespace
+    galgebra\ga.py:E225,E231,E231,E261,E262,E265,E266,E302,E303,W293
+
+    # E228 missing whitespace around modulo operator
+    # E231 missing whitespace after ','
+    # E261 at least two spaces before inline comment
+    # E262 inline comment should start with '# '
+    # E265 block comment should start with '# '
+    # E271 multiple spaces after keyword
+    # E302 expected 2 blank lines, found 1
+    # E701 multiple statements on one line (colon)
+    # F401 'sys' imported but unused
+    galgebra\lt.py:E228,E231,E261,E262,E265,E271,E302,E701,F401
+
+    # E124 closing bracket does not match visual indentation
+    # E125 continuation line with same indent as next logical line
+    # E128 continuation line under-indented for visual indent
+    # E225 missing whitespace around operator
+    # E228 missing whitespace around modulo operator
+    # E231 missing whitespace after ','
+    # E302 expected 2 blank lines, found 1
+    # E303 too many blank lines (2)
+    # F821 undefined name 'Mv'
+    # F841 local variable 'dg' is assigned to but never used
+    # W293 blank line contains whitespace
+    galgebra\metric.py:E124,E125,E128,E225,E228,E231,E302,E303,F821,F841,W293
+
+    # E128 continuation line under-indented for visual indent
+    # E231 missing whitespace after ','
+    # E261 at least two spaces before inline comment
+    # E262 inline comment should start with '# '
+    # E265 block comment should start with '# '
+    # E266 too many leading '#' for block comment
+    # E271 multiple spaces after keyword
+    # E302 expected 2 blank lines, found 1
+    # E303 too many blank lines (2)
+    # E713 test for membership should be 'not in'
+    # F811 redefinition of unused 'expand' from line 10
+    # F841 local variable 'obj' is assigned to but never used
+    galgebra\mv.py:E128,E231,E261,E262,E265,E266,E271,E302,E303,E713,F811,F841
+
+    # E117 over-indented
+    # E122 continuation line missing indentation or outdented
+    # E127 continuation line over-indented for visual indent
+    # E128 continuation line under-indented for visual indent
+    # E225 missing whitespace around operator
+    # E231 missing whitespace after ','
+    # E251 unexpected spaces around keyword / parameter equals
+    # E261 at least two spaces before inline comment
+    # E262 inline comment should start with '# '
+    # E265 block comment should start with '# '
+    # E302 expected 2 blank lines, found 1
+    # E305 expected 2 blank lines after class or function definition, found 1
+    # E402 module level import not at top of file
+    # E502 the backslash is redundant between brackets
+    # F401 'IPython.display.Latex' imported but unused
+    # F401 'IPython.display.Math' imported but unused
+    # F401 'IPython.display.display' imported but unused
+    # F401 'IPython.display.display_latex' imported but unused
+    # F401 'inspect.currentframe' imported but unused
+    # F401 'inspect.getouterframes' imported but unused
+    # F401 'sympy.core.function._coeff_isneg' imported but unused
+    # F401 'sympy.interactive.printing' imported but unused
+    # F841 local variable '_inv_trig_style' is assigned to but never used
+    galgebra\printer.py: E117,E122,E127,E128,E225,E231,E251,E261,E262,E265,E302,E305,E402,E502,F401,F401,F401,F401,F401,F401,F401,F401,F841

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 from setuptools import setup, find_packages
-from distutils.core import Extension
 import os
 
 version_path = os.path.join('galgebra', '_version.py')
@@ -11,15 +10,15 @@ Symbolic Geometric Algebra/Calculus package for SymPy. BSD License.
 """
 
 setup(name='galgebra',
-      version=__version__,
+      version=__version__,  # noqa: F821
       description='Symbolic Geometric Algebra/Calculus package for SymPy.',
       author='Alan Bromborsky',
       author_email='hadfield.hugo@gmail.com',
       url='https://github.com/pygae/galgebra',
       license='BSD',
       packages=find_packages(),
-      package_dir={'galgebra':'galgebra'},
-      install_requires = ['sympy'],
+      package_dir={'galgebra': 'galgebra'},
+      install_requires=['sympy'],
       python_requires='>=3.5.*',
       long_description=LONG_DESCRIPTION,
       classifiers=[


### PR DESCRIPTION
In order to keep this diff small, this ignores every warning we currently have, rather than fixing them.
This is enough to prevent the style drifting further from flake8 unnoticed.

Future patches can aim to cut down the warnings at a file-by-file basis.

CI is set up so that if linting fails, no tests are run [see here](https://circleci.com/workflow-run/ebb57ca9-eb79-4b3a-ab7d-067ef378ebc0)

![image](https://user-images.githubusercontent.com/425260/79877879-b030ed00-83e4-11ea-8797-d86c97cd6af7.png)
