### PR TITLE
Remove the special cases in Ga.blade_derivation

### DIFF
--- a/galgebra/ga.py
+++ b/galgebra/ga.py
@@ -1828,17 +1828,15 @@ class Ga(metric.Metric):
 
         index = self.indexes_to_blades_dict.inverse[blade]
         grade = len(index)
-        if grade == 1:
-            db = self.de[ib][index[0]]
-        elif grade == 2:
-            db = self.wedge(self.de[ib][index[0]], self.basis[index[1]]) + \
-                self.wedge(self.basis[index[0]], self.de[ib][index[1]])
-        else:
-            db = self.wedge(self.de[ib][index[0]], self.indexes_to_blades_dict[index[1:]]) + \
-                self.wedge(self.indexes_to_blades_dict[index[:-1]], self.de[ib][index[-1]])
-            for i in range(1, grade - 1):
-                db += self.wedge(self.wedge(self.indexes_to_blades_dict[index[:i]], self.de[ib][index[i]]),
-                                 self.indexes_to_blades_dict[index[i + 1:]])
+
+        # differentiate each basis vector separately and sum
+        db = S.Zero
+        for i in range(grade):
+            db += reduce(self.wedge, [
+                self.indexes_to_blades_dict[index[:i]],
+                self.de[ib][index[i]],
+                self.indexes_to_blades_dict[index[i + 1:]]
+            ])
         self._dbases[key] = db
         return db
 


### PR DESCRIPTION
The special case in the `grade > 2` branch was previously needed because `indexes_to_blades_dict` did not contain the scalar element.
Also switches to using `reduce` for a bit of clarity.

The other cases were there for optimization purposes. It's not clear whether they were worthwhile.

Fixes gh-282