### PR TITLE
Deprecate another 11 moved members of Ga

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -8,7 +8,24 @@ Changelog
 
 - :support:`280` The ``galgebra.utils`` module, which provided Python 2 compatibility helpers, has been deprecated.
 
-- :support:`245` (also :issue:`248`) The following attributes have been deprecated to reduce the number of similar members in :class:`~galgebra.ga.Ga`.
+- :support:`245` (also :issue:`248`, :issue:`334`) The following attributes have been deprecated to reduce the number of similar members in :class:`~galgebra.ga.Ga`.
+
+  * Unified into the :attr:`~galgebra.ga.ProductFunction.table_dict` attribute of :class:`~galgebra.ga.ProductFunction` instances:
+
+    * :attr:`galgebra.ga.Ga.wedge_table_dict` |rarr| ``wedge.table_dict``
+    * :attr:`galgebra.ga.Ga.left_contract_table_dict` |rarr| ``left_contract.table_dict``
+    * :attr:`galgebra.ga.Ga.right_contract_table_dict` |rarr| ``right_contract.table_dict``
+    * :attr:`galgebra.ga.Ga.dot_table_dict` |rarr| ``hestenes_dot.table_dict``
+    * :attr:`galgebra.ga.Ga.mul_table_dict` |rarr| ``mul.table_dict``
+    * :attr:`galgebra.ga.Ga.basic_mul_table_dict` |rarr| ``basic_mul.table_dict``
+
+  * Unified into methods of :class:`~galgebra.ga.ProductFunction` instances:
+
+    * :attr:`galgebra.ga.Ga.non_orthogonal_bases_products` |rarr| ``basic_mul.of_basis_bases``
+    * :attr:`galgebra.ga.Ga.wedge_product_basis_blades` |rarr| ``wedge.of_basis_blades``
+    * :attr:`galgebra.ga.Ga.geometric_product_basis_blades` |rarr| ``mul.of_basis_blades``
+    * :attr:`galgebra.ga.Ga.dot_product_basis_blades` and :attr:`galgebra.ga.Ga.non_orthogonal_dot_product_basis_blades` |rarr| ``<some_dot_type>.of_basis_blades``.
+      In future it will no longer be possible to call the non-ortho method for an orthogonal ga, or vice-versa.
 
   * Unified into :attr:`galgebra.ga.Ga.blade_expansion_dict`:
 

--- a/galgebra/ga.py
+++ b/galgebra/ga.py
@@ -1229,25 +1229,44 @@ class Ga(metric.Metric):
             DeprecationWarning, stacklevel=2)
         return self.indexes_to_blades_dict.inverse
 
-    # aliases for compatibility
     @property
-    def mul_table_dict(self) -> lazy_dict:
+    def mul_table_dict(self):
+        # galgebra 0.5.0
+        warnings.warn(
+            "`ga.mul_table_dict` is deprecated, use `ga.mul.table_dict`",
+            DeprecationWarning, stacklevel=2)
         return self.mul.table_dict
 
     @property
     def wedge_table_dict(self):
+        # galgebra 0.5.0
+        warnings.warn(
+            "`ga.wedge_table_dict` is deprecated, use `ga.wedge.table_dict`",
+            DeprecationWarning, stacklevel=2)
         return self.wedge.table_dict
 
     @property
     def dot_table_dict(self):
+        # galgebra 0.5.0
+        warnings.warn(
+            "`ga.dot_table_dict` is deprecated, use `ga.hestenes_dot.table_dict`",
+            DeprecationWarning, stacklevel=2)
         return self.hestenes_dot.table_dict
 
     @property
     def left_contract_table_dict(self):
+        # galgebra 0.5.0
+        warnings.warn(
+            "`ga.left_contract_table_dict` is deprecated, use `ga.left_contract.table_dict`",
+            DeprecationWarning, stacklevel=2)
         return self.left_contract.table_dict
 
     @property
     def right_contract_table_dict(self):
