### PR TITLE
Remove GaPrinter._print_Matrix

### DIFF
--- a/galgebra/printer.py
+++ b/galgebra/printer.py
@@ -368,10 +368,6 @@ class GaPrinter(StrPrinter):
         s += str(self._print(function))
         return Eprint.Deriv(s)
 
-    def _print_Matrix(self, expr):
-        out_str = ostr(list(expr))
-        return out_str
-
 
 Basic.__ga_print_str__ = lambda self: GaPrinter().doprint(self)
 Matrix.__ga_print_str__ = lambda self: GaPrinter().doprint(self)


### PR DESCRIPTION
This code is unreachable, because `GaPrinter().doprint(x)` dispatches via `type(x).__name__`, and `Matrix.__name__` is actually `MutableDenseMatrix`.
If you do run this code, the identity matrix prints as `\n[1,0,0,1]` which is nonsense anyway.