### PR TITLE
Use the builtin hooks in sympy printers

### DIFF
--- a/galgebra/dop.py
+++ b/galgebra/dop.py
@@ -116,7 +116,7 @@ class Sdop(_BaseDop):
         new_terms = sorted(self.terms, key=lambda term: Pdop.sort_key(term[1]))
         return Sdop(new_terms)
 
-    def Sdop_str(self, print_obj):
+    def _sympystr(self, print_obj):
         if len(self.terms) == 0:
             return ZERO_STR
 
@@ -144,7 +144,7 @@ class Sdop(_BaseDop):
                 s = '(' + s + ')'
         return s
 
-    def Sdop_latex_str(self, print_obj):
+    def _latex(self, print_obj):
         if len(self.terms) == 0:
             return ZERO_STR
 
@@ -378,7 +378,7 @@ class Pdop(_BaseDop):
         assert not isinstance(other, Pdop)
         return Sdop([(other, self)])
 
-    def Pdop_str(self, print_obj):
+    def _sympystr(self, print_obj):
         if self.order == 0:
             return 'D{}'
         s = 'D'
@@ -389,7 +389,7 @@ class Pdop(_BaseDop):
                 s += '^' + print_obj.doprint(n)
         return s
 
-    def Pdop_latex_str(self, print_obj):
+    def _latex(self, print_obj):
         if self.order == 0:
             return ''
         s = r'\frac{\partial'

--- a/galgebra/lt.py
+++ b/galgebra/lt.py
@@ -389,7 +389,7 @@ class Lt(object):
             raise ValueError('Lt inverse currently implemented only for spinor!\n')
         return Lt_inv
 
-    def Lt_str(self, print_obj):
+    def _sympystr(self, print_obj):
 
         if self.spinor:
             return 'R = ' + print_obj.doprint(self.R)
@@ -403,7 +403,7 @@ class Lt(object):
                     s += pre + print_obj.doprint(base) + ') = 0\n'
             return s[:-1]
 
-    def Lt_latex_str(self, print_obj):
+    def _latex(self, print_obj):
 
         if self.spinor:
             s = '\\left \\{ \\begin{array}{ll} '
@@ -586,10 +586,10 @@ class Mlt(object):
                 base_indexes.append(base_str[i:])
         return base_indexes
 
-    def Mlt_str(self, print_obj):
+    def _sympystr(self, print_obj):
         return print_obj.doprint(self.fvalue)
 
-    def Mlt_latex_str(self, print_obj):
+    def _latex(self, print_obj):
         if self.nargs <= 1:
             return print_obj.doprint(self.fvalue)
         expr_lst = Mlt.expand_expr(self.fvalue, self.Ga)

--- a/galgebra/mv.py
+++ b/galgebra/mv.py
@@ -584,8 +584,6 @@ class Mv(object):
         return self.grade(key)
 
     def Mv_str(self, print_obj):
-        global print_replace_old, print_replace_new
-
         if self.obj == S.Zero:
             return ZERO_STR
 

--- a/galgebra/mv.py
+++ b/galgebra/mv.py
@@ -585,6 +585,10 @@ class Mv(object):
 
     def Mv_str(self, print_obj):
         global print_replace_old, print_replace_new
+
+        if self.obj == S.Zero:
+            return ZERO_STR
+
         if self.i_grade == 0:
             return print_obj.doprint(self.obj)
 
@@ -653,7 +657,7 @@ class Mv(object):
 
     def Mv_latex_str(self, print_obj):
 
-        if self.obj == 0:
+        if self.obj == S.Zero:
             return ZERO_STR
 
         first_line = True

--- a/galgebra/mv.py
+++ b/galgebra/mv.py
@@ -583,7 +583,7 @@ class Mv(object):
         '''
         return self.grade(key)
 
-    def Mv_str(self, print_obj):
+    def _sympystr(self, print_obj):
         if self.obj == S.Zero:
             return ZERO_STR
 
@@ -653,7 +653,7 @@ class Mv(object):
         else:
             return print_obj.doprint(self.obj)
 
-    def Mv_latex_str(self, print_obj):
+    def _latex(self, print_obj):
 
         if self.obj == S.Zero:
             return ZERO_STR
@@ -1718,7 +1718,7 @@ class Dop(dop._BaseDop):
         terms = list(zip(coefs, bases))
         return sorted(terms, key=lambda x: self.Ga.blades.flat.index(x[1]))
 
-    def Dop_str(self, print_obj):
+    def _sympystr(self, print_obj):
         if len(self.terms) == 0:
             return ZERO_STR
 
@@ -1752,7 +1752,7 @@ class Dop(dop._BaseDop):
         s = s.replace('+ -', '-')
         return s[:-3]
 
-    def Dop_latex_str(self, print_obj):
+    def _latex(self, print_obj):
         if len(self.terms) == 0:
             return ZERO_STR
 

--- a/galgebra/printer.py
+++ b/galgebra/printer.py
@@ -371,10 +371,7 @@ class GaPrinter(StrPrinter):
         return out_str
 
     def _print_Mv(self, expr):
-        if expr.obj == S(0):
-            return ZERO_STR
-        else:
-            return expr.Mv_str(self)
+        return expr.Mv_str(self)
 
     def _print_Pdop(self, expr):
         return expr.Pdop_str(self)
@@ -937,10 +934,7 @@ class GaLatexPrinter(LatexPrinter):
         return s
 
     def _print_Mv(self, expr):
-        if expr.obj == S(0):
-            return ZERO_STR
-        else:
-            return expr.Mv_latex_str(self)
+        return expr.Mv_latex_str(self)
 
     def _print_Pdop(self, expr):
         return expr.Pdop_latex_str(self)

--- a/galgebra/printer.py
+++ b/galgebra/printer.py
@@ -370,24 +370,6 @@ class GaPrinter(StrPrinter):
         out_str = ostr(list(expr))
         return out_str
 
-    def _print_Mv(self, expr):
-        return expr.Mv_str(self)
-
-    def _print_Pdop(self, expr):
-        return expr.Pdop_str(self)
-
-    def _print_Dop(self, expr):
-        return expr.Dop_str(self)
-
-    def _print_Sdop(self, expr):
-        return expr.Sdop_str(self)
-
-    def _print_Lt(self, expr):
-        return expr.Lt_str(self)
-
-    def _print_Mlt(self, expr):
-        return expr.Mlt_str(self)
-
 
 Basic.__ga_print_str__ = lambda self: GaPrinter().doprint(self)
 Matrix.__ga_print_str__ = lambda self: GaPrinter().doprint(self)
@@ -932,24 +914,6 @@ class GaLatexPrinter(LatexPrinter):
         else:
             s = r"%s %s" % (tex, self._print(expr.expr))
         return s
-
-    def _print_Mv(self, expr):
-        return expr.Mv_latex_str(self)
-
-    def _print_Pdop(self, expr):
-        return expr.Pdop_latex_str(self)
-
-    def _print_Dop(self, expr):
-        return expr.Dop_latex_str(self)
-
-    def _print_Sdop(self, expr):
-        return expr.Sdop_latex_str(self)
-
-    def _print_Lt(self, expr):
-        return expr.Lt_latex_str(self)
-
-    def _print_Mlt(self, expr):
-        return expr.Mlt_latex_str(self)
 
     def _print_MatrixBase(self, expr):
         rows = expr.rows


### PR DESCRIPTION
As described by @asmeurer in https://github.com/pygae/galgebra/pull/258#issuecomment-622126220, there is no need for us to register our objects this way.

This PR include #270 as its first two commits, but is probably fine to merge all at once.