+        # galgebra 0.5.0
+        warnings.warn(
+            "`ga.right_contract_table_dict` is deprecated, use `ga.right_contract.table_dict`",
+            DeprecationWarning, stacklevel=2)
         return self.right_contract.table_dict
 
     def _build_connection(self):
@@ -1265,6 +1284,10 @@ class Ga(metric.Metric):
     # ******************* Geometric Product (*) ********************** #
 
     def geometric_product_basis_blades(self, blade12: Tuple[Symbol, Symbol]) -> Expr:
+        # galgebra 0.5.0
+        warnings.warn(
+            "`ga.geometric_product_basis_blades` is deprecated, use `ga.mul.of_basis_blades`",
+            DeprecationWarning, stacklevel=2)
         return self.mul.of_basis_blades(*blade12)
 
     def reduce_basis(self, blst):
@@ -1416,6 +1439,10 @@ class Ga(metric.Metric):
         return sgn, lst
 
     def wedge_product_basis_blades(self, blade12: Tuple[Symbol, Symbol]) -> Expr:
+        # galgebra 0.5.0
+        warnings.warn(
+            "`ga.wedge_product_basis_blades` is deprecated, use `ga.wedge.of_basis_blades`",
+            DeprecationWarning, stacklevel=2)
         return self.wedge.of_basis_blades(*blade12)
 
     # ***** Dot (|) product, reft (<) and right (>) contractions ***** #
@@ -1431,15 +1458,29 @@ class Ga(metric.Metric):
             raise ValueError('mode={!r} not allowed'.format(mode))
 
     def dot_product_basis_blades(self, blade12: Tuple[Symbol, Symbol], mode: str) -> Expr:
+        # galgebra 0.5.0
+        warnings.warn(
+            "`ga.dot_product_basis_blades` is deprecated, use `ga.<which-dot>.of_basis_blades` "
+            "where `<which-dot>` is one of `hestenes_dot`, `left_contract`, and `right_contract`",
+            DeprecationWarning, stacklevel=2)
         return self._dot_product_method(mode)._of_basis_blades_ortho(*blade12)
 
     def non_orthogonal_dot_product_basis_blades(self, blade12: Tuple[Symbol, Symbol], mode: str) -> Expr:
+        # galgebra 0.5.0
+        warnings.warn(
+            "`ga.non_orthogonal_dot_product_basis_blades` is deprecated, use `ga.<which-dot>.of_basis_blades` "
+            "where `<which-dot>` is one of `hestenes_dot`, `left_contract`, and `right_contract`",
+            DeprecationWarning, stacklevel=2)
         return self._dot_product_method(mode)._of_basis_blades_non_ortho(*blade12)
 
     ############# Non-Orthogonal Tables and Dictionaries ###############
 
     @property
     def basic_mul_table_dict(self) -> OrderedDict[Mul, Expr]:
+        # galgebra 0.5.0
+        warnings.warn(
+            "`ga.basic_mul_table_dict` is deprecated, use `ga.mul.table_dict`",
+            DeprecationWarning, stacklevel=2)
         return self.basic_mul.table_dict
 
     @property
@@ -1467,6 +1508,10 @@ class Ga(metric.Metric):
         return list(self.basic_mul.table_dict.values())
 
     def non_orthogonal_bases_products(self, base12: Tuple[Symbol, Symbol]) -> Expr:
+        # galgebra 0.5.0
+        warnings.warn(
+            "`ga.non_orthogonal_bases_products` is deprecated, use `ga.basic_mul.of_basis_bases`",
+            DeprecationWarning, stacklevel=2)
         return self.basic_mul.of_basis_bases(*base12)
 
     @_cached_property

--- a/test/test_test.py
+++ b/test/test_test.py
@@ -559,30 +559,38 @@ class TestTest:
         with pytest.warns(DeprecationWarning):
             ga.lt_coords
 
