### PR TITLE
Add a notebook demonstrating weird bugs in the gsym argument

### DIFF
--- a/examples/ipython/gsym-printing.ipynb
+++ b/examples/ipython/gsym-printing.ipynb
@@ -1,0 +1,476 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Test of the weird printing rules for the `gsym` argument to `Ga`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Constructed without the galgebra printer enabled"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from galgebra.ga import Ga\n",
+    "from sympy import symbols, init_printing\n",
+    "from IPython.display import display\n",
+    "init_printing(use_latex='mathjax')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "coords = symbols('u v', real=True)\n",
+    "f = Ga('e*u|v', gsym='f')\n",
+    "g = Ga('e*u|v', gsym='g')\n",
+    "fc = Ga('e*u|v', coords=coords, gsym='f')\n",
+    "gc = Ga('e*u|v', coords=coords, gsym='g')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that `e_sq` changes after we access the reciprocal blades"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle - \\left (\\mathbf{e}_{u}\\cdot \\mathbf{e}_{u}\\right )  \\left (\\mathbf{e}_{v}\\cdot \\mathbf{e}_{v}\\right )  + \\left (\\mathbf{e}_{u}\\cdot \\mathbf{e}_{v}\\right ) ^{2}$"
+      ],
+      "text/plain": [
+       "                          2\n",
+       "-(eᵤ⋅eᵤ)⋅(eᵥ⋅eᵥ) + (eᵤ⋅eᵥ) "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle - \\left (\\mathbf{e}_{u}\\cdot \\mathbf{e}_{u}\\right )  \\left (\\mathbf{e}_{v}\\cdot \\mathbf{e}_{v}\\right )  + \\left (\\mathbf{e}_{u}\\cdot \\mathbf{e}_{v}\\right ) ^{2}$"
+      ],
+      "text/plain": [
+       "                          2\n",
+       "-(eᵤ⋅eᵤ)⋅(eᵥ⋅eᵥ) + (eᵤ⋅eᵥ) "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "display(f.e_sq)\n",
+    "display(g.e_sq)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "f._reciprocal_blade_dict, g._reciprocal_blade_dict;"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Printed with the default printer. Note that the printing is a little off. This is a bug."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle - 1.0 det(f)$"
+      ],
+      "text/plain": [
+       "-1.0⋅det(f)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle - 1.0 det(g)$"
+      ],
+      "text/plain": [
+       "-1.0⋅det(g)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle - 1.0 \\operatorname{det(f)}{\\left(u,v \\right)}$"
+      ],
+      "text/plain": [
+       "-1.0⋅det(f)(u, v)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle - 1.0 \\operatorname{det(g)}{\\left(u,v \\right)}$"
+      ],
+      "text/plain": [
+       "-1.0⋅det(g)(u, v)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "display(f.e_sq)\n",
+    "display(g.e_sq)\n",
+    "display(fc.e_sq)\n",
+    "display(gc.e_sq)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Printed within an Mv. Note that `g` is printed differently to `f`. This is a bug."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "\\begin{equation*} - 1.0 det(f) \\end{equation*}"
+      ],
+      "text/plain": [
+       "-1.0*det(f)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "\\begin{equation*} - 1.0 det(g) \\end{equation*}"
+      ],
+      "text/plain": [
+       "-1.0*det(g)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "\\begin{equation*} - 1.0 det(f) {\\left (u,v \\right )} \\end{equation*}"
+      ],
+      "text/plain": [
+       "-1.0*det(f)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "\\begin{equation*} - 1.0 \\det\\left ( g \\right ) {\\left (u,v \\right )} \\end{equation*}"
+      ],
+      "text/plain": [
+       "-1.0*det(g)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "display(f.mv(f.e_sq))\n",
+    "display(g.mv(g.e_sq))\n",
+    "display(fc.mv(fc.e_sq))\n",
+    "display(gc.mv(gc.e_sq))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Constructed with the printer enabled"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from galgebra.printer import Format\n",
+    "Format()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "coords = symbols('u v', real=True)\n",
+    "fp = Ga('e*u|v', gsym='f')\n",
+    "gp = Ga('e*u|v', gsym='g')\n",
+    "fcp = Ga('e*u|v', coords=coords, gsym='f')\n",
+    "gcp = Ga('e*u|v', coords=coords, gsym='g')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that `e_sq` changes after we access the reciprocal blades"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle - \\left (\\mathbf{e}_{u}\\cdot \\mathbf{e}_{u}\\right )  \\left (\\mathbf{e}_{v}\\cdot \\mathbf{e}_{v}\\right )  + \\left (\\mathbf{e}_{u}\\cdot \\mathbf{e}_{v}\\right ) ^{2}$"
+      ],
+      "text/plain": [
+       "                          2\n",
+       "-(eᵤ⋅eᵤ)⋅(eᵥ⋅eᵥ) + (eᵤ⋅eᵥ) "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle - \\left (\\mathbf{e}_{u}\\cdot \\mathbf{e}_{u}\\right )  \\left (\\mathbf{e}_{v}\\cdot \\mathbf{e}_{v}\\right )  + \\left (\\mathbf{e}_{u}\\cdot \\mathbf{e}_{v}\\right ) ^{2}$"
+      ],
+      "text/plain": [
+       "                          2\n",
+       "-(eᵤ⋅eᵤ)⋅(eᵥ⋅eᵥ) + (eᵤ⋅eᵥ) "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "display(fp.e_sq)\n",
+    "display(gp.e_sq)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fp._reciprocal_blade_dict, gp._reciprocal_blade_dict;"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Printed with the non-galgebra printer. Note that the rendering is now consistent"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle - 1.0 \\det\\left ( f\\right ) $"
+      ],
+      "text/plain": [
+       "-1.0⋅\\det\\left ( f\\right ) "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle - 1.0 \\det\\left ( g\\right ) $"
+      ],
+      "text/plain": [
+       "-1.0⋅\\det\\left ( g\\right ) "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle - 1.0 \\det\\left ( f\\right ) {\\left(u,v \\right)}$"
+      ],
+      "text/plain": [
+       "-1.0⋅\\det\\left ( f\\right ) (u, v)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle - 1.0 \\det\\left ( g\\right ) {\\left(u,v \\right)}$"
+      ],
+      "text/plain": [
+       "-1.0⋅\\det\\left ( g\\right ) (u, v)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "display(fp.e_sq)\n",
+    "display(gp.e_sq)\n",
+    "display(fcp.e_sq)\n",
+    "display(gcp.e_sq)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Printed within an Mv - now also consistent. Note that the galgebra printer does not show function arguments."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "\\begin{equation*} - 1.0 \\det\\left ( f\\right )  \\end{equation*}"
+      ],
+      "text/plain": [
+       "- 1.0 \\det\\left ( f\\right ) "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "\\begin{equation*} - 1.0 \\det\\left ( g\\right )  \\end{equation*}"
+      ],
+      "text/plain": [
+       "- 1.0 \\det\\left ( g\\right ) "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "\\begin{equation*} - 1.0 \\det\\left ( f\\right )   \\end{equation*}"
+      ],
+      "text/plain": [
+       "- 1.0 \\det\\left ( f\\right )  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "\\begin{equation*} - 1.0 \\det\\left ( g\\right )   \\end{equation*}"
+      ],
+      "text/plain": [
+       "- 1.0 \\det\\left ( g\\right )  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "display(fp.mv(fp.e_sq))\n",
+    "display(gp.mv(gp.e_sq))\n",
+    "display(fcp.mv(fcp.e_sq))\n",
+    "display(gcp.mv(gcp.e_sq))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
There are lots of bugs hiding in here relating to printing, felt it would be best to put in a baseline notebook so that I can fix them as I go along.

Bugs include:

* `g` being treated specially
* `det` often being printed incorrectly
* print behavior changing based on whether the printer was enabled yet when the reciprocal blades were computed
* floats creeping into `e_sq`