### PR TITLE
Remove buffering artifacts from Terminal.ipynb

### DIFF
--- a/examples/ipython/Terminal.ipynb
+++ b/examples/ipython/Terminal.ipynb
@@ -98,13 +98,7 @@
       "-I*(grad^A) =  (-\u001b[0;36mD{z}\u001b[0;31mA__y\u001b[0m\u001b[0m + \u001b[0;36mD{y}\u001b[0;31mA__z\u001b[0m\u001b[0m)*\u001b[0;34me_x\u001b[0m + (\u001b[0;36mD{z}\u001b[0;31mA__x\u001b[0m\u001b[0m - \u001b[0;36mD{x}\u001b[0;31mA__z\u001b[0m\u001b[0m)*\u001b[0;34me_y\u001b[0m + (-\u001b[0;36mD{y}\u001b[0;31mA__x\u001b[0m\u001b[0m + \u001b[0;36mD{x}\u001b[0;31mA__y\u001b[0m\u001b[0m)*\u001b[0;34me_z\u001b[0m\n",
       "grad*B =  (-\u001b[0;36mD{y}\u001b[0;31mB__xy\u001b[0m\u001b[0m - \u001b[0;36mD{z}\u001b[0;31mB__xz\u001b[0m\u001b[0m)*\u001b[0;34me_x\u001b[0m + (\u001b[0;36mD{x}\u001b[0;31mB__xy\u001b[0m\u001b[0m - \u001b[0;36mD{z}\u001b[0;31mB__yz\u001b[0m\u001b[0m)*\u001b[0;34me_y\u001b[0m + (\u001b[0;36mD{x}\u001b[0;31mB__xz\u001b[0m\u001b[0m + \u001b[0;36mD{y}\u001b[0;31mB__yz\u001b[0m\u001b[0m)*\u001b[0;34me_z\u001b[0m\n",
       " + (\u001b[0;36mD{z}\u001b[0;31mB__xy\u001b[0m\u001b[0m - \u001b[0;36mD{y}\u001b[0;31mB__xz\u001b[0m\u001b[0m + \u001b[0;36mD{x}\u001b[0;31mB__yz\u001b[0m\u001b[0m)*\u001b[0;34me_x\u001b[0m^\u001b[0;34me_y\u001b[0m^\u001b[0;34me_z\u001b[0m\n",
-      "grad^B = (\u001b[0;36mD{z}\u001b[0;31mB__xy\u001b[0m\u001b[0m - \u001b[0;36mD{y}\u001b[0;31mB__xz\u001b[0m\u001b[0m + \u001b[0;36mD{x}\u001b[0;31mB__yz\u001b[0m\u001b[0m)*\u001b[0;34me_x\u001b[0m^\u001b[0;34me_y\u001b[0m^\u001b[0;34me_z\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "grad^B = (\u001b[0;36mD{z}\u001b[0;31mB__xy\u001b[0m\u001b[0m - \u001b[0;36mD{y}\u001b[0;31mB__xz\u001b[0m\u001b[0m + \u001b[0;36mD{x}\u001b[0;31mB__yz\u001b[0m\u001b[0m)*\u001b[0;34me_x\u001b[0m^\u001b[0;34me_y\u001b[0m^\u001b[0;34me_z\u001b[0m\n",
       "grad|B =  (-\u001b[0;36mD{y}\u001b[0;31mB__xy\u001b[0m\u001b[0m - \u001b[0;36mD{z}\u001b[0;31mB__xz\u001b[0m\u001b[0m)*\u001b[0;34me_x\u001b[0m + (\u001b[0;36mD{x}\u001b[0;31mB__xy\u001b[0m\u001b[0m - \u001b[0;36mD{z}\u001b[0;31mB__yz\u001b[0m\u001b[0m)*\u001b[0;34me_y\u001b[0m + (\u001b[0;36mD{x}\u001b[0;31mB__xz\u001b[0m\u001b[0m + \u001b[0;36mD{y}\u001b[0;31mB__yz\u001b[0m\u001b[0m)*\u001b[0;34me_z\u001b[0m\n",
       "grad<A = \u001b[0;36mD{x}\u001b[0;31mA__x\u001b[0m\u001b[0m + \u001b[0;36mD{y}\u001b[0;31mA__y\u001b[0m\u001b[0m + \u001b[0;36mD{z}\u001b[0;31mA__z\u001b[0m\u001b[0m\n",
       "grad>A = \u001b[0;36mD{x}\u001b[0;31mA__x\u001b[0m\u001b[0m + \u001b[0;36mD{y}\u001b[0;31mA__y\u001b[0m\u001b[0m + \u001b[0;36mD{z}\u001b[0;31mA__z\u001b[0m\u001b[0m\n",
@@ -197,13 +191,7 @@
       "Sphere through a, b, c, and d\n",
       "Sphere: A^B^C^D^X = 0 = (-x1**2/2 - x2**2/2 - x3**2/2 + 1/2)*\u001b[0;34me_1\u001b[0m^\u001b[0;34me_2\u001b[0m^\u001b[0;34me_3\u001b[0m^\u001b[0;34mn\u001b[0m^\u001b[0;34mnbar\u001b[0m\n",
       "Plane through a, b, and d\n",
-      "Plane : A^B^n^D^X = 0 = (-x1/2 - x2/2 - x3/2 + 1/2)*\u001b[0;34me_1\u001b[0m^\u001b[0;34me_2\u001b[0m^\u001b[0;34me_3\u001b[0m^\u001b[0;34mn\u001b[0m^\u001b[0;34mnbar\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Plane : A^B^n^D^X = 0 = (-x1/2 - x2/2 - x3/2 + 1/2)*\u001b[0;34me_1\u001b[0m^\u001b[0;34me_2\u001b[0m^\u001b[0;34me_3\u001b[0m^\u001b[0;34mn\u001b[0m^\u001b[0;34mnbar\u001b[0m\n",
       " -x3*\u001b[0;34me_1\u001b[0m^\u001b[0;34me_2\u001b[0m^\u001b[0;34me_3\u001b[0m^\u001b[0;34mn\u001b[0m\n",
       " - x3*\u001b[0;34me_1\u001b[0m^\u001b[0;34me_2\u001b[0m^\u001b[0;34me_3\u001b[0m^\u001b[0;34mnbar\u001b[0m\n",
       " + (-x1**2/2 + x1 - x2**2/2 + x2 - x3**2/2 - 1/2)*\u001b[0;34me_1\u001b[0m^\u001b[0;34me_2\u001b[0m^\u001b[0;34mn\u001b[0m^\u001b[0;34mnbar\u001b[0m\n",


### PR DESCRIPTION
These are caused by ipython deciding to render partial results.
nbval ignores these, and they make it harder to inspect diffs in the ipynb files as they move around randomly.