### PR TITLE
Remove unused global printer properties

### DIFF
--- a/examples/LaTeX/FmtChk.py
+++ b/examples/LaTeX/FmtChk.py
@@ -19,7 +19,7 @@ print(B.Fmt(3))
 lap = o3d.grad*o3d.grad
 print(r'%\nabla^{2} = \nabla\cdot\nabla =', lap)
 dop = lap + o3d.grad
-print(dop.Fmt(fmt=3,dop_fmt=3))
+print(dop.Fmt(fmt=3))
 
 # xpdf(paper=(6, 7))
 xpdf(pdfprog=None, paper=(6, 7))

--- a/galgebra/mv.py
+++ b/galgebra/mv.py
@@ -1451,7 +1451,7 @@ class Dop(dop._BaseDop):
                 'In Dop.__init__ terms are neither (Mv, Pdop) pairs or '
                 '(Sdop, Mv) pairs, got {}'.format(terms))
 
-    def __init__(self, *args, ga: 'Ga', cmpflg: bool = False, debug: bool = False, fmt_dop: int = 1) -> None:
+    def __init__(self, *args, ga: 'Ga', cmpflg: bool = False, debug: bool = False) -> None:
         """
         Parameters
         ----------
@@ -1461,15 +1461,12 @@ class Dop(dop._BaseDop):
             Complement flag for Dop
         debug : bool
             True to print out debugging information
-        fmt_dop :
-            1 for normal dop partial derivative formatting
         """
         if ga is None:
             raise ValueError('ga argument to Dop() must not be None')
 
         self.cmpflg = cmpflg
         self.Ga = ga
-        self.dop_fmt = fmt_dop
         self.title = None
 
         if len(args) == 2:
@@ -1787,13 +1784,11 @@ class Dop(dop._BaseDop):
         dop.Sdop.str_mode = False
         return s[:-3]
 
-    def Fmt(self, fmt: int = 1, title: str = None, dop_fmt: int = None) -> Union['Dop', str]:
+    def Fmt(self, fmt: int = 1, title: str = None) -> Union['Dop', str]:
         if printer.GaLatexPrinter.latex_flg:
             printer.GaLatexPrinter.prev_fmt = printer.GaLatexPrinter.fmt
-            printer.GaLatexPrinter.prev_dop_fmt = printer.GaLatexPrinter.dop_fmt
         else:
             printer.GaPrinter.prev_fmt = printer.GaPrinter.fmt
-            printer.GaPrinter.prev_dop_fmt = printer.GaPrinter.dop_fmt
 
         if title is not None:
             self.title = title
@@ -1807,7 +1802,6 @@ class Dop(dop._BaseDop):
             s = printer.GaPrinter().doprint(self)
 
         printer.GaPrinter.fmt = printer.GaPrinter.prev_fmt
-        printer.GaPrinter.dop_fmt = printer.GaPrinter.prev_dop_fmt
 
         if title is not None:
             return title + ' = ' + s

--- a/galgebra/printer.py
+++ b/galgebra/printer.py
@@ -291,8 +291,6 @@ class GaPrinter(StrPrinter):
     str_flg = True
     prev_fmt = 1
     fmt = 1
-    dop_fmt =1
-    prev_dop_fmt = 1
     lt_fmt = 1
     prev_lt_fmt = 1
 
@@ -429,8 +427,6 @@ class GaLatexPrinter(LatexPrinter):
 
     fmt = 1
     prev_fmt = 1
-    dop_fmt =1
-    prev_dop_fmt = 1
     lt_fmt = 1
     prev_lt_fmt = 1
 

--- a/galgebra/printer.py
+++ b/galgebra/printer.py
@@ -288,7 +288,6 @@ class GaPrinter(StrPrinter):
                       'cosh', 'cot', 'coth', 'exp', 'floor', 'im', 'log', 're',
                       'root', 'sin', 'sinh', 'sqrt', 'sign', 'tan', 'tanh', 'Abs')
 
-    str_flg = True
     prev_fmt = 1
     fmt = 1
 

--- a/galgebra/printer.py
+++ b/galgebra/printer.py
@@ -291,8 +291,6 @@ class GaPrinter(StrPrinter):
     str_flg = True
     prev_fmt = 1
     fmt = 1
-    lt_fmt = 1
-    prev_lt_fmt = 1
 
     def _print_Function(self, expr):
         name = expr.func.__name__
@@ -427,8 +425,6 @@ class GaLatexPrinter(LatexPrinter):
 
     fmt = 1
     prev_fmt = 1
-    lt_fmt = 1
-    prev_lt_fmt = 1
 
     latex_flg = False
     latex_str = ''


### PR DESCRIPTION
As far as I could tell, none of these do anything. Let's just remove them.