### PR TITLE
Remove all callers of `printer.GaLatexPrinter.latex`

### DIFF
--- a/galgebra/dop.py
+++ b/galgebra/dop.py
@@ -175,7 +175,7 @@ class Sdop(_BaseDop):
         return s[:-3]
 
     def _repr_latex_(self):
-        latex_str = printer.GaLatexPrinter.latex(self)
+        latex_str = printer.GaLatexPrinter().doprint(self)
         return ' ' + latex_str + ' '
 
     def __str__(self):
@@ -407,7 +407,7 @@ class Pdop(_BaseDop):
         return s
 
     def _repr_latex_(self):
-        latex_str = printer.GaLatexPrinter.latex(self)
+        latex_str = printer.GaLatexPrinter().doprint(self)
         return ' ' + latex_str + ' '
 
     def __str__(self):

--- a/galgebra/lt.py
+++ b/galgebra/lt.py
@@ -347,7 +347,7 @@ class Lt(object):
         return str(self)
 
     def _repr_latex_(self):
-        latex_str = printer.GaLatexPrinter.latex(self)
+        latex_str = printer.GaLatexPrinter().doprint(self)
         if r'\begin{align*}' not in latex_str:
             latex_str = r'\begin{equation*} ' + latex_str + r' \end{equation*}'
         return latex_str
@@ -428,7 +428,7 @@ class Lt(object):
         if printer.isinteractive():
             return self
 
-        latex_str = printer.GaLatexPrinter.latex(self)
+        latex_str = printer.GaLatexPrinter().doprint(self)
 
         r"""
         if printer.GaLatexPrinter.ipy:
@@ -646,7 +646,7 @@ class Mlt(object):
         for latex.
         """
         self.lcnt = lcnt
-        latex_str = printer.GaLatexPrinter.latex(self)
+        latex_str = printer.GaLatexPrinter().doprint(self)
         self.lcnt = 1
 
         if printer.GaLatexPrinter.ipy:
@@ -838,7 +838,7 @@ class Mlt(object):
             return Mlt(X * self.fvalue, self.Ga, self.nargs)
 
     def _repr_latex_(self):
-        latex_str = printer.GaLatexPrinter.latex(self)
+        latex_str = printer.GaLatexPrinter().doprint(self)
         if r'\begin{align*}' not in latex_str:
             latex_str = r'\begin{equation*} ' + latex_str + r' \end{equation*}'
         return latex_str

--- a/galgebra/mv.py
+++ b/galgebra/mv.py
@@ -1184,7 +1184,7 @@ class Mv(object):
             return s
 
     def _repr_latex_(self):
-        latex_str = printer.GaLatexPrinter.latex(self)
+        latex_str = printer.GaLatexPrinter().doprint(self)
         if r'\begin{align*}' not in latex_str:
             if self.title is None:
                 latex_str = r'\begin{equation*} ' + latex_str + r' \end{equation*}'
@@ -1662,7 +1662,7 @@ class Dop(dop._BaseDop):
         return str(self)
 
     def _repr_latex_(self):
-        latex_str = printer.GaLatexPrinter.latex(self)
+        latex_str = printer.GaLatexPrinter().doprint(self)
         if r'\begin{align*}' not in latex_str:
             if self.title is None:
                 latex_str = r'\begin{equation*} ' + latex_str + r' \end{equation*}'


### PR DESCRIPTION
This function is just `GaLatexPrinter().doprint(x)` with some extra behavior for whether `x` is a list.
`self` is not a list in any of these places.

https://github.com/pygae/galgebra/blob/6c3856856ddcf1d5bbabe5f26b749c4bea85cca4/galgebra/printer.py#L973-L983

Brought on by https://github.com/pygae/galgebra/pull/264#issuecomment-621884504