### PR TITLE
Do not generate `reflect_test.tex` every time any test is run

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,12 @@
 [test]
 test_suite = test
 
+[tool:pytest]
+# The default also includes *_test.py. This matches some example scripts, which are
+# not tests at all, and perform unwanted work and global configuration when
+# pytest scans them for tests.
+python_files = test_*.py
+
 [flake8]
 
 # for now, just check the main code


### PR DESCRIPTION
No idea why coverage changed, but I don't think it matters here.