### PR TITLE
Add support for passing other forms of argument to `Mv.subs`

### DIFF
--- a/galgebra/mv.py
+++ b/galgebra/mv.py
@@ -1306,10 +1306,10 @@ class Mv(object):
             obj += coef * base
         return Mv(obj, ga=self.Ga)
 
-    def subs(self, d):
-        # For each scalar coef of the multivector apply substitution argument d
+    def subs(self, *args, **kwargs):
+        """ Perform a substitution on each coefficient separately """
         obj = sum((
-            coef.subs(d) * base for coef, base in metric.linear_expand_terms(self.obj)
+            coef.subs(*args, **kwargs) * base for coef, base in metric.linear_expand_terms(self.obj)
         ), S(0))
         return Mv(obj, ga=self.Ga)
 

--- a/test/test_mv.py
+++ b/test/test_mv.py
@@ -138,3 +138,14 @@ class TestMv(unittest.TestCase):
         assert d[e_1 + 0] == 1
         d[10] = 3  # note: not a multivector key!
         assert d[e_1 * 0 + 10] == 3
+
+    def test_subs(self):
+        ga, e_1, e_2, e_3 = Ga.build('e*1|2|3', g=[1, 1, 1])
+        B = ga.mv('B', 'bivector')
+        B_inv = B.inv()
+
+        B_mag = Symbol('|B|')
+
+        # both of the sympy subs syntaxes work:
+        assert (-B / B_mag**2).subs(B_mag, abs(B)) == B_inv
+        assert (-B / B_mag**2).subs({B_mag: abs(B)}) == B_inv


### PR DESCRIPTION
This means that all of the calling conventions of `sympy.Basic.subs` are supported

I think this covers one of the changes from #62.