### PR TITLE
Move an if from the printer

### DIFF
--- a/galgebra/mv.py
+++ b/galgebra/mv.py
@@ -584,8 +584,6 @@ class Mv(object):
         return self.grade(key)
 
     def Mv_str(self, print_obj):
-        global print_replace_old, print_replace_new
-
         if self.obj == S.Zero:
             return ZERO_STR
 

--- a/galgebra/mv.py
+++ b/galgebra/mv.py
@@ -585,6 +585,10 @@ class Mv(object):
 
     def Mv_str(self, print_obj):
         global print_replace_old, print_replace_new
+
+        if self.obj == S.Zero:
+            return ZERO_STR
+
         if self.i_grade == 0:
             return print_obj.doprint(self.obj)
 
@@ -653,7 +657,7 @@ class Mv(object):
 
     def Mv_latex_str(self, print_obj):
 
-        if self.obj == 0:
+        if self.obj == S.Zero:
             return ZERO_STR
 
         first_line = True

--- a/galgebra/printer.py
+++ b/galgebra/printer.py
@@ -371,10 +371,7 @@ class GaPrinter(StrPrinter):
         return out_str
 
     def _print_Mv(self, expr):
-        if expr.obj == S(0):
-            return ZERO_STR
-        else:
-            return expr.Mv_str(self)
+        return expr.Mv_str(self)
 
     def _print_Pdop(self, expr):
         return expr.Pdop_str(self)
@@ -937,10 +934,7 @@ class GaLatexPrinter(LatexPrinter):
         return s
 
     def _print_Mv(self, expr):
-        if expr.obj == S(0):
-            return ZERO_STR
-        else:
-            return expr.Mv_latex_str(self)
+        return expr.Mv_latex_str(self)
 
     def _print_Pdop(self, expr):
         return expr.Pdop_latex_str(self)


### PR DESCRIPTION
This if is already present in `Mv_latex_str` and `Mv_str`, there is no need to perform it twice.