### PR TITLE
Deprecate a bunch of similar members of `Ga`

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -2,8 +2,14 @@
 Changelog
 =========
 
-- :support:`64` :attr:`galgebra.ga.Ga.indexes_lst`, :attr:`galgebra.ga.Ga.bases_lst`, :attr:`galgebra.ga.Ga.blades_lst`, and :attr:`galgebra.ga.Ga.mv_blades_lst` are deprecated in favor of the new :attr:`~galgebra.ga.GradedTuple.flat` attribute of :attr:`galgebra.ga.Ga.indexes`, :attr:`galgebra.ga.Ga.bases`, :attr:`galgebra.ga.Ga.blades`, and :attr:`galgebra.ga.Ga.mv_blades`.
-  Since the new properties also include the scalar element, so ``ga.blades_lst`` is equivalent to ``ga.blades.flat[1:]`` (and likewise for the other two properties).
+- :support:`64` The following attributes have been deprecated in favor of using the new :attr:`~galgebra.ga.GradedTuple.flat` attribute:
+
+  * :attr:`galgebra.ga.Ga.indexes_lst` |rarr| :attr:`galgebra.ga.Ga.indexes` ``.flat``
+  * :attr:`galgebra.ga.Ga.bases_lst` |rarr| :attr:`galgebra.ga.Ga.bases` ``.flat``
+  * :attr:`galgebra.ga.Ga.blades_lst` |rarr| :attr:`galgebra.ga.Ga.blades` ``.flat``
+  * :attr:`galgebra.ga.Ga.mv_blades_lst` |rarr| :attr:`galgebra.ga.Ga.mv_blades` ``.flat``
+
+  Since the replacement properties also include the scalar element, ``ga.blades_lst`` is equivalent to ``ga.blades.flat[1:]`` (and likewise for the other properties).
 
 - :release:`0.4.5 <2019.12.31>`
 - :support:`83` This is the last release to support Python 2.7.
@@ -144,3 +150,5 @@ Changelog
 - :support:`2` Clean up obsolete code in setup.py and make it simple
 - :bug:`2` Fixes `brombo/galgebra#19 <https://github.com/brombo/galgebra/issues/19>`_: Failures in `test_noneuclidian_distance_calculation`
 - :bug:`2` Fixes `brombo/galgebra#20 <https://github.com/brombo/galgebra/issues/20>`_: Incorrect LaTeX output in `test_derivatives_in_spherical_coordinates`
+
+.. include:: <isonum.txt>

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -2,6 +2,20 @@
 Changelog
 =========
 
+- :support:`245` The following attributes have been deprecated to reduce the number of similar members in :class:`~galgebra.ga.Ga`.
+
+  * Unified into :attr:`galgebra.ga.Ga.indexes_to_bases_dict`:
+
+    * :attr:`galgebra.ga.Ga.indexes_to_bases` |rarr| ``indexes_to_bases_dict.items()``
+    * :attr:`galgebra.ga.Ga.bases_to_indexes` |rarr| ``indexes_to_bases_dict.inverse.items()``
+    * :attr:`galgebra.ga.Ga.bases_to_indexes_dict` |rarr| ``indexes_to_bases_dict.inverse``
+
+  * Unified into :attr:`galgebra.ga.Ga.indexes_to_bases_dict`:
+
+    * :attr:`galgebra.ga.Ga.indexes_to_blades` |rarr| ``indexes_to_blades_dict.items()``
+    * :attr:`galgebra.ga.Ga.blades_to_indexes` |rarr| ``indexes_to_blades_dict.inverse.items()``
+    * :attr:`galgebra.ga.Ga.blades_to_indexes_dict` |rarr| ``indexes_to_blades_dict.inverse``
+
 - :support:`64` The following attributes have been deprecated in favor of using the new :attr:`~galgebra.ga.GradedTuple.flat` attribute:
 
   * :attr:`galgebra.ga.Ga.indexes_lst` |rarr| :attr:`galgebra.ga.Ga.indexes` ``.flat``

--- a/galgebra/lt.py
+++ b/galgebra/lt.py
@@ -277,7 +277,7 @@ class Lt(object):
             self.mv_dict = copy(self.lt_dict)
             for key in self.Ga.blades[2:]:
                 for blade in key:
-                    index = self.Ga.blades_to_indexes_dict[blade]
+                    index = self.Ga.indexes_to_blades_dict.inverse[blade]
                     lt_blade = self(self.Ga.basis[index[0]], obj=True)
                     for i in index[1:]:
                         lt_blade = self.Ga.wedge(lt_blade, self(self.Ga.basis[i], obj=True))

--- a/test/test_test.py
+++ b/test/test_test.py
@@ -435,3 +435,22 @@ class TestTest(unittest.TestCase):
             assert ga.bases_lst[0] == e_1.obj
         with pytest.warns(DeprecationWarning):
             assert ga.indexes_lst[1] == (1,)
+
+        # deprecated to reduce the number of similar members
+        with pytest.warns(DeprecationWarning):
+            ga.blades_to_indexes
+        with pytest.warns(DeprecationWarning):
+            ga.bases_to_indexes
+        with pytest.warns(DeprecationWarning):
+            ga.blades_to_indexes_dict
+        with pytest.warns(DeprecationWarning):
+            ga.bases_to_indexes_dict
+        with pytest.warns(DeprecationWarning):
+            ga.indexes_to_blades
+        with pytest.warns(DeprecationWarning):
+            ga.indexes_to_bases
+
+        # all the above are deprecated in favor of these two, which are _not_
+        # deprecated
+        ga.indexes_to_blades_dict
+        ga.indexes_to_bases_dict


### PR DESCRIPTION
By adding an OrderedBiMap class, we can squash 8 members down to 2.