### PR TITLE
Make `galgebra.lt.Mlt` somewhat usable again

### DIFF
--- a/doc/python/TensorDef.py
+++ b/doc/python/TensorDef.py
@@ -13,8 +13,7 @@ A = st4d.mv('T', 'bivector')
 
 
 def TA(a1, a2):
-    global A
     return A | (a1 ^ a2)
 
-# FIXME TypeError: __init__() missing 1 required positional argument: 'args'
+
 T = Mlt(TA, st4d)  # Define multi-linear function

--- a/galgebra/ga.py
+++ b/galgebra/ga.py
@@ -328,8 +328,6 @@ class Ga(metric.Metric):
     dual_mode_value = 'I+'
     dual_mode_lst = ['+I', 'I+', '-I', 'I-', '+Iinv', 'Iinv+', '-Iinv', 'Iinv-']
 
-    a = []
-
     presets = {'o3d': 'x,y,z:[1,1,1]:[1,1,0]',
                'cyl3d': 'r,theta,z:[1,r**2,1]:[1,1,0]:norm=True',
                'sph3d': 'r,theta,phi:[1,X[0]**2,X[0]**2*cos(X[1])**2]:[1,1,0]:norm=True',
@@ -478,11 +476,14 @@ class Ga(metric.Metric):
         if self.debug:
             print('Exit Ga.__init__()')
 
-        self.a = []  # List of dummy vectors for Mlt calculations
         self._agrads = {}  # cache of gradient operator with respect to vector a
         self.dslot = -1  # args slot for dervative, -1 for coordinates
-        self.acoefs = []  # List of dummy vectors coefficients
-        self.pdiffs = []  # List of lists dummy vector coefficients
+
+        # mystery state used by the Mlt class
+        self._mlt_a = []  # List of dummy vectors for Mlt calculations
+        self._mlt_acoefs = []  # List of dummy vectors coefficients
+        self._mlt_pdiffs = []  # List of lists dummy vector coefficients
+
         self._XOX = self.mv('XOX', 'vector')  # cached vector for use in is_versor
 
     @_cached_property

--- a/galgebra/ga.py
+++ b/galgebra/ga.py
@@ -481,6 +481,8 @@ class Ga(metric.Metric):
         self.a = []  # List of dummy vectors for Mlt calculations
         self._agrads = {}  # cache of gradient operator with respect to vector a
         self.dslot = -1  # args slot for dervative, -1 for coordinates
+        self.acoefs = []  # List of dummy vectors coefficients
+        self.pdiffs = []  # List of lists dummy vector coefficients
         self._XOX = self.mv('XOX', 'vector')  # cached vector for use in is_versor
 
     @_cached_property
@@ -497,11 +499,6 @@ class Ga(metric.Metric):
         if self.r_basis is None:
             self._build_reciprocal_basis(self.gsym)
 
-        if isinstance(a, (list, tuple)):
-            for ai in a:
-                self.make_grad(ai, cmpflg=cmpflg)
-            return
-
         cache_key = (a, cmpflg)
 
         if cache_key in self._agrads:
@@ -511,9 +508,6 @@ class Ga(metric.Metric):
             ai = a.get_coefs(1)
         else:
             ai = a
-
-        # TODO: Work out what the heck Mlt is trying to do with this
-        self.a.append(a)
 
         # make the grad and cache it
         grad_a = mv.Dop([

--- a/galgebra/lt.py
+++ b/galgebra/lt.py
@@ -808,7 +808,7 @@ class Mlt(object):
             return self.fvalue.subs(sub_lst, simultaneous=True)
 
     def __add__(self, X):
-        if isinstance(Mlt, X):
+        if isinstance(X, Mlt):
             if self.nargs == X.nargs:
                 return Mlt(self.fvalue + X.fvalue, self.Ga, self.nargs)
             else:
@@ -817,7 +817,7 @@ class Mlt(object):
             raise TypeError('In Mlt add second argument not an Mkt\n')
 
     def __sub__(self, X):
-        if isinstance(Mlt, X):
+        if isinstance(X, Mlt):
             if self.nargs == X.nargs:
                 return Mlt(self.fvalue - X.fvalue, self.Ga, self.nargs)
             else:

--- a/galgebra/lt.py
+++ b/galgebra/lt.py
@@ -840,7 +840,7 @@ class Mlt(object):
         if isinstance(X, Mlt):
             nargs = self.nargs + X.nargs
             Mlt.increment_slots(nargs, self.Ga)
-            value = self(*self.Ga.a[:self.nargs]) ^ X(X.Ga.a[self.nargs:nargs])
+            value = self(*self.Ga.a[:self.nargs]) ^ X(*X.Ga.a[self.nargs:nargs])
             return Mlt(value, self.Ga, nargs)
         else:
             return Mlt(X * self.fvalue, self.Ga, self.nargs)
@@ -849,7 +849,7 @@ class Mlt(object):
         if isinstance(X, Mlt):
             nargs = self.nargs + X.nargs
             Mlt.increment_slots(nargs, self.Ga)
-            value = self(*self.Ga.a[:self.nargs]) | X(X.Ga.a[self.nargs:nargs])
+            value = self(*self.Ga.a[:self.nargs]) | X(*X.Ga.a[self.nargs:nargs])
             return Mlt(value, self.Ga, nargs)
         else:
             return Mlt(X * self.fvalue, self.Ga, self.nargs)

--- a/galgebra/lt.py
+++ b/galgebra/lt.py
@@ -573,24 +573,24 @@ class Mlt(object):
         sub_lst = []
         for i, a in enumerate(anew):
             acoefs = a.get_coefs(1)
-            sub_lst += list(zip(Ga.pdiffs[i], acoefs))
+            sub_lst += list(zip(Ga._mlt_pdiffs[i], acoefs))
         return sub_lst
 
     @staticmethod
     def increment_slots(nargs, Ga):
         # Increment cache of available slots (vector variables) if needed for Mlt class
-        n_a = len(Ga.a)
+        n_a = len(Ga._mlt_a)
         if n_a < nargs:
             for i in range(n_a, nargs):
                 #  New slot variable with coefficients a_{n_a}__k
                 a = Ga.mv('a_' + str(i + 1), 'vector')
                 #  Append new slot variable a_j
-                Ga.a.append(a)
+                Ga._mlt_a.append(a)
                 #  Append slot variable coefficients a_j__k for purpose
                 #  of differentiation
                 coefs = a.get_coefs(1)
-                Ga.pdiffs.append(coefs)
-                Ga.acoefs += coefs
+                Ga._mlt_pdiffs.append(coefs)
+                Ga._mlt_acoefs += coefs
 
     @staticmethod
     def extact_basis_indexes(Ga):
@@ -698,12 +698,12 @@ class Mlt(object):
             coef = S(1)
             a_lst = []
             for factor in term.args:
-                if factor in ga.acoefs:
+                if factor in ga._mlt_acoefs:
                     a_lst.append(factor)
                 else:
                     coef *= factor
-            a_lst = tuple([x for x in a_lst if x in ga.acoefs])
-            b_lst = tuple([ga.acoefs.index(x) for x in a_lst])
+            a_lst = tuple([x for x in a_lst if x in ga._mlt_acoefs])
+            b_lst = tuple([ga._mlt_acoefs.index(x) for x in a_lst])
             lst_expr.append((coef, a_lst, b_lst))
         lst_expr = sorted(lst_expr, key=lambda x: x[2])
         new_lst_expr = []
@@ -737,7 +737,7 @@ class Mlt(object):
             if f.is_vector():  # f is vector T = f | a1
                 self.nargs = 1
                 Mlt.increment_slots(1, Ga)
-                self.fvalue = (f | Ga.a[0]).obj
+                self.fvalue = (f | Ga._mlt_a[0]).obj
                 self.f = None
             else:  # To be inplemented for f a general pure grade mulitvector
                 self.nargs = nargs
@@ -746,7 +746,7 @@ class Mlt(object):
         elif isinstance(f, Lt):  # f is linear transformation T = a1 | f(a2)
             self.nargs = 2
             Mlt.increment_slots(2, Ga)
-            self.fvalue = (Ga.a[0] | f(Ga.a[1])).obj
+            self.fvalue = (Ga._mlt_a[0] | f(Ga._mlt_a[1])).obj
             self.f = None
         elif isinstance(f, str) and nargs is not None:
             self.f = None
@@ -756,7 +756,7 @@ class Mlt(object):
                 t_indexes = nargs * [Mlt.extact_basis_indexes(self.Ga)]
                 self.fvalue = 0
                 for t_index, a_prod in zip(itertools.product(*t_indexes),
-                                           itertools.product(*self.Ga.pdiffs)):
+                                           itertools.product(*self.Ga._mlt_pdiffs)):
                     if fct:  # Tensor field
                         coef = Function(f+'_'+''.join(map(str, t_index)), real=True)(*self.Ga.coords)
                     else:  # Constant Tensor
@@ -765,7 +765,7 @@ class Mlt(object):
                     self.fvalue += coef
             else:  # General tensor of rank = 1
                 self.fvalue = 0
-                for t_index, a_prod in zip(Mlt.extact_basis_indexes(self.Ga), self.Ga.pdiffs[0]):
+                for t_index, a_prod in zip(Mlt.extact_basis_indexes(self.Ga), self.Ga._mlt_pdiffs[0]):
                     if fct:  # Tensor field
                         coef = Function(f+'_'+''.join(map(str, t_index)), real=True)(*self.Ga.coords)
                     else:  # Constant Tensor
@@ -777,7 +777,7 @@ class Mlt(object):
                 self.nargs = len(args)
                 self.f = f
                 Mlt.increment_slots(self.nargs, Ga)
-                self.fvalue = f(*tuple(Ga.a[0:self.nargs]))
+                self.fvalue = f(*tuple(Ga._mlt_a[0:self.nargs]))
             else:  # Tensor defined by component expression
                 self.f = None
                 self.nargs = len(args)
@@ -802,7 +802,7 @@ class Mlt(object):
             return self.f(*args)
         else:
             sub_lst = []
-            for x, ai in zip(args, self.Ga.pdiffs):
+            for x, ai in zip(args, self.Ga._mlt_pdiffs):
                 for r_base, aij in zip(self.Ga.r_basis_mv, ai):
                     sub_lst.append((aij, (r_base | x).scalar()))
             return self.fvalue.subs(sub_lst, simultaneous=True)
@@ -829,8 +829,8 @@ class Mlt(object):
         if isinstance(X, Mlt):
             nargs = self.nargs + X.nargs
             Mlt.increment_slots(nargs, self.Ga)
-            self_args = self.Ga.a[:self.nargs]
-            X_args = X.Ga.a[self.nargs:nargs]
+            self_args = self.Ga._mlt_a[:self.nargs]
+            X_args = X.Ga._mlt_a[self.nargs:nargs]
             value = (self(*self_args) * X(*X_args)).expand()
             return Mlt(value, self.Ga, nargs)
         else:
@@ -840,7 +840,7 @@ class Mlt(object):
         if isinstance(X, Mlt):
             nargs = self.nargs + X.nargs
             Mlt.increment_slots(nargs, self.Ga)
-            value = self(*self.Ga.a[:self.nargs]) ^ X(*X.Ga.a[self.nargs:nargs])
+            value = self(*self.Ga._mlt_a[:self.nargs]) ^ X(*X.Ga._mlt_a[self.nargs:nargs])
             return Mlt(value, self.Ga, nargs)
         else:
             return Mlt(X * self.fvalue, self.Ga, self.nargs)
@@ -849,7 +849,7 @@ class Mlt(object):
         if isinstance(X, Mlt):
             nargs = self.nargs + X.nargs
             Mlt.increment_slots(nargs, self.Ga)
-            value = self(*self.Ga.a[:self.nargs]) | X(*X.Ga.a[self.nargs:nargs])
+            value = self(*self.Ga._mlt_a[:self.nargs]) | X(*X.Ga._mlt_a[self.nargs:nargs])
             return Mlt(value, self.Ga, nargs)
         else:
             return Mlt(X * self.fvalue, self.Ga, self.nargs)
@@ -862,7 +862,7 @@ class Mlt(object):
 
     def dd(self):
         Mlt.increment_slots(self.nargs + 1, self.Ga)
-        dd_fvalue = (self.Ga.a[self.nargs] | self.Ga.grad) * self.fvalue
+        dd_fvalue = (self.Ga._mlt_a[self.nargs] | self.Ga.grad) * self.fvalue
         return Mlt(dd_fvalue, self.Ga, self.nargs + 1)
 
     def pdiff(self, slot: int):
@@ -881,7 +881,7 @@ class Mlt(object):
         if slot == nargs:
             return mv
         for islot in range(slot, nargs):
-            mv = mv.subs(list(zip(ga.pdiffs[islot], ga.pdiffs[islot - 1])))
+            mv = mv.subs(list(zip(ga._mlt_pdiffs[islot], ga._mlt_pdiffs[islot - 1])))
         return mv
 
     def contract(self, slot1: int, slot2: int):
@@ -915,13 +915,13 @@ class Mlt(object):
         :ref:`MLtrans`.
         """
         Mlt.increment_slots(self.nargs + 1, self.Ga)
-        agrad = self.Ga.a[self.nargs] | self.Ga.grad
+        agrad = self.Ga._mlt_a[self.nargs] | self.Ga.grad
         CD = Mlt((agrad * self.Ga.mv(self.fvalue)).obj, self.Ga, self.nargs + 1)
         if CD != 0:
             CD = CD.fvalue
         for i in range(self.nargs):
-            args = self.Ga.a[:self.nargs]
-            tmp = agrad * self.Ga.a[i]
+            args = self.Ga._mlt_a[:self.nargs]
+            tmp = agrad * self.Ga._mlt_a[i]
             if tmp.obj != 0:
                 args[i] = tmp
                 CD = CD - self(*args)

--- a/galgebra/lt.py
+++ b/galgebra/lt.py
@@ -831,7 +831,7 @@ class Mlt(object):
             Mlt.increment_slots(nargs, self.Ga)
             self_args = self.Ga.a[:self.nargs]
             X_args = X.Ga.a[self.nargs:nargs]
-            value = expand(self(*self_args) * X(*X_args))
+            value = (self(*self_args) * X(*X_args)).expand()
             return Mlt(value, self.Ga, nargs)
         else:
             return Mlt(X * self.fvalue, self.Ga, self.nargs)

--- a/test/test_lt.py
+++ b/test/test_lt.py
@@ -38,3 +38,7 @@ class TestMlt(unittest.TestCase):
 
         # calling the Mlt is like calling the function
         assert T(a1, a2) == TA(a1, a2)
+
+        # for addition, argument slots are reused
+        assert (T + T)(a1, a2) == T(a1, a2) + T(a1, a2)
+        assert (T - T)(a1, a2) == T(a1, a2) - T(a1, a2)

--- a/test/test_lt.py
+++ b/test/test_lt.py
@@ -2,6 +2,8 @@ import unittest
 
 from sympy import symbols
 from galgebra.ga import Ga
+from galgebra.lt import Mlt
+
 
 class TestLt(unittest.TestCase):
 
@@ -12,3 +14,27 @@ class TestLt(unittest.TestCase):
         A = base.lt([a+b, 2*a-b])
         assert str(A) == 'Lt(a) = a + b\nLt(b) = 2*a - b'
         assert str(A.matrix()) == 'Matrix([[1, 2], [1, -1]])'
+
+
+class TestMlt(unittest.TestCase):
+
+    def test_basic(self):
+        # from TensorDef.py
+        coords = symbols('t x y z', real=True)
+        st4d, g0, g1, g2, g3 = Ga.build('gamma*t|x|y|z', g=[1, -1, -1, -1],
+                                        coords=coords)
+
+        A = st4d.mv('T', 'bivector')
+
+        def TA(a1, a2):
+            return A | (a1 ^ a2)
+
+        T = Mlt(TA, st4d)
+
+        # tests begin
+
+        a1 = st4d.mv('a1', 'vector')
+        a2 = st4d.mv('a2', 'vector')
+
+        # calling the Mlt is like calling the function
+        assert T(a1, a2) == TA(a1, a2)

--- a/test/test_lt.py
+++ b/test/test_lt.py
@@ -35,6 +35,8 @@ class TestMlt(unittest.TestCase):
 
         a1 = st4d.mv('a1', 'vector')
         a2 = st4d.mv('a2', 'vector')
+        a3 = st4d.mv('a3', 'vector')
+        a4 = st4d.mv('a4', 'vector')
 
         # calling the Mlt is like calling the function
         assert T(a1, a2) == TA(a1, a2)
@@ -42,3 +44,7 @@ class TestMlt(unittest.TestCase):
         # for addition, argument slots are reused
         assert (T + T)(a1, a2) == T(a1, a2) + T(a1, a2)
         assert (T - T)(a1, a2) == T(a1, a2) - T(a1, a2)
+
+        # for multiplication, argument slots are chained
+        assert (T ^ T)(a1, a2, a3, a4) == TA(a1, a2) ^ T(a3, a4)
+        assert (T | T)(a1, a2, a3, a4) == TA(a1, a2) | T(a3, a4)

--- a/test/test_lt.py
+++ b/test/test_lt.py
@@ -46,5 +46,6 @@ class TestMlt(unittest.TestCase):
         assert (T - T)(a1, a2) == T(a1, a2) - T(a1, a2)
 
         # for multiplication, argument slots are chained
+        assert (T * T)(a1, a2, a3, a4) == TA(a1, a2) * T(a3, a4)
         assert (T ^ T)(a1, a2, a3, a4) == TA(a1, a2) ^ T(a3, a4)
         assert (T | T)(a1, a2, a3, a4) == TA(a1, a2) | T(a3, a4)


### PR DESCRIPTION
This is best reviewed commit-by-commit. The summary is:

1. Revert the parts of fc598df56ac6573248a187d514262f6312b17f31 that started a refactor of `Mlt` that was unfinished. This fixes gh-171.
2. Fix some obvious typos in code that never worked, and add tests.
3. Make the attributes restored in 1. private