### PR TITLE
Remove Ga.X(), which is a worse spelling of Ga.coord_vec

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 
 - :feature:`326` The :meth:`galgebra.ga.Ga.make_grad` function now accepts multivectors, not just vectors.
 
-- :support:`334` The undocumented method :meth:`galgebra.ga.Ga.X` (the same as :attr:`~galgebra.ga.Ga.coords_vec`) has been deprecated.
+- :support:`335` The undocumented method :meth:`galgebra.ga.Ga.X` (the same as :attr:`~galgebra.ga.Ga.coords_vec`) has been deprecated.
 
 - :support:`317` The undocumented attributes :attr:`galgebra.ga.Ga.lt_x` (the same as :attr:`~galgebra.ga.Ga.coords_vec`) and :attr:`galgebra.ga.Ga.lt_coords` (the same as :attr:`~galgebra.ga.Ga.coords`) have been deprecated.
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -4,6 +4,8 @@ Changelog
 
 - :feature:`326` The :meth:`galgebra.ga.Ga.make_grad` function now accepts multivectors, not just vectors.
 
+- :support:`334` The undocumented method :meth:`galgebra.ga.Ga.X` (the same as :attr:`~galgebra.ga.Ga.coords_vec`) has been deprecated.
+
 - :support:`317` The undocumented attributes :attr:`galgebra.ga.Ga.lt_x` (the same as :attr:`~galgebra.ga.Ga.coords_vec`) and :attr:`galgebra.ga.Ga.lt_coords` (the same as :attr:`~galgebra.ga.Ga.coords`) have been deprecated.
 
 - :support:`280` The ``galgebra.utils`` module, which provided Python 2 compatibility helpers, has been deprecated.

--- a/galgebra/ga.py
+++ b/galgebra/ga.py
@@ -814,7 +814,11 @@ class Ga(metric.Metric):
         return mv.Mv('XxXx', 'vector', ga=self)
 
     def X(self):
-        return self.mv(sum([coord*base for coord, base in zip(self.coords, self.basis)]))
+        # galgebra 0.5.0
+        warnings.warn(
+            "ga.X() is deprecated, use `ga.coord_vec` instead",
+            DeprecationWarning, stacklevel=2)
+        return self.coord_vec
 
     @property
     def Pdiffs(self) -> Dict[Symbol, _dop.Pdop]:

--- a/test/test_test.py
+++ b/test/test_test.py
@@ -555,6 +555,13 @@ class TestTest:
 
         # aliases
         with pytest.warns(DeprecationWarning):
+            assert ga.X()
+
+        # derived from
+        ga.coord_vec
+
+        # aliases
+        with pytest.warns(DeprecationWarning):
             ga.lt_x
         with pytest.warns(DeprecationWarning):
             ga.lt_coords


### PR DESCRIPTION
xref #333