### PR TITLE
Extract a helper class to unify the mess of properties associated with each type of multiplication.

### DIFF
--- a/test/test_test.py
+++ b/test/test_test.py
@@ -518,3 +518,31 @@ class TestTest(unittest.TestCase):
             ga.lt_x
         with pytest.warns(DeprecationWarning):
             ga.lt_coords
+
+    def test_aliases(self):
+        """ Tests of trivial getters which are aliases of other attributes.
+
+        These may merge into test_deprecated in future
+        """
+        ga, e_1, e_2, e_3 = Ga.build('e*1|2|3')
+
+        ga.mul_table_dict
+        ga.wedge_table_dict
+        ga.dot_table_dict
+        ga.left_contract_table_dict
+        ga.right_contract_table_dict
+        ga.basic_mul_table_dict
+
+        assert ga.geometric_product_basis_blades((e_1.obj, e_2.obj)) == (e_1 * e_2).obj
+        assert ga.wedge_product_basis_blades((e_1.obj, e_2.obj)) == (e_1 ^ e_2).obj
+        e_12 = e_1 ^ e_2
+        assert ga.non_orthogonal_dot_product_basis_blades((e_1.obj, e_12.obj), mode='|') == (e_1 | e_12).obj
+        assert ga.non_orthogonal_dot_product_basis_blades((e_1.obj, e_12.obj), mode='<') == (e_1 < e_12).obj
+        assert ga.non_orthogonal_dot_product_basis_blades((e_1.obj, e_12.obj), mode='>') == (e_1 > e_12).obj
+
+        # test the member that is nonsense unless in an orthonormal algebra
+        ga_ortho, e_1, e_2, e_3 = Ga.build('e*1|2|3', g=[1, 1, 1])
+        e_12 = e_1 ^ e_2
+        assert ga_ortho.dot_product_basis_blades((e_1.obj, e_12.obj), mode='|') == (e_1 | e_12).obj
+        assert ga_ortho.dot_product_basis_blades((e_1.obj, e_12.obj), mode='<') == (e_1 < e_12).obj
+        assert ga_ortho.dot_product_basis_blades((e_1.obj, e_12.obj), mode='>') == (e_1 > e_12).obj


### PR DESCRIPTION
For each product, this merges together:

* `ga.prod`
* `ga.prod_table_dict` -> `ga.prod.table_dict`
* `ga.prod_basis_blades` -> `ga.prod.basis_blades`

This removes a lot of boilerplate construction of lazydicts, and means it's easier to add more products in future, such as a scalar product or vee product.

Related to #196. This leaves behind a lot of alias attributes that we could consider deprecating and eventually removing in future:

* `mul_table_dict`
* `wedge_table_dict`
* `left_contract_table_dict`
* `right_contract_table_dict`
* `basic_mul_table_dict`
* `_dot_product_method`
* `dot_product_basis_blades`
* `non_orthogonal_dot_product_basis_blades`
* `wedge_product_basis_blades`
* `non_orthogonal_bases_products`

Almost all of the mathematically interesting code in this diff is just moved code, very little of it actually changed.

~~If it would make review easier, I could split this patch into a separate commit for each type of product, so you can see the chunks of code move one at a time.~~ (edit: this is difficult to do, since most of the products use the same function anyway)