### PR TITLE
Remove Mv.Format, Mv.latex_flg, and Mv.restore

### DIFF
--- a/galgebra/mv.py
+++ b/galgebra/mv.py
@@ -1172,7 +1172,11 @@ class Mv(object):
         if printer.isinteractive():
             return self
 
-        s = str(self)
+        if printer.GaLatexPrinter.latex_flg:
+            s = printer.GaLatexPrinter().doprint(self)
+        else:
+            s = printer.GaPrinter().doprint(self)
+
         printer.GaPrinter.fmt = printer.GaPrinter.prev_fmt
         if title is not None:
             return title + ' = ' + s
@@ -1804,7 +1808,11 @@ class Dop(dop._BaseDop):
         if printer.isinteractive():
             return self
 
-        s = str(self)
+        if printer.GaLatexPrinter.latex_flg:
+            s = printer.GaLatexPrinter().doprint(self)
+        else:
+            s = printer.GaPrinter().doprint(self)
+
         printer.GaPrinter.fmt = printer.GaPrinter.prev_fmt
         printer.GaPrinter.dop_fmt = printer.GaPrinter.prev_dop_fmt
 

--- a/galgebra/mv.py
+++ b/galgebra/mv.py
@@ -60,7 +60,10 @@ class Mv(object):
 
     ################### Multivector initialization #####################
 
+    # This is read by one code path in `galgebra.printer.Fmt`. Only one example
+    # sets it.
     fmt = 1
+
     latex_flg = False
     dual_mode_lst = ['+I', 'I+', '+Iinv', 'Iinv+', '-I', 'I-', '-Iinv', 'Iinv-']
 
@@ -70,14 +73,8 @@ class Mv(object):
         Set up constant multivectors required for multivector class for
         a given geometric algebra, `ga`.
         """
-        Mv.fmt = 1
         # copy basis in case the caller wanted to change it
         return ga.mv_I, list(ga.mv_basis), ga.mv_x
-
-    @staticmethod
-    def Format(mode=1):
-        Mv.latex_flg = True
-        Mv.fmt = mode
 
     @staticmethod
     def Mul(A, B, op):

--- a/galgebra/mv.py
+++ b/galgebra/mv.py
@@ -62,7 +62,6 @@ class Mv(object):
 
     fmt = 1
     latex_flg = False
-    restore = False
     dual_mode_lst = ['+I', 'I+', '+Iinv', 'Iinv+', '-I', 'I-', '-Iinv', 'Iinv-']
 
     @staticmethod

--- a/galgebra/mv.py
+++ b/galgebra/mv.py
@@ -64,7 +64,6 @@ class Mv(object):
     # sets it.
     fmt = 1
 
-    latex_flg = False
     dual_mode_lst = ['+I', 'I+', '+Iinv', 'Iinv+', '-I', 'I-', '-Iinv', 'Iinv-']
 
     @staticmethod
@@ -1173,21 +1172,12 @@ class Mv(object):
         if printer.isinteractive():
             return self
 
-        if Mv.latex_flg:
-            latex_str = printer.GaLatexPrinter.latex(self)
-            printer.GaLatexPrinter.fmt = printer.GaLatexPrinter.prev_fmt
-
-            if title is not None:
-                return title + ' = ' + latex_str
-            else:
-                return latex_str
+        s = str(self)
+        printer.GaPrinter.fmt = printer.GaPrinter.prev_fmt
+        if title is not None:
+            return title + ' = ' + s
         else:
-            s = str(self)
-            printer.GaPrinter.fmt = printer.GaPrinter.prev_fmt
-            if title is not None:
-                return title + ' = ' + s
-            else:
-                return s
+            return s
 
     def _repr_latex_(self):
         latex_str = printer.GaLatexPrinter.latex(self)
@@ -1814,24 +1804,14 @@ class Dop(dop._BaseDop):
         if printer.isinteractive():
             return self
 
-        if Mv.latex_flg:
-            latex_str = printer.GaLatexPrinter.latex(self)
-            printer.GaLatexPrinter.fmt = printer.GaLatexPrinter.prev_fmt
-            printer.GaLatexPrinter.dop_fmt = printer.GaLatexPrinter.prev_dop_fmt
+        s = str(self)
+        printer.GaPrinter.fmt = printer.GaPrinter.prev_fmt
+        printer.GaPrinter.dop_fmt = printer.GaPrinter.prev_dop_fmt
 
-            if title is not None:
-                return title + ' = ' + latex_str
-            else:
-                return latex_str
+        if title is not None:
+            return title + ' = ' + s
         else:
-            s = str(self)
-            printer.GaPrinter.fmt = printer.GaPrinter.prev_fmt
-            printer.GaPrinter.dop_fmt = printer.GaPrinter.prev_dop_fmt
-
-            if title is not None:
-                return title + ' = ' + s
-            else:
-                return s
+            return s
 
     def _eval_derivative_n_times(self, x, n):
         return Dop(dop._eval_derivative_n_times_terms(self.terms, x, n), cmpflg=self.cmpflg, ga=self.Ga)


### PR DESCRIPTION
These didn't appear to be used from any examples or tests, and don't make much sense - it would be weird to configure `Mv` to use latex when the rest did not.

Inspired by splitting up #258.