### PR TITLE
Show member documentation in source order

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -89,6 +89,7 @@ autodoc_default_options = {
         # Make sure that any autodoc declarations show the right members
         "members": True,
         "inherited-members": True,
+        "member-order": "bysource",
         # "undoc-members": True,
         # "special-members": True,
         # "private-members": True,


### PR DESCRIPTION
Even if the order still ends up bad, this gives us the power to more easily change it in future, simply by reordering the source code.

Demonstrating where this provides value, the [dot products](https://galgebra--254.org.readthedocs.build/en/254/generated/galgebra.ga.html#galgebra.ga.Ga.hestenes_dot) are now all documented adjacent to each other.