### PR TITLE
Avoid checking whether the basis blades are blades

### DIFF
--- a/galgebra/mv.py
+++ b/galgebra/mv.py
@@ -982,12 +982,10 @@ class Mv(object):
 
         if blade_lst is None:
             blade_lst = self.Ga.mv_blades.flat
-
-        # print 'Enter blade_coefs blade_lst =', blade_lst, type(blade_lst), [i.is_blade() for i in blade_lst]
-
-        for blade in blade_lst:
-            if not blade.is_base() or not blade.is_blade():
-                raise ValueError("%s expression isn't a basis blade" % blade)
+        else:
+            for blade in blade_lst:
+                if not blade.is_base() or not blade.is_blade():
+                    raise ValueError("%s expression isn't a basis blade" % blade)
         blade_lst = [x.obj for x in blade_lst]
         coefs, bases = metric.linear_expand(self.obj)
         coef_lst = []


### PR DESCRIPTION
Cherry-picked from @meuns' branch (#68)
We can skip a check here, since we know `Ga.mv_blades` will contain only blades.

No behavior change, but likely a small performance boost.