### PR TITLE
Remove a pointless docstring that is not attached to anything

### DIFF
--- a/galgebra/printer.py
+++ b/galgebra/printer.py
@@ -1183,15 +1183,6 @@ def GAeval(s: str, pstr: bool = False):
     return eval(seval, _eval_global_dict)
 
 
-r"""
-\begin{array}{c}
-\left ( \begin{array}{c} F,\\ \end{array} \right . \\
-\begin{array}{c} F, \\ \end{array} \\
-\left .\begin{array}{c}         F \\ \end{array} \right ) \\
-\end{array}
-"""
-
-
 def Fmt(obj, fmt=0):
     if isinstance(obj, (list, tuple, dict)):
         n = len(obj)


### PR DESCRIPTION
Cherry-picked from abrombo/master (#62). The rendered latex for this comment would be:

![image](https://user-images.githubusercontent.com/425260/82052877-412d7800-96b4-11ea-893f-08889ba1f059.png)

Of course, this string is not used at all, so this doesn't matter.