### PR TITLE
Remove the `1.0` floats that snuck into ga.e_sq

### DIFF
--- a/examples/ipython/gsym-printing.ipynb
+++ b/examples/ipython/gsym-printing.ipynb
@@ -109,10 +109,10 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle - 1.0 det(f)$"
+       "$\\displaystyle - det(f)$"
       ],
       "text/plain": [
-       "-1.0⋅det(f)"
+       "-det(f)"
       ]
      },
      "metadata": {},
@@ -121,10 +121,10 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle - 1.0 det(g)$"
+       "$\\displaystyle - det(g)$"
       ],
       "text/plain": [
-       "-1.0⋅det(g)"
+       "-det(g)"
       ]
      },
      "metadata": {},
@@ -133,10 +133,10 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle - 1.0 \\operatorname{det(f)}{\\left(u,v \\right)}$"
+       "$\\displaystyle - \\operatorname{det(f)}{\\left(u,v \\right)}$"
       ],
       "text/plain": [
-       "-1.0⋅det(f)(u, v)"
+       "-det(f)(u, v)"
       ]
      },
      "metadata": {},
@@ -145,10 +145,10 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle - 1.0 \\operatorname{det(g)}{\\left(u,v \\right)}$"
+       "$\\displaystyle - \\operatorname{det(g)}{\\left(u,v \\right)}$"
       ],
       "text/plain": [
-       "-1.0⋅det(g)(u, v)"
+       "-det(g)(u, v)"
       ]
      },
      "metadata": {},
@@ -177,10 +177,10 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} - 1.0 det(f) \\end{equation*}"
+       "\\begin{equation*} - det(f) \\end{equation*}"
       ],
       "text/plain": [
-       "-1.0*det(f)"
+       "-det(f)"
       ]
      },
      "metadata": {},
@@ -189,10 +189,10 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} - 1.0 det(g) \\end{equation*}"
+       "\\begin{equation*} - det(g) \\end{equation*}"
       ],
       "text/plain": [
-       "-1.0*det(g)"
+       "-det(g)"
       ]
      },
      "metadata": {},
@@ -201,10 +201,10 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} - 1.0 det(f) {\\left (u,v \\right )} \\end{equation*}"
+       "\\begin{equation*} - det(f) {\\left (u,v \\right )} \\end{equation*}"
       ],
       "text/plain": [
-       "-1.0*det(f)"
+       "-det(f)"
       ]
      },
      "metadata": {},
@@ -213,10 +213,10 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} - 1.0 \\det\\left ( g \\right ) {\\left (u,v \\right )} \\end{equation*}"
+       "\\begin{equation*} - \\det\\left ( g \\right ) {\\left (u,v \\right )} \\end{equation*}"
       ],
       "text/plain": [
-       "-1.0*det(g)"
+       "-det(g)"
       ]
      },
      "metadata": {},
@@ -330,10 +330,10 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle - 1.0 \\det\\left ( f\\right ) $"
+       "$\\displaystyle - \\det\\left ( f\\right ) $"
       ],
       "text/plain": [
-       "-1.0⋅\\det\\left ( f\\right ) "
+       "-\\det\\left ( f\\right ) "
       ]
      },
      "metadata": {},
@@ -342,10 +342,10 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle - 1.0 \\det\\left ( g\\right ) $"
+       "$\\displaystyle - \\det\\left ( g\\right ) $"
       ],
       "text/plain": [
-       "-1.0⋅\\det\\left ( g\\right ) "
+       "-\\det\\left ( g\\right ) "
       ]
      },
      "metadata": {},
@@ -354,10 +354,10 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle - 1.0 \\det\\left ( f\\right ) {\\left(u,v \\right)}$"
+       "$\\displaystyle - \\det\\left ( f\\right ) {\\left(u,v \\right)}$"
       ],
       "text/plain": [
-       "-1.0⋅\\det\\left ( f\\right ) (u, v)"
+       "-\\det\\left ( f\\right ) (u, v)"
       ]
      },
      "metadata": {},
@@ -366,10 +366,10 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle - 1.0 \\det\\left ( g\\right ) {\\left(u,v \\right)}$"
+       "$\\displaystyle - \\det\\left ( g\\right ) {\\left(u,v \\right)}$"
       ],
       "text/plain": [
-       "-1.0⋅\\det\\left ( g\\right ) (u, v)"
+       "-\\det\\left ( g\\right ) (u, v)"
       ]
      },
      "metadata": {},
@@ -398,10 +398,10 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} - 1.0 \\det\\left ( f\\right )  \\end{equation*}"
+       "\\begin{equation*} - \\det\\left ( f\\right )  \\end{equation*}"
       ],
       "text/plain": [
-       "- 1.0 \\det\\left ( f\\right ) "
+       "- \\det\\left ( f\\right ) "
       ]
      },
      "metadata": {},
@@ -410,10 +410,10 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} - 1.0 \\det\\left ( g\\right )  \\end{equation*}"
+       "\\begin{equation*} - \\det\\left ( g\\right )  \\end{equation*}"
       ],
       "text/plain": [
-       "- 1.0 \\det\\left ( g\\right ) "
+       "- \\det\\left ( g\\right ) "
       ]
      },
      "metadata": {},
@@ -422,10 +422,10 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} - 1.0 \\det\\left ( f\\right )   \\end{equation*}"
+       "\\begin{equation*} - \\det\\left ( f\\right )   \\end{equation*}"
       ],
       "text/plain": [
-       "- 1.0 \\det\\left ( f\\right )  "
+       "- \\det\\left ( f\\right )  "
       ]
      },
      "metadata": {},
@@ -434,10 +434,10 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} - 1.0 \\det\\left ( g\\right )   \\end{equation*}"
+       "\\begin{equation*} - \\det\\left ( g\\right )   \\end{equation*}"
       ],
       "text/plain": [
-       "- 1.0 \\det\\left ( g\\right )  "
+       "- \\det\\left ( g\\right )  "
       ]
      },
      "metadata": {},

--- a/galgebra/ga.py
+++ b/galgebra/ga.py
@@ -1878,10 +1878,10 @@ class Ga(metric.Metric):
                 # determinant
                 n = self.n
                 if self.coords is None:  # Metric tensor is constant
-                    self.e_sq = (-1) ** (n*(n - 1)/2) * Symbol(det_str, real=True)
+                    self.e_sq = (-1) ** (n*(n - 1)//2) * Symbol(det_str, real=True)
                 else:  # Metric tensor is function of coordinates
                     n = len(self.coords)
-                    self.e_sq = (-1) ** (n*(n - 1)/2) * Function(det_str, real=True)(*self.coords)
+                    self.e_sq = (-1) ** (n*(n - 1)//2) * Function(det_str, real=True)(*self.coords)
             else:
                 self.e_sq = simplify((self.e * self.e).obj)
             if self.debug:


### PR DESCRIPTION
These was caused by a floating point division in an exponent. Since `n` is an integer, `n*(n+1)` is always even, so we can use floor division and end up with an `int` rather than a `float`.