### PR TITLE
Avoid injecting a float into a sympy expression

### DIFF
--- a/galgebra/metric.py
+++ b/galgebra/metric.py
@@ -129,7 +129,7 @@ def square_root_of_expr(expr):
             if n % 2 != 0:
                 return sqrt(abs(expr))  # Product not all even powers
             else:
-                coef *= f ** (n / 2)  # Positive sqrt of the square of an expression
+                coef *= f ** (n / S(2))  # Positive sqrt of the square of an expression
         return coef
 
 

--- a/test/test_mv.py
+++ b/test/test_mv.py
@@ -129,6 +129,11 @@ class TestMv(unittest.TestCase):
         with self.assertRaises(TypeError):
             ga.mv([1, 2, 3], 'vector', f=True)  # can't pass f with coefficients
 
+    def test_abs(self):
+        ga, e_1, e_2, e_3 = Ga.build('e*1|2|3', g=[1, 1, 1])
+        B = ga.mv('B', 'bivector')
+        assert abs(B*B) == -(B*B).scalar()
+
     def test_hashable(self):
         ga, e_1, e_2, e_3 = Ga.build('e*1|2|3')
 


### PR DESCRIPTION
`n` is an integer, so `n / 2` evaluates to a `float`.
This then can't be simplified by sympy.
Using `S(2)` here forces the result to be rational.

Previously this test gave `abs(B*B)` as `(B__12**2 + B__13**2 + B__23**2)**1.0`