### PR TITLE
Move documentation for a single printer function to the source code

### DIFF
--- a/doc/module-components.rst
+++ b/doc/module-components.rst
@@ -804,24 +804,8 @@ Latex Printing
 
 For latex printing one uses one functions from the ``ga`` module and one function from the ``printer`` module. The functions are
 
-.. function:: Format(Fmode=True,Dmode=True)
+.. autofunction:: galgebra.printer.Format
    :noindex:
-
-   This function from the ``ga`` module turns on latex printing with the following options
-
-   +-----------+-----------+-----------------------------------------------------------------------------------------+
-   | Argument  | Value     | Result                                                                                  |
-   +===========+===========+=========================================================================================+
-   | ``Fmode`` | ``True``  | Print functions without argument list, :math:`f`                                        |
-   +-----------+-----------+-----------------------------------------------------------------------------------------+
-   |           | ``False`` | Print functions with standard *sympy* latex formatting, :math:`{{f}\lp {x,y,z} \rp }`   |
-   +-----------+-----------+-----------------------------------------------------------------------------------------+
-   | ``Dmode`` | ``True``  | Print partial derivatives with condensed notation, :math:`\partial_{x}f`                |
-   +-----------+-----------+-----------------------------------------------------------------------------------------+
-   |           | ``False`` | Print partial derivatives with standard *sympy* latex formatting, :math:`\pdiff{f}{x}`  |
-   +-----------+-----------+-----------------------------------------------------------------------------------------+
-
-   ``Format()`` is also required for printing from *ipython notebook* (note that ``xpdf()`` is not needed to print from *ipython notebook*).
 
 .. function:: Fmt(obj,fmt=1)
    :noindex:

--- a/galgebra/printer.py
+++ b/galgebra/printer.py
@@ -902,14 +902,22 @@ def print_latex(expr, **settings):
     print(latex(expr, **settings))
 
 
-def Format(Fmode=True, Dmode=True, dop=1, inverse='full'):
-    """
-    Set modes for latex printer -
+def Format(Fmode: bool = True, Dmode: bool = True, dop=1, inverse='full'):
+    r"""
+    Turns on latex printing with configurable options.
 
-        Fmode:  Suppress function arguments (True)          Use sympy latex for functions (False)
-        Dmode:  Use compact form of derivatives (True)      Use sympy latex for derivatives (False)
+    This redirects printer output so that latex compiler can capture it.
 
-    and redirects printer output so that latex compiler can capture it.
+    ``Format()`` is also required for printing from *ipython notebook* (note that ``xpdf()`` is not needed to print from *ipython notebook*).
+
+    Parameters
+    ----------
+    Fmode:
+        * ``True`` -- Print functions without argument list, :math:`f`
+        * ``False`` -- Print functions with standard *sympy* latex formatting, :math:`{{f}\lp {x,y,z} \rp }`
+    Dmode:
+        * ``True`` -- Print partial derivatives with condensed notation, :math:`\partial_{x}f`
+        * ``False`` -- Print partial derivatives with standard *sympy* latex formatting, :math:`\pdiff{f}{x}`
     """
     global Format_cnt
 


### PR DESCRIPTION
This is an example of how gh-300 can be addressed.

Before: https://galgebra.readthedocs.io/en/latest/module-components.html#latex-printing

![image](https://user-images.githubusercontent.com/425260/81087684-efd1fb80-8ef1-11ea-802f-6d39c7fbb349.png)

After: https://galgebra--301.org.readthedocs.build/en/301/module-components.html#latex-printing

![image](https://user-images.githubusercontent.com/425260/81087805-0bd59d00-8ef2-11ea-9811-112ee8c85163.png)
