### PR TITLE
Ensure the latex printer is not invoked when the string printer is requested

### DIFF
--- a/galgebra/mv.py
+++ b/galgebra/mv.py
@@ -589,9 +589,12 @@ class Mv(object):
         return self.grade(key)
 
     def Mv_str(self):
+        # todo: make this an argument?
+        print_obj = printer.GaPrinter()
+
         global print_replace_old, print_replace_new
         if self.i_grade == 0:
-            return str(self.obj)
+            return print_obj.doprint(self.obj)
 
         # note: this just replaces `self` for the rest of this function
         obj = expand(self.obj)
@@ -629,22 +632,22 @@ class Mv(object):
             terms = list(terms.items())
             sorted_terms = sorted(terms, key=operator.itemgetter(0))  # sort via base indexes
 
-            s = str(sorted_terms[0][1][0] * sorted_terms[0][1][1])
-            if printer.GaPrinter.fmt == 3:
+            s = print_obj.doprint(sorted_terms[0][1][0] * sorted_terms[0][1][1])
+            if print_obj.fmt == 3:
                 s = ' ' + s + '\n'
-            if printer.GaPrinter.fmt == 2:
+            if print_obj.fmt == 2:
                 s = ' ' + s
             old_grade = sorted_terms[0][1][2]
             for (key, (c, base, grade)) in sorted_terms[1:]:
-                term = str(c * base)
-                if printer.GaPrinter.fmt == 2 and old_grade != grade:  # one grade per line
+                term = print_obj.doprint(c * base)
+                if print_obj.fmt == 2 and old_grade != grade:  # one grade per line
                     old_grade = grade
                     s += '\n'
                 if term[0] == '-':
                     term = ' - ' + term[1:]
                 else:
                     term = ' + ' + term
-                if printer.GaPrinter.fmt == 3:  # one base per line
+                if print_obj.fmt == 3:  # one base per line
                     s += term + '\n'
                 else:  # one multivector per line
                     s += term
@@ -654,7 +657,7 @@ class Mv(object):
                 s = s.replace(printer.print_replace_old, printer.print_replace_new)
             return s
         else:
-            return str(self.obj)
+            return print_obj.doprint(self.obj)
 
     def Mv_latex_str(self):
 

--- a/test/test_printer.py
+++ b/test/test_printer.py
@@ -1,0 +1,21 @@
+import pytest
+from sympy import Symbol
+
+from galgebra.printer import GaPrinter, GaLatexPrinter
+from galgebra.ga import Ga
+
+
+def test_latex_flg():
+    g3d, e_1, e_2, e_3 = Ga.build('e*1|2|3')
+    t = Symbol('theta')
+
+    mv = t + 0*e_1
+
+    # it shouldn't matter whether the latex printer is enabled, if we call
+    # the non-latex one we should get a non latex result.
+    assert GaPrinter().doprint(mv) == 'theta'
+    GaLatexPrinter.redirect()
+    try:
+        assert GaPrinter().doprint(mv) == 'theta'
+    finally:
+        GaLatexPrinter.restore()


### PR DESCRIPTION
It is not safe to call `str()` from within `Mv_str`, as `str()` is overloaded by `ga.printer` to sometimes mean `latex()`.
Previously, `GaPrinter().doprint(mv)` would return latex despite being an explicit request for the non-latex format.

Split from #258