-    def test_aliases(self):
-        """ Tests of trivial getters which are aliases of other attributes.
+        # more aliases
+        with pytest.warns(DeprecationWarning):
+            ga.mul_table_dict
+        with pytest.warns(DeprecationWarning):
+            ga.wedge_table_dict
+        with pytest.warns(DeprecationWarning):
+            ga.dot_table_dict
+        with pytest.warns(DeprecationWarning):
+            ga.left_contract_table_dict
+        with pytest.warns(DeprecationWarning):
+            ga.right_contract_table_dict
+        with pytest.warns(DeprecationWarning):
+            ga.basic_mul_table_dict
 
-        These may merge into test_deprecated in future
-        """
-        ga, e_1, e_2, e_3 = Ga.build('e*1|2|3')
-
-        ga.mul_table_dict
-        ga.wedge_table_dict
-        ga.dot_table_dict
-        ga.left_contract_table_dict
-        ga.right_contract_table_dict
-        ga.basic_mul_table_dict
-
-        assert ga.geometric_product_basis_blades((e_1.obj, e_2.obj)) == (e_1 * e_2).obj
-        assert ga.wedge_product_basis_blades((e_1.obj, e_2.obj)) == (e_1 ^ e_2).obj
+        with pytest.warns(DeprecationWarning):
+            assert ga.geometric_product_basis_blades((e_1.obj, e_2.obj)) == (e_1 * e_2).obj
+        with pytest.warns(DeprecationWarning):
+            assert ga.wedge_product_basis_blades((e_1.obj, e_2.obj)) == (e_1 ^ e_2).obj
         e_12 = e_1 ^ e_2
-        assert ga.non_orthogonal_dot_product_basis_blades((e_1.obj, e_12.obj), mode='|') == (e_1 | e_12).obj
-        assert ga.non_orthogonal_dot_product_basis_blades((e_1.obj, e_12.obj), mode='<') == (e_1 < e_12).obj
-        assert ga.non_orthogonal_dot_product_basis_blades((e_1.obj, e_12.obj), mode='>') == (e_1 > e_12).obj
+        with pytest.warns(DeprecationWarning):
+            assert ga.non_orthogonal_dot_product_basis_blades((e_1.obj, e_12.obj), mode='|') == (e_1 | e_12).obj
+        with pytest.warns(DeprecationWarning):
+            assert ga.non_orthogonal_dot_product_basis_blades((e_1.obj, e_12.obj), mode='<') == (e_1 < e_12).obj
+        with pytest.warns(DeprecationWarning):
+            assert ga.non_orthogonal_dot_product_basis_blades((e_1.obj, e_12.obj), mode='>') == (e_1 > e_12).obj
 
         # test the member that is nonsense unless in an orthonormal algebra
         ga_ortho, e_1, e_2, e_3 = Ga.build('e*1|2|3', g=[1, 1, 1])
         e_12 = e_1 ^ e_2
-        assert ga_ortho.dot_product_basis_blades((e_1.obj, e_12.obj), mode='|') == (e_1 | e_12).obj
-        assert ga_ortho.dot_product_basis_blades((e_1.obj, e_12.obj), mode='<') == (e_1 < e_12).obj
-        assert ga_ortho.dot_product_basis_blades((e_1.obj, e_12.obj), mode='>') == (e_1 > e_12).obj
+        with pytest.warns(DeprecationWarning):
+            assert ga_ortho.dot_product_basis_blades((e_1.obj, e_12.obj), mode='|') == (e_1 | e_12).obj
+        with pytest.warns(DeprecationWarning):
+            assert ga_ortho.dot_product_basis_blades((e_1.obj, e_12.obj), mode='<') == (e_1 < e_12).obj
+        with pytest.warns(DeprecationWarning):
+            assert ga_ortho.dot_product_basis_blades((e_1.obj, e_12.obj), mode='>') == (e_1 > e_12).obj


### PR DESCRIPTION
This makes a reasonable dent in #196.

It's fairly likely these weren't intended to be public anyway, but they seem reasonably harmless to expose publically in a nested object.