### PR TITLE
Add an overview of different ways of printing as a CI test

### DIFF
--- a/doc/python/BACCAB.py
+++ b/doc/python/BACCAB.py
@@ -9,7 +9,6 @@ print('g_{ij} =', g4d.g)
 print('\\bm{a|(b*c)} =', a | (b * c))
 print('\\bm{a|(b^c)} =', a | (b ^ c))
 print('\\bm{a|(b^c^d)} =', a | (b ^ c ^ d))
-# FIXME:FIXED this should print 0, got blank
 print('\\bm{a|(b^c)+c|(a^b)+b|(c^a)} =',
       (a | (b ^ c)) + (c | (a ^ b)) + (b | (c ^ a)))
 print('\\bm{a*(b^c)-b*(a^c)+c*(a^b)} =',

--- a/examples/ipython/printing-galgebra.ipynb
+++ b/examples/ipython/printing-galgebra.ipynb
@@ -237,6 +237,164 @@
     "    data = f.read()\n",
     "display_pretty(data, raw=True)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Reproduce Some bugs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Format()\n",
+    "xyz_coords = x, y, z = symbols('x y z', real=True)\n",
+    "o3d, ex, ey, ez = Ga.build('e', g=[1, 1, 1], coords=xyz_coords, norm=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\left( \\left( 1\\right), \\  \\left( e_{x}, \\  e_{y}, \\  e_{z}\\right), \\  \\left( e^{e}_{x y}, \\  e^{e}_{x z}, \\  e^{e}_{y z}\\right), \\  \\left( e^{e e}_{x y z}\\right)\\right)$"
+      ],
+      "text/plain": [
+       "((1,), (eₓ, e_y, e_z), (e_x_y__e, e_x_z__e, e_y_z__e), (e_x_y_z__e__e,))"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# FIXME BUG: incorrect handling of \\wedge\n",
+    "o3d.blades"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def build_ga_from_solution(solution, norm=False):\n",
+    "    [metric, coordinate_set, _index_config, cosmological_constant] = solution\n",
+    "    return Ga('e', g=metric, coords=coordinate_set, norm=norm)\n",
+    "\n",
+    "g4coords = u, x, y, z = symbols(\"u x y z\")\n",
+    "g = [\n",
+    "    [0, 0, -exp(-z), 0],\n",
+    "    [0, S.Half * u ** 2 * exp(4 * z), 0, 0],\n",
+    "    [-exp(-z), 0, 12 * exp(-2 * z), u * exp(-z)],\n",
+    "    [0, 0, u * exp(-z), S.Half * u ** 2],\n",
+    "]\n",
+    "g4 = build_ga_from_solution([g, g4coords, None, 0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(e_u, e_x, e_y, e_z)"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# FIXME BUG: should be LaTeX\n",
+    "g4.mv()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(-10*e_u - exp(z)*e_y + 2*e_z/u,\n",
+       " 2*exp(-4*z)*e_x/u**2,\n",
+       " -exp(z)*e_u,\n",
+       " 2*e_u/u + 2*e_z/u**2)"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# FIXME BUG: should be LaTeX\n",
+    "g4.mvr()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\left( \\left( 1\\right), \\  \\left( e_{u}, \\  e_{x}, \\  e_{y}, \\  e_{z}\\right), \\  \\left( e^{e}_{u x}, \\  e^{e}_{u y}, \\  e^{e}_{u z}, \\  e^{e}_{x y}, \\  e^{e}_{x z}, \\  e^{e}_{y z}\\right), \\  \\left( e^{e e}_{u x y}, \\  e^{e e}_{u x z}, \\  e^{e e}_{u y z}, \\  e^{e e}_{x y z}\\right), \\  \\left( e^{e e e}_{u x y z}\\right)\\right)$"
+      ],
+      "text/plain": [
+       "((1,), (eᵤ, eₓ, e_y, e_z), (e_u_x__e, e_u_y__e, e_u_z__e, e_x_y__e, e_x_z__e, \n",
+       "e_y_z__e), (e_u_x_y__e__e, e_u_x_z__e__e, e_u_y_z__e__e, e_x_y_z__e__e), (e_u_\n",
+       "x_y_z__e__e__e,))"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# FIXME BUG: incorrect handling of \\wedge\n",
+    "g4.blades"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle e^{e e e}_{u x y z}$"
+      ],
+      "text/plain": [
+       "e_u_x_y_z__e__e__e"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# FIXME BUG: incorrect handling of \\wedge\n",
+    "# This is the root cause of the above\n",
+    "g4.e.obj"
+   ]
   }
  ],
  "metadata": {

--- a/examples/ipython/printing-galgebra.ipynb
+++ b/examples/ipython/printing-galgebra.ipynb
@@ -1,0 +1,263 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 4 ways to print in GAlgebra"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "import subprocess\n",
+    "from IPython.core.display import display_pretty\n",
+    "from sympy import *\n",
+    "from galgebra.ga import Ga\n",
+    "from galgebra.printer import Eprint, Format, xpdf"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cga3d = Ga(r'e_1 e_2 e_3 e e_{0}',g='1 0 0 0 0,0 1 0 0 0,0 0 1 0 0,0 0 0 0 -1,0 0 0 -1 0')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Printing in plain text"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "e_1^e_2^e_3^e^e_{0}\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(cga3d.I())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##  Enhanced Console Printing\n",
+    "\n",
+    "If called `Eprint()` upfront, `print()` will do Enhanced Console Printing(colored printing with ANSI escape sequences):\n",
+    "\n",
+    "- code: https://github.com/pygae/galgebra/blob/master/examples/Terminal/terminal_check.py\n",
+    "- output: https://nbviewer.jupyter.org/github/pygae/galgebra/blob/master/examples/ipython/Terminal.ipynb"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\u001b[0;34me_1\u001b[0m^\u001b[0;34me_2\u001b[0m^\u001b[0;34me_3\u001b[0m^\u001b[0;34me\u001b[0m^\u001b[0;34me_{0}\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Eprint modifies global state, start a new python process to avoid it\n",
+    "# affecting the rest of this notebook.\n",
+    "code = \"\"\"\n",
+    "from galgebra.ga import Ga\n",
+    "from galgebra.printer import Eprint\n",
+    "Eprint()\n",
+    "cga3d = Ga(r'e_1 e_2 e_3 e e_{0}',g='1 0 0 0 0,0 1 0 0 0,0 0 1 0 0,0 0 0 0 -1,0 0 0 -1 0')\n",
+    "print(cga3d.I())\n",
+    "\"\"\"\n",
+    "result = subprocess.check_output([sys.executable, '-c', code], universal_newlines=True)\n",
+    "display_pretty(result, raw=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## MathJax printing in Jupyter Notebook\n",
+    "\n",
+    "In a Jupyter Notebook upfront, without calling `print()`, it will do LaTeX printing with MathJax for Geometric Algebra expressions.\n",
+    "\n",
+    "- code & output: https://nbviewer.jupyter.org/github/pygae/galgebra/blob/master/examples/ipython/colored_christoffel_symbols.ipynb"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "\\begin{equation*}  \\boldsymbol{e}_{1}\\wedge \\boldsymbol{e}_{2}\\wedge \\boldsymbol{e}_{3}\\wedge \\boldsymbol{e}\\wedge \\boldsymbol{e}_{{0}} \\end{equation*}"
+      ],
+      "text/plain": [
+       "e_1^e_2^e_3^e^e_{0}"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cga3d.I()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## LaTeX printing\n",
+    "\n",
+    "If called `Format()` upfront and `xpdf()` eventually, `print()` will do LaTeX printing (internally, the standard output will be redirected to a buffer for later consumption).\n",
+    "\n",
+    "- code: https://github.com/pygae/galgebra/blob/master/examples/LaTeX/colored_christoffel_symbols.py\n",
+    "- output: https://nbviewer.jupyter.org/github/pygae/galgebra/blob/master/examples/ipython/LaTeX.ipynb"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Format()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(cga3d.I())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xpdf(filename='test_latex_output.tex', paper=(9, 10), pdfprog=None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\n",
+       "\\documentclass[10pt,fleqn]{report}\n",
+       "\\usepackage[vcentering]{geometry}\n",
+       "\\geometry{papersize={9in,10in},total={8in,9in}}\n",
+       "\n",
+       "\\pagestyle{empty}\n",
+       "\\usepackage[latin1]{inputenc}\n",
+       "\\usepackage{amsmath}\n",
+       "\\usepackage{amsfonts}\n",
+       "\\usepackage{amssymb}\n",
+       "\\usepackage{amsbsy}\n",
+       "\\usepackage{tensor}\n",
+       "\\usepackage{listings}\n",
+       "\\usepackage{color}\n",
+       "\\usepackage{xcolor}\n",
+       "\\usepackage{bm}\n",
+       "\\usepackage{breqn}\n",
+       "\\definecolor{gray}{rgb}{0.95,0.95,0.95}\n",
+       "\\setlength{\\parindent}{0pt}\n",
+       "\\DeclareMathOperator{\\Tr}{Tr}\n",
+       "\\DeclareMathOperator{\\Adj}{Adj}\n",
+       "\\newcommand{\\bfrac}[2]{\\displaystyle\\frac{#1}{#2}}\n",
+       "\\newcommand{\\lp}{\\left (}\n",
+       "\\newcommand{\\rp}{\\right )}\n",
+       "\\newcommand{\\paren}[1]{\\lp {#1} \\rp}\n",
+       "\\newcommand{\\half}{\\frac{1}{2}}\n",
+       "\\newcommand{\\llt}{\\left <}\n",
+       "\\newcommand{\\rgt}{\\right >}\n",
+       "\\newcommand{\\abs}[1]{\\left |{#1}\\right | }\n",
+       "\\newcommand{\\pdiff}[2]{\\bfrac{\\partial {#1}}{\\partial {#2}}}\n",
+       "\\newcommand{\\lbrc}{\\left \\{}\n",
+       "\\newcommand{\\rbrc}{\\right \\}}\n",
+       "\\newcommand{\\W}{\\wedge}\n",
+       "\\newcommand{\\prm}[1]{{#1}'}\n",
+       "\\newcommand{\\ddt}[1]{\\bfrac{d{#1}}{dt}}\n",
+       "\\newcommand{\\R}{\\dagger}\n",
+       "\\newcommand{\\deriv}[3]{\\bfrac{d^{#3}#1}{d{#2}^{#3}}}\n",
+       "\\newcommand{\\grade}[1]{\\left < {#1} \\right >}\n",
+       "\\newcommand{\\f}[2]{{#1}\\lp{#2}\\rp}\n",
+       "\\newcommand{\\eval}[2]{\\left . {#1} \\right |_{#2}}\n",
+       "\\newcommand{\\Nabla}{\\boldsymbol{\\nabla}}\n",
+       "\\newcommand{\\eb}{\\boldsymbol{e}}\n",
+       "\\usepackage{float}\n",
+       "\\floatstyle{plain} % optionally change the style of the new float\n",
+       "\\newfloat{Code}{H}{myc}\n",
+       "\\lstloadlanguages{Python}\n",
+       "\n",
+       "\\begin{document}\n",
+       "\\begin{equation*} \\boldsymbol{e}_{1}\\wedge \\boldsymbol{e}_{2}\\wedge \\boldsymbol{e}_{3}\\wedge \\boldsymbol{e}\\wedge \\boldsymbol{e}_{{0}} \\end{equation*}\n",
+       "\\end{document}\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "with open('test_latex_output.tex') as f:\n",
+    "    data = f.read()\n",
+    "display_pretty(data, raw=True)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
- added "4 ways to print in GAlgebra", an overview of different ways of printing as a CI test
- also reproduced a few printing bugs to fix later, including
  - incorrect handling of \wedge
  - printed raw string instead of LaTeX in lists/tuples