### PR TITLE
Add intersphinx mapping to make sympy references linked [ci skip]

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -326,3 +326,8 @@ epub_exclude_files = ['search.html']
 
 
 # -- Extension configuration -------------------------------------------------
+
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+    'sympy': ('https://docs.sympy.org/latest', None),
+}


### PR DESCRIPTION
See https://galgebra--328.org.readthedocs.build/en/328/generated/galgebra.mv.html#galgebra.mv.Mv.get_coefs for an example of a working link to `Expr`.