### PR TITLE
Improve type annotations

### DIFF
--- a/galgebra/_backports/typing.py
+++ b/galgebra/_backports/typing.py
@@ -8,7 +8,7 @@ else:
     import collections
 
     K = TypeVar('K')
-    V = TypeVar('K')
+    V = TypeVar('V')
 
     class OrderedDict(collections.OrderedDict, Mapping[K, V]):
         pass

--- a/galgebra/mv.py
+++ b/galgebra/mv.py
@@ -1431,7 +1431,7 @@ class Dop(dop._BaseDop):
     terms : list of tuples
     """
 
-    def __init_from_coef_and_pdop(self, coefs: List[Any], pdiffs: List['Pdop']):
+    def __init_from_coef_and_pdop(self, coefs: List[Any], pdiffs: List['dop.Pdop']):
         if len(coefs) != len(pdiffs):
             raise ValueError('In Dop.__init__ coefficent list and Pdop list must be same length.')
         self.terms = tuple(zip(coefs, pdiffs))
@@ -1684,7 +1684,7 @@ class Dop(dop._BaseDop):
                 return False
         return True
 
-    def components(self) -> Tuple['Dop']:
+    def components(self) -> Tuple['Dop', ...]:
         return tuple(
             Dop([(sdop, Mv(base, ga=self.Ga))], ga=self.Ga)
             for sdop, base in self.Dop_mv_expand()

--- a/galgebra/printer.py
+++ b/galgebra/printer.py
@@ -1201,10 +1201,10 @@ def def_prec(gd: dict, op_ord: str = '<>|,^,*') -> None:
         precedence, followed by ``^``, and lastly ``*``.
     """
     global _eval_global_dict, _eval_parse_order
-    op_ord = op_ord.split(',')
-    _parser.validate_op_order(op_ord)
+    op_ord_list = op_ord.split(',')
+    _parser.validate_op_order(op_ord_list)
     _eval_global_dict = gd
-    _eval_parse_order = op_ord
+    _eval_parse_order = op_ord_list
 
 
 def GAeval(s: str, pstr: bool = False):


### PR DESCRIPTION
This also makes some fixes regarding type annotations found by mypy, including reusing a variable with different types each time.

MyPy also complained about using `_X = TypeVar('X')`, so instead this uses the name without an underscore, but deletes it as soon as it is no longer needed.