### PR TITLE
Fix CI failures on sympy master

### DIFF
--- a/test/.nbval_sanitize.cfg
+++ b/test/.nbval_sanitize.cfg
@@ -44,3 +44,7 @@ replace: \\operatorname{F^{\1}}^{2}
 # sympy master does not bold subscripts of bold symbols
 regex: \\mathbf\{(\w+)_\{(\w+)}}
 replace: \\mathbf{\1}_{\2}
+
+# sympy master shows trailing commas on 1-tuples. This replacement is easier to do in reverse.
+regex: ,\\right\)
+replace: \\right)


### PR DESCRIPTION
I made a PR to sympy that affected how tuples print out (sympy/sympy#19348)

A failing CI run is here: https://circleci.com/gh/pygae/galgebra/5213?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link