### PR TITLE
Add a tutorial taken from Alan's branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,8 +17,23 @@ defaults: &defaults
     - run:
         name: Test
         command: |
+          # we can't pass lists of arguments with spaces through environment
+          # variables, so reassemble the list here
+          PYTEST_ARGS=();
+          if [[ ! -z "$PYTEST_K_FILTER" ]]; then
+            PYTEST_ARGS+=(-k "$PYTEST_K_FILTER");
+          fi;
+
           mkdir -p test-reports/pytest
-          pytest -n 2 --dist loadscope --cov=galgebra --nbval examples/ipython/ test --current-env --sanitize-with test/.nbval_sanitize.cfg --junitxml=test-reports/pytest/results.xml
+          pytest -n 2 \
+            --dist loadscope \
+            --cov=galgebra \
+            --nbval examples/ipython/ \
+            test \
+            --current-env \
+            --sanitize-with test/.nbval_sanitize.cfg \
+            --junitxml=test-reports/pytest/results.xml \
+            "${PYTEST_ARGS[@]}"
     - run:
         name: Coverage
         when: on_success
@@ -88,6 +103,9 @@ jobs:
       - image: circleci/python:3.6
   "python-3.5":
     <<: *defaults
+    environment:
+      # the tutorial uses Python 3.6 syntax, for convenience.
+      PYTEST_K_FILTER: not examples/ipython/tutorial_algebra.ipynb
     docker:
       - image: circleci/python:3.5
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -38,6 +38,7 @@ author = 'Alan Bromborsky'
 # ones.
 extensions = [
     'nbsphinx',
+    'nbsphinx_link',
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
     'sphinx.ext.intersphinx',

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -12,12 +12,19 @@
     galgebra_guide
     sympy-representation
     module-components
-    bibliography
 
 .. toctree::
+    :caption: Tutorials
+    :maxdepth: 2
+
+    tutorials/algebra
+
+.. toctree::
+    :caption: Other information
     :maxdepth: 2
 
     changelog
+    bibliography
 
 Indices and tables
 ==================

--- a/doc/readthedocs-pip-requirements.txt
+++ b/doc/readthedocs-pip-requirements.txt
@@ -20,3 +20,6 @@ semantic-version==2.6.0
 releases>=1.6.1
 sphinxcontrib-bibtex
 nbsphinx-link
+
+# the first release to support f-strings
+pygments >= 2.5.0

--- a/doc/readthedocs-pip-requirements.txt
+++ b/doc/readthedocs-pip-requirements.txt
@@ -19,3 +19,4 @@ m2r
 semantic-version==2.6.0
 releases>=1.6.1
 sphinxcontrib-bibtex
+nbsphinx-link

--- a/doc/tutorials/algebra.nblink
+++ b/doc/tutorials/algebra.nblink
@@ -1,0 +1,3 @@
+{
+    "path": "../../examples/ipython/tutorial_algebra.ipynb"
+}

--- a/examples/ipython/tutorial_algebra.ipynb
+++ b/examples/ipython/tutorial_algebra.ipynb
@@ -4,129 +4,37 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This is a tutorial to introduce you to galgebra3 which is a symbolic geometric algebra library for python3.  One of the main reasons it uses python3 instead of python2.7 is that it also uses the symbolic algebra library sympy and sympy will no longer be supporting python3.\n",
+    "# Introduction to using GAlgebra\n",
+    "\n",
+    "This is a tutorial to introduce you to `galgebra`, a symbolic geometric algebra library for python.\n",
     "\n",
     "A geometric algebra is defined by a set of symbols that represent the basis vectors of a real vector space, a metric tensor, and possible a set of coordinate symbols.  If coordinates are defined the metric tensor can be a function of them.\n",
     "\n",
-    "The following cell imports all the functions needed in the tutorial from `sympy`, `ga`, `mv`, and `printer`.  The `Format()` function enables LaTeX output and allows the `python 3` print function to be used for LaTex output in the same way as in `python 3` that is not executed through Jupyter Notebook.\n",
-    "\n",
-    "Using the print function allows one to annotate the output and to print multiple lines in a single output cell.  There are examples in the code below.\n",
-    "\n",
-    "When in the Latex output mode initiated by executing `Format()` all output is in LaTeX equation mode. The following LaTeX macros are defined by `Format()`:\n",
-    "\n",
-    "```\\newcommand{\\bfrac}[2]{\\displaystyle\\frac{#1}{#2}}\n",
-    "\\newcommand{\\lp}{\\left (}\n",
-    "\\newcommand{\\rp}{\\right )}\n",
-    "\\newcommand{\\paren}[1]{\\lp {#1} \\rp}\n",
-    "\\newcommand{\\half}{\\frac{1}{2}}\n",
-    "\\newcommand{\\llt}{\\left <}\n",
-    "\\newcommand{\\rgt}{\\right >}\n",
-    "\\newcommand{\\abs}[1]{\\left |{#1}\\right | }\n",
-    "\\newcommand{\\pdiff}[2]{\\bfrac{\\partial {#1}}{\\partial {#2}}}\n",
-    "\\newcommand{\\npdiff}[3]{\\bfrac{\\partial^{#3} {#1}}{\\partial {#2}^{#3}}}\n",
-    "\\newcommand{\\lbrc}{\\left \\{}\n",
-    "\\newcommand{\\rbrc}{\\right \\}}\n",
-    "\\newcommand{\\W}{\\wedge}\n",
-    "\\newcommand{\\prm}[1]{{#1}'}\n",
-    "\\newcommand{\\ddt}[1]{\\bfrac{d{#1}}{dt}}\n",
-    "\\newcommand{\\R}{\\dagger}\n",
-    "\\newcommand{\\deriv}[3]{\\bfrac{d^{#3}#1}{d{#2}^{#3}}}\n",
-    "\\newcommand{\\grd}[1]{\\left < {#1} \\right >}\n",
-    "\\newcommand{\\f}[2]{{#1}\\lp {#2} \\rp}\n",
-    "\\newcommand{\\eval}[2]{\\left . {#1} \\right |_{#2}}\n",
-    "\\newcommand{\\bs}[1]{\\boldsymbol{#1}}\n",
-    "\\newcommand{\\es}[1]{\\boldsymbol{e}_{#1}}\n",
-    "\\newcommand{\\eS}[1]{\\boldsymbol{e}^{#1}}\n",
-    "\\newcommand{\\grade}[2]{\\left < {#1} \\right >_{#2}}\n",
-    "\\newcommand{\\lc}{\\rfloor}\n",
-    "\\newcommand{\\rc}{\\lfloor}\n",
-    "\\newcommand{\\T}[1]{\\text{#1}}\n",
-    "\\newcommand{\\lop}[1]{\\overleftarrow{#1}}\n",
-    "\\newcommand{\\rop}[1]{\\overrightarrow{#1}}```\n",
-    "\n",
-    "So to print a string in text (not equation) mode use the code -\n",
-    "\n",
-    "```print(r'\\text{This is a string in text mode.}')```.\n",
-    "\n",
-    "Likewise if you wish to annotate a multivector `M` the print command could be -\n",
-    "\n",
-    "```print('M =',M)```,\n",
-    "\n",
-    "or if you wish the annotation to be in a bold font -\n",
-    "\n",
-    "```print(r'\\bs{M} =',M)```,\n",
-    "\n",
-    "finally if you wish a line draw above and below the ouput -\n",
-    "\n",
-    "```print('h',r'\\bs{M} =',M)```.\n",
-    "\n",
-    "All of the macros defined above can be used in text strings in print functions.\n"
+    "The following cell imports all the functions needed in the tutorial from `sympy`, `ga`, and `printer`."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "$\\displaystyle \n",
-       "\\newcommand{\\bfrac}[2]{\\displaystyle\\frac{#1}{#2}}\n",
-       "\\newcommand{\\lp}{\\left (}\n",
-       "\\newcommand{\\rp}{\\right )}\n",
-       "\\newcommand{\\paren}[1]{\\lp {#1} \\rp}\n",
-       "\\newcommand{\\half}{\\frac{1}{2}}\n",
-       "\\newcommand{\\llt}{\\left <}\n",
-       "\\newcommand{\\rgt}{\\right >}\n",
-       "\\newcommand{\\abs}[1]{\\left |{#1}\\right | }\n",
-       "\\newcommand{\\pdiff}[2]{\\bfrac{\\partial {#1}}{\\partial {#2}}}\n",
-       "\\newcommand{\\npdiff}[3]{\\bfrac{\\partial^{#3} {#1}}{\\partial {#2}^{#3}}}\n",
-       "\\newcommand{\\lbrc}{\\left \\{}\n",
-       "\\newcommand{\\rbrc}{\\right \\}}\n",
-       "\\newcommand{\\W}{\\wedge}\n",
-       "\\newcommand{\\prm}[1]{{#1}'}\n",
-       "\\newcommand{\\ddt}[1]{\\bfrac{d{#1}}{dt}}\n",
-       "\\newcommand{\\grade}[1]{\\left < {#1} \\right >}\n",
-       "\\newcommand{\\f}[2]{{#1}\\lp {#2} \\rp}\n",
-       "\\newcommand{\\eval}[2]{\\left . {#1} \\right |_{#2}}\n",
-       "\\newcommand{\\R}{\\dagger}\n",
-       "\\newcommand{\\deriv}[3]{\\bfrac{d^{#3}#1}{d{#2}^{#3}}}\n",
-       "\\newcommand{\\grd}[2]{\\left < {#1} \\right >_{#2}}\n",
-       "\\newcommand{\\f}[2]{{#1}\\lp {#2} \\rp}\n",
-       "\\newcommand{\\eval}[2]{\\left . {#1} \\right |_{#2}}\n",
-       "\\newcommand{\\bs}[1]{\\boldsymbol{#1}}\n",
-       "\\newcommand{\\es}[1]{\\boldsymbol{e}_{#1}}\n",
-       "\\newcommand{\\eS}[1]{\\boldsymbol{e}^{#1}}\n",
-       "\\newcommand{\\lc}{\\rfloor}\n",
-       "\\newcommand{\\rc}{\\lfloor}\n",
-       "\\newcommand{\\T}[1]{\\text{#1}}\n",
-       "\\newcommand{\\lop}[1]{\\overleftarrow{#1}}\n",
-       "\\newcommand{\\rop}[1]{\\overrightarrow{#1}}\n",
-       "$"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Math object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "from sympy import symbols, sin, cos\n",
+    "import sympy\n",
     "from galgebra.ga import Ga\n",
-    "from galgebra.mv import Mv\n",
-    "from galgebra.printer import Format, gprint\n",
-    "from IPython.display import display, Latex, Math, display_latex\n",
-    "Format()"
+    "from galgebra.printer import latex\n",
+    "from IPython.display import Math\n",
+    "\n",
+    "# tell sympy to use our printing by default\n",
+    "sympy.init_printing(latex_printer=latex, use_latex='mathjax')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To start with we will define the geometric algebra of a 3 dimensional Euclidaen vector space, `o3d`, with coordinates $x$, $y$, and $z$ and unit vectors $e_x$, $e_y$, and $e_z$."
+    "## Printing in sympy\n",
+    "\n",
+    "Sympy will show pretty $\\LaTeX$ renderings of symbolic expressions by default"
    ]
   },
   {
@@ -135,16 +43,71 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "ABC = \\text{X}\n"
-     ]
+     "data": {
+      "text/latex": [
+       "$\\displaystyle n^{2}$"
+      ],
+      "text/plain": [
+       " 2\n",
+       "n "
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "xyz = (x, y, z) = symbols('x y z', real=True)\n",
-    "o3d = Ga('e_x e_y e_z', g = [1,1,1], coords=xyz)\n",
+    "sympy.S('n')**2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "But if we want to append freeform text on the same line, we must use `Math`, `latex`, and f-strings in tandem:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle y = n^{2}$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Math(f\"y = { latex(sympy.S('n')**2) }\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Creating an algebra\n",
+    "\n",
+    "To start with we will define the geometric algebra of a 3 dimensional Euclidaen vector space, `o3d`, with coordinates $x$, $y$, and $z$ and unit vectors $e_x$, $e_y$, and $e_z$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xyz = (x, y, z) = sympy.symbols('x y z', real=True)\n",
+    "o3d = Ga('e_x e_y e_z', g=[1, 1, 1], coords=xyz)\n",
     "grad = o3d.grad"
    ]
   },
@@ -157,24 +120,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle g = \\left [ \\begin{array}{ccc} 1 & 0 & 0  \\\\ 0 & 1 & 0  \\\\ 0 & 0 & 1  \\end{array}\\right ] $"
+       "$\\displaystyle g = \\left[\\begin{array}{ccc}1 & 0 & 0\\\\0 & 1 & 0\\\\0 & 0 & 1\\end{array}\\right]$"
       ],
       "text/plain": [
        "<IPython.core.display.Math object>"
       ]
      },
+     "execution_count": 5,
      "metadata": {},
-     "output_type": "display_data"
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "gprint('g =',o3d.g)"
+    "Math(f'g = {latex(o3d.g)}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Creating multivectors"
    ]
   },
   {
@@ -186,67 +157,94 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle \\text{Scalar:}S =S$"
+       "\\begin{equation*} S = S \\end{equation*}"
       ],
       "text/plain": [
-       "<IPython.core.display.Math object>"
+       "S"
       ]
      },
+     "execution_count": 6,
      "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/latex": [
-       "$\\displaystyle \\text{Vector:}V =V^{x} \\boldsymbol{e}_{x} + V^{y} \\boldsymbol{e}_{y} + V^{z} \\boldsymbol{e}_{z}$"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Math object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/latex": [
-       "$\\displaystyle \\text{Bivector:}B =B^{xy} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + B^{xz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + B^{yz} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}$"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Math object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/latex": [
-       "$\\displaystyle \\text{Pseudoscalar:}I =I^{xyz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}$"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Math object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "S = o3d.mv('S', 'scalar')\n",
-    "V = o3d.mv('V', 'vector')\n",
-    "B = o3d.mv('B', 'bivector')\n",
-    "P = o3d.mv('I', 'pseudo')\n",
-    "gprint(r'\\text{Scalar:}S =',S)\n",
-    "gprint(r'\\text{Vector:}V =',V)\n",
-    "gprint(r'\\text{Bivector:}B =',B)\n",
-    "gprint(r'\\text{Pseudoscalar:}I =',P)"
+    "o3d.mv('S', 'scalar')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "\\begin{equation*} V = V^{x} \\boldsymbol{e}_{x} + V^{y} \\boldsymbol{e}_{y} + V^{z} \\boldsymbol{e}_{z} \\end{equation*}"
+      ],
+      "text/plain": [
+       "V__x*e_x + V__y*e_y + V__z*e_z"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "o3d.mv('V', 'vector')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "\\begin{equation*} B = B^{xy} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + B^{xz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + B^{yz} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} \\end{equation*}"
+      ],
+      "text/plain": [
+       "B__xy*e_x^e_y + B__xz*e_x^e_z + B__yz*e_y^e_z"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "o3d.mv('B', 'bivector')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "\\begin{equation*} I = I^{xyz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} \\end{equation*}"
+      ],
+      "text/plain": [
+       "I__xyz*e_x^e_y^e_z"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "o3d.mv('I', 'pseudo')"
    ]
   },
   {
@@ -258,333 +256,232 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle \\text{basis} =( \\boldsymbol{e}_{x},  \\boldsymbol{e}_{y},  \\boldsymbol{e}_{z})$"
+       "$\\displaystyle  \\boldsymbol{e}_{x},  \\boldsymbol{e}_{y},  \\boldsymbol{e}_{z}$"
       ],
       "text/plain": [
        "<IPython.core.display.Math object>"
       ]
      },
+     "execution_count": 10,
      "metadata": {},
-     "output_type": "display_data"
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "basis = (ex, ey, ez) = o3d.mv()\n",
-    "gprint(r'\\text{basis} =',basis)"
+    "ex, ey, ez = o3d.mv()\n",
+    "Math(f'{latex(ex)}, {latex(ey)}, {latex(ez)}')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Binary operations that we can apply to vectors or multivectors in general are addition, `+`, subtraction, `-`, geometric product, `*`, inner (dot) product, `|`, outer (wedge) product, `^`, left contraction, `<`, right contraction, `>`, and scalar product, `&`.  Because operator precedence is immuatable in Python we need to always use parenthesis to determine the correct order of the operations in our expression.  Examples for `+`, `-`, `*`, `|`, and `^` follow:"
+    "## Multivector operators"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Binary operations that we can apply to vectors or multivectors in general are addition, `+`, subtraction, `-`, geometric product, `*`, inner (dot) product, `|`, outer (wedge) product, `^`, left contraction, `<`, right contraction, `>`.\n",
+    "Because operator precedence is immuatable in Python we need to always use parenthesis to determine the correct order of the operations in our expression.  Examples for `+`, `-`, `*`, `|`, and `^` follow:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle a =a^{x} \\boldsymbol{e}_{x} + a^{y} \\boldsymbol{e}_{y} + a^{z} \\boldsymbol{e}_{z}$"
+       "$\\displaystyle \n",
+       "\\begin{align}\n",
+       "    a &= a^{x} \\boldsymbol{e}_{x} + a^{y} \\boldsymbol{e}_{y} + a^{z} \\boldsymbol{e}_{z} \\\\\n",
+       "    b &= b^{x} \\boldsymbol{e}_{x} + b^{y} \\boldsymbol{e}_{y} + b^{z} \\boldsymbol{e}_{z}\n",
+       "\\end{align}\n",
+       "$"
       ],
       "text/plain": [
        "<IPython.core.display.Math object>"
       ]
      },
+     "execution_count": 11,
      "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/latex": [
-       "$\\displaystyle b =b^{x} \\boldsymbol{e}_{x} + b^{y} \\boldsymbol{e}_{y} + b^{z} \\boldsymbol{e}_{z}$"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Math object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/latex": [
-       "$\\displaystyle a+b =\\left ( a^{x} + b^{x}\\right ) \\boldsymbol{e}_{x} + \\left ( a^{y} + b^{y}\\right ) \\boldsymbol{e}_{y} + \\left ( a^{z} + b^{z}\\right ) \\boldsymbol{e}_{z}$"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Math object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/latex": [
-       "$\\displaystyle a-b =\\left ( a^{x} - b^{x}\\right ) \\boldsymbol{e}_{x} + \\left ( a^{y} - b^{y}\\right ) \\boldsymbol{e}_{y} + \\left ( a^{z} - b^{z}\\right ) \\boldsymbol{e}_{z}$"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Math object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/latex": [
-       "$\\displaystyle ab =\\left ( a^{x} b^{x} + a^{y} b^{y} + a^{z} b^{z}\\right )  + \\left ( a^{x} b^{y} - a^{y} b^{x}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + \\left ( a^{x} b^{z} - a^{z} b^{x}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + \\left ( a^{y} b^{z} - a^{z} b^{y}\\right ) \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}$"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Math object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/latex": [
-       "$\\displaystyle a\\cdot b =a^{x} b^{x} + a^{y} b^{y} + a^{z} b^{z}$"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Math object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/latex": [
-       "$\\displaystyle a \\rfloor b =a^{x} b^{x} + a^{y} b^{y} + a^{z} b^{z}$"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Math object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/latex": [
-       "$\\displaystyle a \\lfloor b =a^{x} b^{x} + a^{y} b^{y} + a^{z} b^{z}$"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Math object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/latex": [
-       "$\\displaystyle a\\wedge b =\\left ( a^{x} b^{y} - a^{y} b^{x}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + \\left ( a^{x} b^{z} - a^{z} b^{x}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + \\left ( a^{y} b^{z} - a^{z} b^{y}\\right ) \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}$"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Math object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+     "output_type": "execute_result"
     }
    ],
    "source": [
     "a = o3d.mv('a','vector')\n",
     "b = o3d.mv('b','vector')\n",
-    "gprint('a =',a)\n",
-    "gprint('b =',b)\n",
-    "gprint('a+b =',a+b)\n",
-    "gprint('a-b =',a-b)\n",
-    "gprint('ab =',a*b)\n",
-    "gprint(r'a\\cdot b =', a|b)\n",
-    "gprint(r'a \\rfloor b =',a<b)\n",
-    "gprint(r'a \\lfloor b =',a>b)\n",
-    "gprint(r'a\\wedge b =',a^b)\n",
-    "#print(r'a * b =',a&b)"
+    "Math(fr'''\n",
+    "\\begin{{align}}\n",
+    "    a &= {latex(a)} \\\\\n",
+    "    b &= {latex(b)}\n",
+    "\\end{{align}}\n",
+    "''')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle B =B^{xy} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + B^{xz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + B^{yz} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}$"
+       "$\\displaystyle \n",
+       "\\begin{align}\n",
+       "    a+b         &= \\left ( a^{x} + b^{x}\\right ) \\boldsymbol{e}_{x} + \\left ( a^{y} + b^{y}\\right ) \\boldsymbol{e}_{y} + \\left ( a^{z} + b^{z}\\right ) \\boldsymbol{e}_{z} \\\\\n",
+       "    a-b         &= \\left ( a^{x} - b^{x}\\right ) \\boldsymbol{e}_{x} + \\left ( a^{y} - b^{y}\\right ) \\boldsymbol{e}_{y} + \\left ( a^{z} - b^{z}\\right ) \\boldsymbol{e}_{z} \\\\\n",
+       "    ab          &= \\left ( a^{x} b^{x} + a^{y} b^{y} + a^{z} b^{z}\\right )  + \\left ( a^{x} b^{y} - a^{y} b^{x}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + \\left ( a^{x} b^{z} - a^{z} b^{x}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + \\left ( a^{y} b^{z} - a^{z} b^{y}\\right ) \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} \\\\\n",
+       "    a\\cdot b    &= a^{x} b^{x} + a^{y} b^{y} + a^{z} b^{z} \\\\\n",
+       "    a \\rfloor b &= a^{x} b^{x} + a^{y} b^{y} + a^{z} b^{z} \\\\\n",
+       "    a \\lfloor b &= a^{x} b^{x} + a^{y} b^{y} + a^{z} b^{z} \\\\\n",
+       "    a\\wedge b   &= \\left ( a^{x} b^{y} - a^{y} b^{x}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + \\left ( a^{x} b^{z} - a^{z} b^{x}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + \\left ( a^{y} b^{z} - a^{z} b^{y}\\right ) \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}\n",
+       "\\end{align}\n",
+       "$"
       ],
       "text/plain": [
        "<IPython.core.display.Math object>"
       ]
      },
+     "execution_count": 12,
      "metadata": {},
-     "output_type": "display_data"
-    },
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Math(fr'''\n",
+    "\\begin{{align}}\n",
+    "    a+b         &= {latex(a+b)} \\\\\n",
+    "    a-b         &= {latex(a-b)} \\\\\n",
+    "    ab          &= {latex(a*b)} \\\\\n",
+    "    a\\cdot b    &= {latex(a|b)} \\\\\n",
+    "    a \\rfloor b &= {latex(a<b)} \\\\\n",
+    "    a \\lfloor b &= {latex(a>b)} \\\\\n",
+    "    a\\wedge b   &= {latex(a^b)}\n",
+    "\\end{{align}}\n",
+    "''')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle BB =- {\\left ( B^{xy} \\right )}^{2} - {\\left ( B^{xz} \\right )}^{2} - {\\left ( B^{yz} \\right )}^{2}$"
+       "\\begin{equation*} B = B^{xy} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + B^{xz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + B^{yz} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} \\end{equation*}"
       ],
       "text/plain": [
-       "<IPython.core.display.Math object>"
+       "B__xy*e_x^e_y + B__xz*e_x^e_z + B__yz*e_y^e_z"
       ]
      },
+     "execution_count": 13,
      "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/latex": [
-       "$\\displaystyle a+B =a^{x} \\boldsymbol{e}_{x} + a^{y} \\boldsymbol{e}_{y} + a^{z} \\boldsymbol{e}_{z} + B^{xy} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + B^{xz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + B^{yz} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}$"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Math object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/latex": [
-       "$\\displaystyle a-B =a^{x} \\boldsymbol{e}_{x} + a^{y} \\boldsymbol{e}_{y} + a^{z} \\boldsymbol{e}_{z} - B^{xy} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} - B^{xz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} - B^{yz} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}$"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Math object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/latex": [
-       "$\\displaystyle aB =\\left ( - B^{xy} a^{y} - B^{xz} a^{z}\\right ) \\boldsymbol{e}_{x} + \\left ( B^{xy} a^{x} - B^{yz} a^{z}\\right ) \\boldsymbol{e}_{y} + \\left ( B^{xz} a^{x} + B^{yz} a^{y}\\right ) \\boldsymbol{e}_{z} + \\left ( B^{xy} a^{z} - B^{xz} a^{y} + B^{yz} a^{x}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}$"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Math object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/latex": [
-       "$\\displaystyle a\\cdot B =\\left ( - B^{xy} a^{y} - B^{xz} a^{z}\\right ) \\boldsymbol{e}_{x} + \\left ( B^{xy} a^{x} - B^{yz} a^{z}\\right ) \\boldsymbol{e}_{y} + \\left ( B^{xz} a^{x} + B^{yz} a^{y}\\right ) \\boldsymbol{e}_{z}$"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Math object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/latex": [
-       "$\\displaystyle a \\rfloor B =\\left ( - B^{xy} a^{y} - B^{xz} a^{z}\\right ) \\boldsymbol{e}_{x} + \\left ( B^{xy} a^{x} - B^{yz} a^{z}\\right ) \\boldsymbol{e}_{y} + \\left ( B^{xz} a^{x} + B^{yz} a^{y}\\right ) \\boldsymbol{e}_{z}$"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Math object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/latex": [
-       "$\\displaystyle a \\lfloor B = 0 $"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Math object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/latex": [
-       "$\\displaystyle a\\wedge B =\\left ( B^{xy} a^{z} - B^{xz} a^{y} + B^{yz} a^{x}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}$"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Math object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+     "output_type": "execute_result"
     }
    ],
    "source": [
     "B = o3d.mv('B','bivector')\n",
-    "gprint('B =',B)\n",
-    "gprint('BB =', B*B)\n",
-    "gprint('a+B =',a+B)\n",
-    "gprint('a-B =',a-B)\n",
-    "gprint('aB =',a*B)\n",
-    "gprint(r'a\\cdot B =', a|B)\n",
-    "gprint(r'a \\rfloor B =',a<B)\n",
-    "gprint(r'a \\lfloor B =',a>B)\n",
-    "gprint(r'a\\wedge B =',a^B)\n",
-    "#print(r'a * B =',a&B)"
+    "B"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \n",
+       "\\begin{align}\n",
+       "BB          &= - {\\left ( B^{xy} \\right )}^{2} - {\\left ( B^{xz} \\right )}^{2} - {\\left ( B^{yz} \\right )}^{2} \\\\\n",
+       "a+B         &= a^{x} \\boldsymbol{e}_{x} + a^{y} \\boldsymbol{e}_{y} + a^{z} \\boldsymbol{e}_{z} + B^{xy} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + B^{xz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + B^{yz} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} \\\\\n",
+       "a-B         &= a^{x} \\boldsymbol{e}_{x} + a^{y} \\boldsymbol{e}_{y} + a^{z} \\boldsymbol{e}_{z} - B^{xy} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} - B^{xz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} - B^{yz} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} \\\\\n",
+       "aB          &= \\left ( - B^{xy} a^{y} - B^{xz} a^{z}\\right ) \\boldsymbol{e}_{x} + \\left ( B^{xy} a^{x} - B^{yz} a^{z}\\right ) \\boldsymbol{e}_{y} + \\left ( B^{xz} a^{x} + B^{yz} a^{y}\\right ) \\boldsymbol{e}_{z} + \\left ( B^{xy} a^{z} - B^{xz} a^{y} + B^{yz} a^{x}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} \\\\\n",
+       "a\\cdot B    &= \\left ( - B^{xy} a^{y} - B^{xz} a^{z}\\right ) \\boldsymbol{e}_{x} + \\left ( B^{xy} a^{x} - B^{yz} a^{z}\\right ) \\boldsymbol{e}_{y} + \\left ( B^{xz} a^{x} + B^{yz} a^{y}\\right ) \\boldsymbol{e}_{z} \\\\\n",
+       "a \\rfloor B &= \\left ( - B^{xy} a^{y} - B^{xz} a^{z}\\right ) \\boldsymbol{e}_{x} + \\left ( B^{xy} a^{x} - B^{yz} a^{z}\\right ) \\boldsymbol{e}_{y} + \\left ( B^{xz} a^{x} + B^{yz} a^{y}\\right ) \\boldsymbol{e}_{z} \\\\\n",
+       "a \\lfloor B &=  0  \\\\\n",
+       "a\\wedge B   &= \\left ( B^{xy} a^{z} - B^{xz} a^{y} + B^{yz} a^{x}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} \\\\\n",
+       "\\end{align}\n",
+       "$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Math(fr'''\n",
+    "\\begin{{align}}\n",
+    "BB          &= {latex(B*B)} \\\\\n",
+    "a+B         &= {latex(a+B)} \\\\\n",
+    "a-B         &= {latex(a-B)} \\\\\n",
+    "aB          &= {latex(a*B)} \\\\\n",
+    "a\\cdot B    &= {latex(a|B)} \\\\\n",
+    "a \\rfloor B &= {latex(a<B)} \\\\\n",
+    "a \\lfloor B &= {latex(a>B)} \\\\\n",
+    "a\\wedge B   &= {latex(a^B)} \\\\\n",
+    "\\end{{align}}\n",
+    "''')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## More examples\n",
+    "\n",
     "Additionally, we can define multivector fields that are functions of the coordinates.  Some concrete examples are (vector and bivector fields):"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle \\text{Vector Field }V_f =x^{2} \\boldsymbol{e}_{x} + y^{2} \\boldsymbol{e}_{y} + z^{2} \\boldsymbol{e}_{z}$"
+       "$\\displaystyle \n",
+       "\\begin{align}\n",
+       "\\text{Vector Field:}   && V_f &= x^{2} \\boldsymbol{e}_{x} + y^{2} \\boldsymbol{e}_{y} + z^{2} \\boldsymbol{e}_{z} \\\\\n",
+       "\\text{Bivector Field:} && B_f &= z \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + y \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + x \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}\n",
+       "\\end{align}\n",
+       "$"
       ],
       "text/plain": [
        "<IPython.core.display.Math object>"
       ]
      },
+     "execution_count": 15,
      "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/latex": [
-       "$\\displaystyle \\text{Bivector Field }B_f =z \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + y \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + x \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}$"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Math object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+     "output_type": "execute_result"
     }
    ],
    "source": [
     "Vf = x**2*ex + y**2*ey + z**2*ez\n",
     "Bf = x*(ey^ez) + y*(ex^ez) + z*(ex^ey)\n",
-    "gprint(r'\\text{Vector Field }V_f =', Vf)\n",
-    "gprint(r'\\text{Bivector Field }B_f =', Bf)"
+    "Math(fr'''\n",
+    "\\begin{{align}}\n",
+    "\\text{{Vector Field:}}   && V_f &= {latex(Vf)} \\\\\n",
+    "\\text{{Bivector Field:}} && B_f &= {latex(Bf)}\n",
+    "\\end{{align}}\n",
+    "''')"
    ]
   },
   {
@@ -596,91 +493,72 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle M =M  + M^{x} \\boldsymbol{e}_{x} + M^{y} \\boldsymbol{e}_{y} + M^{z} \\boldsymbol{e}_{z} + M^{xy} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + M^{xz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + M^{yz} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} + M^{xyz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}$"
+       "$\\displaystyle M = M  + M^{x} \\boldsymbol{e}_{x} + M^{y} \\boldsymbol{e}_{y} + M^{z} \\boldsymbol{e}_{z} + M^{xy} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + M^{xz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + M^{yz} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} + M^{xyz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}$"
       ],
       "text/plain": [
        "<IPython.core.display.Math object>"
       ]
      },
+     "execution_count": 16,
      "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/latex": [
-       "$\\displaystyle \\text{Grade 0: }\\grd{M}{0} =M$"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Math object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/latex": [
-       "$\\displaystyle \\text{Grade 1: }\\grd{M}{1} =M^{x} \\boldsymbol{e}_{x} + M^{y} \\boldsymbol{e}_{y} + M^{z} \\boldsymbol{e}_{z}$"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Math object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/latex": [
-       "$\\displaystyle \\text{Grade 2: }\\grd{M}{2} =M^{xy} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + M^{xz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + M^{yz} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}$"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Math object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/latex": [
-       "$\\displaystyle \\text{Grade 3: }\\grd{M}{3} =M^{xyz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}$"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Math object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/latex": [
-       "$\\displaystyle \\text{Reverse: }M^{\\R} =M  + M^{x} \\boldsymbol{e}_{x} + M^{y} \\boldsymbol{e}_{y} + M^{z} \\boldsymbol{e}_{z} - M^{xy} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} - M^{xz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} - M^{yz} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} - M^{xyz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}$"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Math object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+     "output_type": "execute_result"
     }
    ],
    "source": [
     "M = o3d.mv('M', 'mv')\n",
-    "gprint('M =',M)\n",
-    "gprint(r'\\text{Grade 0: }\\grd{M}{0} =',M.grade(0))\n",
-    "gprint(r'\\text{Grade 1: }\\grd{M}{1} =',M.grade(1))\n",
-    "gprint(r'\\text{Grade 2: }\\grd{M}{2} =',M.grade(2))\n",
-    "gprint(r'\\text{Grade 3: }\\grd{M}{3} =',M.grade(3))\n",
-    "gprint(r'\\text{Reverse: }M^{\\R} =',M.rev())\n",
-    "#print(r'\\text{Norm Squared: }\\grade{MM^{\\R}}{0}=\\abs{M}^{2} =',M.norm2())"
+    "Math('M = %s' % latex(M))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \n",
+       "\\begin{align}\n",
+       "\\text{Grade 0:} && \\left<M\\right>_0 &= M \\\\\n",
+       "\\text{Grade 1:} && \\left<M\\right>_1 &= M^{x} \\boldsymbol{e}_{x} + M^{y} \\boldsymbol{e}_{y} + M^{z} \\boldsymbol{e}_{z} \\\\\n",
+       "\\text{Grade 2:} && \\left<M\\right>_2 &= M^{xy} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + M^{xz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + M^{yz} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} \\\\\n",
+       "\\text{Grade 3:} && \\left<M\\right>_3 &= M^{xyz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} \\\\\n",
+       "\\text{Reverse:} && M^\\dagger        &= M  + M^{x} \\boldsymbol{e}_{x} + M^{y} \\boldsymbol{e}_{y} + M^{z} \\boldsymbol{e}_{z} - M^{xy} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} - M^{xz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} - M^{yz} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} - M^{xyz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}\n",
+       "\\end{align}\n",
+       "$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Math(fr'''\n",
+    "\\begin{{align}}\n",
+    "\\text{{Grade 0:}} && \\left<M\\right>_0 &= {latex(M.grade(0))} \\\\\n",
+    "\\text{{Grade 1:}} && \\left<M\\right>_1 &= {latex(M.grade(1))} \\\\\n",
+    "\\text{{Grade 2:}} && \\left<M\\right>_2 &= {latex(M.grade(2))} \\\\\n",
+    "\\text{{Grade 3:}} && \\left<M\\right>_3 &= {latex(M.grade(3))} \\\\\n",
+    "\\text{{Reverse:}} && M^\\dagger        &= {latex(M.rev())}\n",
+    "\\end{{align}}\n",
+    "''')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## More printing options"
    ]
   },
   {
@@ -692,74 +570,82 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle \\bs{M} =M  + M^{x} \\boldsymbol{e}_{x} + M^{y} \\boldsymbol{e}_{y} + M^{z} \\boldsymbol{e}_{z} + M^{xy} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + M^{xz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + M^{yz} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} + M^{xyz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}$"
+       "\\begin{equation*} M  + M^{x} \\boldsymbol{e}_{x} + M^{y} \\boldsymbol{e}_{y} + M^{z} \\boldsymbol{e}_{z} + M^{xy} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + M^{xz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + M^{yz} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} + M^{xyz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} \\end{equation*}"
       ],
       "text/plain": [
-       "<IPython.core.display.Math object>"
+       "M + M__x*e_x + M__y*e_y + M__z*e_z + M__xy*e_x^e_y + M__xz*e_x^e_z + M__yz*e_y^e_z + M__xyz*e_x^e_y^e_z"
       ]
      },
+     "execution_count": 18,
      "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/latex": [
-       "$\\displaystyle \\bs{M} = \\begin{align*}  & M  \\\\  &  + M^{x} \\boldsymbol{e}_{x} + M^{y} \\boldsymbol{e}_{y} + M^{z} \\boldsymbol{e}_{z} \\\\  &  + M^{xy} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + M^{xz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + M^{yz} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} \\\\  &  + M^{xyz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}  \\end{align*} \n",
-       "$"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Math object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/latex": [
-       "$\\displaystyle \\bs{M} = \\begin{align*}  & M  \\\\  &  + M^{x} \\boldsymbol{e}_{x} \\\\  &  + M^{y} \\boldsymbol{e}_{y} \\\\  &  + M^{z} \\boldsymbol{e}_{z} \\\\  &  + M^{xy} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} \\\\  &  + M^{xz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} \\\\  &  + M^{yz} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} \\\\  &  + M^{xyz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}  \\end{align*} \n",
-       "$"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Math object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "gprint(r'\\bs{M} =',M.Fmt(1))\n",
-    "gprint(r'\\bs{M} =',M.Fmt(2))\n",
-    "gprint(r'\\bs{M} =',M.Fmt(3))"
+    "M.Fmt(1)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "\\begin{equation*}  \\begin{aligned}[t]  & M  \\\\  &  + M^{x} \\boldsymbol{e}_{x} + M^{y} \\boldsymbol{e}_{y} + M^{z} \\boldsymbol{e}_{z} \\\\  &  + M^{xy} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + M^{xz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + M^{yz} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} \\\\  &  + M^{xyz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}  \\end{aligned}  \\end{equation*}"
+      ],
+      "text/plain": [
+       " M\n",
+       " + M__x*e_x + M__y*e_y + M__z*e_z\n",
+       " + M__xy*e_x^e_y + M__xz*e_x^e_z + M__yz*e_y^e_z\n",
+       " + M__xyz*e_x^e_y^e_z"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "M.Fmt(2)"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "\\begin{equation*}  \\begin{aligned}[t]  & M  \\\\  &  + M^{x} \\boldsymbol{e}_{x} \\\\  &  + M^{y} \\boldsymbol{e}_{y} \\\\  &  + M^{z} \\boldsymbol{e}_{z} \\\\  &  + M^{xy} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} \\\\  &  + M^{xz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} \\\\  &  + M^{yz} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} \\\\  &  + M^{xyz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}  \\end{aligned}  \\end{equation*}"
+      ],
+      "text/plain": [
+       " M\n",
+       " + M__x*e_x\n",
+       " + M__y*e_y\n",
+       " + M__z*e_z\n",
+       " + M__xy*e_x^e_y\n",
+       " + M__xz*e_x^e_z\n",
+       " + M__yz*e_y^e_z\n",
+       " + M__xyz*e_x^e_y^e_z"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "M.Fmt(3)"
+   ]
   }
  ],
  "metadata": {

--- a/examples/ipython/tutorial_algebra.ipynb
+++ b/examples/ipython/tutorial_algebra.ipynb
@@ -1,0 +1,786 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is a tutorial to introduce you to galgebra3 which is a symbolic geometric algebra library for python3.  One of the main reasons it uses python3 instead of python2.7 is that it also uses the symbolic algebra library sympy and sympy will no longer be supporting python3.\n",
+    "\n",
+    "A geometric algebra is defined by a set of symbols that represent the basis vectors of a real vector space, a metric tensor, and possible a set of coordinate symbols.  If coordinates are defined the metric tensor can be a function of them.\n",
+    "\n",
+    "The following cell imports all the functions needed in the tutorial from `sympy`, `ga`, `mv`, and `printer`.  The `Format()` function enables LaTeX output and allows the `python 3` print function to be used for LaTex output in the same way as in `python 3` that is not executed through Jupyter Notebook.\n",
+    "\n",
+    "Using the print function allows one to annotate the output and to print multiple lines in a single output cell.  There are examples in the code below.\n",
+    "\n",
+    "When in the Latex output mode initiated by executing `Format()` all output is in LaTeX equation mode. The following LaTeX macros are defined by `Format()`:\n",
+    "\n",
+    "```\\newcommand{\\bfrac}[2]{\\displaystyle\\frac{#1}{#2}}\n",
+    "\\newcommand{\\lp}{\\left (}\n",
+    "\\newcommand{\\rp}{\\right )}\n",
+    "\\newcommand{\\paren}[1]{\\lp {#1} \\rp}\n",
+    "\\newcommand{\\half}{\\frac{1}{2}}\n",
+    "\\newcommand{\\llt}{\\left <}\n",
+    "\\newcommand{\\rgt}{\\right >}\n",
+    "\\newcommand{\\abs}[1]{\\left |{#1}\\right | }\n",
+    "\\newcommand{\\pdiff}[2]{\\bfrac{\\partial {#1}}{\\partial {#2}}}\n",
+    "\\newcommand{\\npdiff}[3]{\\bfrac{\\partial^{#3} {#1}}{\\partial {#2}^{#3}}}\n",
+    "\\newcommand{\\lbrc}{\\left \\{}\n",
+    "\\newcommand{\\rbrc}{\\right \\}}\n",
+    "\\newcommand{\\W}{\\wedge}\n",
+    "\\newcommand{\\prm}[1]{{#1}'}\n",
+    "\\newcommand{\\ddt}[1]{\\bfrac{d{#1}}{dt}}\n",
+    "\\newcommand{\\R}{\\dagger}\n",
+    "\\newcommand{\\deriv}[3]{\\bfrac{d^{#3}#1}{d{#2}^{#3}}}\n",
+    "\\newcommand{\\grd}[1]{\\left < {#1} \\right >}\n",
+    "\\newcommand{\\f}[2]{{#1}\\lp {#2} \\rp}\n",
+    "\\newcommand{\\eval}[2]{\\left . {#1} \\right |_{#2}}\n",
+    "\\newcommand{\\bs}[1]{\\boldsymbol{#1}}\n",
+    "\\newcommand{\\es}[1]{\\boldsymbol{e}_{#1}}\n",
+    "\\newcommand{\\eS}[1]{\\boldsymbol{e}^{#1}}\n",
+    "\\newcommand{\\grade}[2]{\\left < {#1} \\right >_{#2}}\n",
+    "\\newcommand{\\lc}{\\rfloor}\n",
+    "\\newcommand{\\rc}{\\lfloor}\n",
+    "\\newcommand{\\T}[1]{\\text{#1}}\n",
+    "\\newcommand{\\lop}[1]{\\overleftarrow{#1}}\n",
+    "\\newcommand{\\rop}[1]{\\overrightarrow{#1}}```\n",
+    "\n",
+    "So to print a string in text (not equation) mode use the code -\n",
+    "\n",
+    "```print(r'\\text{This is a string in text mode.}')```.\n",
+    "\n",
+    "Likewise if you wish to annotate a multivector `M` the print command could be -\n",
+    "\n",
+    "```print('M =',M)```,\n",
+    "\n",
+    "or if you wish the annotation to be in a bold font -\n",
+    "\n",
+    "```print(r'\\bs{M} =',M)```,\n",
+    "\n",
+    "finally if you wish a line draw above and below the ouput -\n",
+    "\n",
+    "```print('h',r'\\bs{M} =',M)```.\n",
+    "\n",
+    "All of the macros defined above can be used in text strings in print functions.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \n",
+       "\\newcommand{\\bfrac}[2]{\\displaystyle\\frac{#1}{#2}}\n",
+       "\\newcommand{\\lp}{\\left (}\n",
+       "\\newcommand{\\rp}{\\right )}\n",
+       "\\newcommand{\\paren}[1]{\\lp {#1} \\rp}\n",
+       "\\newcommand{\\half}{\\frac{1}{2}}\n",
+       "\\newcommand{\\llt}{\\left <}\n",
+       "\\newcommand{\\rgt}{\\right >}\n",
+       "\\newcommand{\\abs}[1]{\\left |{#1}\\right | }\n",
+       "\\newcommand{\\pdiff}[2]{\\bfrac{\\partial {#1}}{\\partial {#2}}}\n",
+       "\\newcommand{\\npdiff}[3]{\\bfrac{\\partial^{#3} {#1}}{\\partial {#2}^{#3}}}\n",
+       "\\newcommand{\\lbrc}{\\left \\{}\n",
+       "\\newcommand{\\rbrc}{\\right \\}}\n",
+       "\\newcommand{\\W}{\\wedge}\n",
+       "\\newcommand{\\prm}[1]{{#1}'}\n",
+       "\\newcommand{\\ddt}[1]{\\bfrac{d{#1}}{dt}}\n",
+       "\\newcommand{\\grade}[1]{\\left < {#1} \\right >}\n",
+       "\\newcommand{\\f}[2]{{#1}\\lp {#2} \\rp}\n",
+       "\\newcommand{\\eval}[2]{\\left . {#1} \\right |_{#2}}\n",
+       "\\newcommand{\\R}{\\dagger}\n",
+       "\\newcommand{\\deriv}[3]{\\bfrac{d^{#3}#1}{d{#2}^{#3}}}\n",
+       "\\newcommand{\\grd}[2]{\\left < {#1} \\right >_{#2}}\n",
+       "\\newcommand{\\f}[2]{{#1}\\lp {#2} \\rp}\n",
+       "\\newcommand{\\eval}[2]{\\left . {#1} \\right |_{#2}}\n",
+       "\\newcommand{\\bs}[1]{\\boldsymbol{#1}}\n",
+       "\\newcommand{\\es}[1]{\\boldsymbol{e}_{#1}}\n",
+       "\\newcommand{\\eS}[1]{\\boldsymbol{e}^{#1}}\n",
+       "\\newcommand{\\lc}{\\rfloor}\n",
+       "\\newcommand{\\rc}{\\lfloor}\n",
+       "\\newcommand{\\T}[1]{\\text{#1}}\n",
+       "\\newcommand{\\lop}[1]{\\overleftarrow{#1}}\n",
+       "\\newcommand{\\rop}[1]{\\overrightarrow{#1}}\n",
+       "$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from sympy import symbols, sin, cos\n",
+    "from galgebra.ga import Ga\n",
+    "from galgebra.mv import Mv\n",
+    "from galgebra.printer import Format, gprint\n",
+    "from IPython.display import display, Latex, Math, display_latex\n",
+    "Format()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To start with we will define the geometric algebra of a 3 dimensional Euclidaen vector space, `o3d`, with coordinates $x$, $y$, and $z$ and unit vectors $e_x$, $e_y$, and $e_z$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ABC = \\text{X}\n"
+     ]
+    }
+   ],
+   "source": [
+    "xyz = (x, y, z) = symbols('x y z', real=True)\n",
+    "o3d = Ga('e_x e_y e_z', g = [1,1,1], coords=xyz)\n",
+    "grad = o3d.grad"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The metric tensor $g$ is:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle g = \\left [ \\begin{array}{ccc} 1 & 0 & 0  \\\\ 0 & 1 & 0  \\\\ 0 & 0 & 1  \\end{array}\\right ] $"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "gprint('g =',o3d.g)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The most general element of a geometric algebra is a multivector.  To define a scalar `S`, a vector `V`, a bivector `B`, and a pseudo-scalar `P` (these are the only pure grade multivectors we can have in three dimensions):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\text{Scalar:}S =S$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\text{Vector:}V =V^{x} \\boldsymbol{e}_{x} + V^{y} \\boldsymbol{e}_{y} + V^{z} \\boldsymbol{e}_{z}$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\text{Bivector:}B =B^{xy} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + B^{xz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + B^{yz} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\text{Pseudoscalar:}I =I^{xyz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "S = o3d.mv('S', 'scalar')\n",
+    "V = o3d.mv('V', 'vector')\n",
+    "B = o3d.mv('B', 'bivector')\n",
+    "P = o3d.mv('I', 'pseudo')\n",
+    "gprint(r'\\text{Scalar:}S =',S)\n",
+    "gprint(r'\\text{Vector:}V =',V)\n",
+    "gprint(r'\\text{Bivector:}B =',B)\n",
+    "gprint(r'\\text{Pseudoscalar:}I =',P)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also extract the basis vectors from `o3d`. If we name them `ex`, `ey`, and `ez` and form vectors from linear combinations of them:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\text{basis} =( \\boldsymbol{e}_{x},  \\boldsymbol{e}_{y},  \\boldsymbol{e}_{z})$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "basis = (ex, ey, ez) = o3d.mv()\n",
+    "gprint(r'\\text{basis} =',basis)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Binary operations that we can apply to vectors or multivectors in general are addition, `+`, subtraction, `-`, geometric product, `*`, inner (dot) product, `|`, outer (wedge) product, `^`, left contraction, `<`, right contraction, `>`, and scalar product, `&`.  Because operator precedence is immuatable in Python we need to always use parenthesis to determine the correct order of the operations in our expression.  Examples for `+`, `-`, `*`, `|`, and `^` follow:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle a =a^{x} \\boldsymbol{e}_{x} + a^{y} \\boldsymbol{e}_{y} + a^{z} \\boldsymbol{e}_{z}$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle b =b^{x} \\boldsymbol{e}_{x} + b^{y} \\boldsymbol{e}_{y} + b^{z} \\boldsymbol{e}_{z}$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle a+b =\\left ( a^{x} + b^{x}\\right ) \\boldsymbol{e}_{x} + \\left ( a^{y} + b^{y}\\right ) \\boldsymbol{e}_{y} + \\left ( a^{z} + b^{z}\\right ) \\boldsymbol{e}_{z}$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle a-b =\\left ( a^{x} - b^{x}\\right ) \\boldsymbol{e}_{x} + \\left ( a^{y} - b^{y}\\right ) \\boldsymbol{e}_{y} + \\left ( a^{z} - b^{z}\\right ) \\boldsymbol{e}_{z}$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle ab =\\left ( a^{x} b^{x} + a^{y} b^{y} + a^{z} b^{z}\\right )  + \\left ( a^{x} b^{y} - a^{y} b^{x}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + \\left ( a^{x} b^{z} - a^{z} b^{x}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + \\left ( a^{y} b^{z} - a^{z} b^{y}\\right ) \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle a\\cdot b =a^{x} b^{x} + a^{y} b^{y} + a^{z} b^{z}$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle a \\rfloor b =a^{x} b^{x} + a^{y} b^{y} + a^{z} b^{z}$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle a \\lfloor b =a^{x} b^{x} + a^{y} b^{y} + a^{z} b^{z}$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle a\\wedge b =\\left ( a^{x} b^{y} - a^{y} b^{x}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + \\left ( a^{x} b^{z} - a^{z} b^{x}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + \\left ( a^{y} b^{z} - a^{z} b^{y}\\right ) \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "a = o3d.mv('a','vector')\n",
+    "b = o3d.mv('b','vector')\n",
+    "gprint('a =',a)\n",
+    "gprint('b =',b)\n",
+    "gprint('a+b =',a+b)\n",
+    "gprint('a-b =',a-b)\n",
+    "gprint('ab =',a*b)\n",
+    "gprint(r'a\\cdot b =', a|b)\n",
+    "gprint(r'a \\rfloor b =',a<b)\n",
+    "gprint(r'a \\lfloor b =',a>b)\n",
+    "gprint(r'a\\wedge b =',a^b)\n",
+    "#print(r'a * b =',a&b)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle B =B^{xy} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + B^{xz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + B^{yz} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle BB =- {\\left ( B^{xy} \\right )}^{2} - {\\left ( B^{xz} \\right )}^{2} - {\\left ( B^{yz} \\right )}^{2}$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle a+B =a^{x} \\boldsymbol{e}_{x} + a^{y} \\boldsymbol{e}_{y} + a^{z} \\boldsymbol{e}_{z} + B^{xy} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + B^{xz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + B^{yz} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle a-B =a^{x} \\boldsymbol{e}_{x} + a^{y} \\boldsymbol{e}_{y} + a^{z} \\boldsymbol{e}_{z} - B^{xy} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} - B^{xz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} - B^{yz} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle aB =\\left ( - B^{xy} a^{y} - B^{xz} a^{z}\\right ) \\boldsymbol{e}_{x} + \\left ( B^{xy} a^{x} - B^{yz} a^{z}\\right ) \\boldsymbol{e}_{y} + \\left ( B^{xz} a^{x} + B^{yz} a^{y}\\right ) \\boldsymbol{e}_{z} + \\left ( B^{xy} a^{z} - B^{xz} a^{y} + B^{yz} a^{x}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle a\\cdot B =\\left ( - B^{xy} a^{y} - B^{xz} a^{z}\\right ) \\boldsymbol{e}_{x} + \\left ( B^{xy} a^{x} - B^{yz} a^{z}\\right ) \\boldsymbol{e}_{y} + \\left ( B^{xz} a^{x} + B^{yz} a^{y}\\right ) \\boldsymbol{e}_{z}$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle a \\rfloor B =\\left ( - B^{xy} a^{y} - B^{xz} a^{z}\\right ) \\boldsymbol{e}_{x} + \\left ( B^{xy} a^{x} - B^{yz} a^{z}\\right ) \\boldsymbol{e}_{y} + \\left ( B^{xz} a^{x} + B^{yz} a^{y}\\right ) \\boldsymbol{e}_{z}$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle a \\lfloor B = 0 $"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle a\\wedge B =\\left ( B^{xy} a^{z} - B^{xz} a^{y} + B^{yz} a^{x}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "B = o3d.mv('B','bivector')\n",
+    "gprint('B =',B)\n",
+    "gprint('BB =', B*B)\n",
+    "gprint('a+B =',a+B)\n",
+    "gprint('a-B =',a-B)\n",
+    "gprint('aB =',a*B)\n",
+    "gprint(r'a\\cdot B =', a|B)\n",
+    "gprint(r'a \\rfloor B =',a<B)\n",
+    "gprint(r'a \\lfloor B =',a>B)\n",
+    "gprint(r'a\\wedge B =',a^B)\n",
+    "#print(r'a * B =',a&B)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Additionally, we can define multivector fields that are functions of the coordinates.  Some concrete examples are (vector and bivector fields):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\text{Vector Field }V_f =x^{2} \\boldsymbol{e}_{x} + y^{2} \\boldsymbol{e}_{y} + z^{2} \\boldsymbol{e}_{z}$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\text{Bivector Field }B_f =z \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + y \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + x \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "Vf = x**2*ex + y**2*ey + z**2*ez\n",
+    "Bf = x*(ey^ez) + y*(ex^ez) + z*(ex^ey)\n",
+    "gprint(r'\\text{Vector Field }V_f =', Vf)\n",
+    "gprint(r'\\text{Bivector Field }B_f =', Bf)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In addition to binary algebraic operations the most important member functions for multivectors are `grade(i)`, `rev()`, and `norm2()`.  For a general multivector, `M`, we have:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle M =M  + M^{x} \\boldsymbol{e}_{x} + M^{y} \\boldsymbol{e}_{y} + M^{z} \\boldsymbol{e}_{z} + M^{xy} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + M^{xz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + M^{yz} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} + M^{xyz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\text{Grade 0: }\\grd{M}{0} =M$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\text{Grade 1: }\\grd{M}{1} =M^{x} \\boldsymbol{e}_{x} + M^{y} \\boldsymbol{e}_{y} + M^{z} \\boldsymbol{e}_{z}$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\text{Grade 2: }\\grd{M}{2} =M^{xy} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + M^{xz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + M^{yz} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\text{Grade 3: }\\grd{M}{3} =M^{xyz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\text{Reverse: }M^{\\R} =M  + M^{x} \\boldsymbol{e}_{x} + M^{y} \\boldsymbol{e}_{y} + M^{z} \\boldsymbol{e}_{z} - M^{xy} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} - M^{xz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} - M^{yz} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} - M^{xyz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "M = o3d.mv('M', 'mv')\n",
+    "gprint('M =',M)\n",
+    "gprint(r'\\text{Grade 0: }\\grd{M}{0} =',M.grade(0))\n",
+    "gprint(r'\\text{Grade 1: }\\grd{M}{1} =',M.grade(1))\n",
+    "gprint(r'\\text{Grade 2: }\\grd{M}{2} =',M.grade(2))\n",
+    "gprint(r'\\text{Grade 3: }\\grd{M}{3} =',M.grade(3))\n",
+    "gprint(r'\\text{Reverse: }M^{\\R} =',M.rev())\n",
+    "#print(r'\\text{Norm Squared: }\\grade{MM^{\\R}}{0}=\\abs{M}^{2} =',M.norm2())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A problem in displaying multivectors is that the expression can be very long and does not display nicely on the page.  To alleviate this problem one can use the multivector member function `Fmt()`.  The default is `Fmt(1)` which displays the multivector on one line, `Fmt(2)` displayes the multivector one grade per line, and `Fmt(3)` displayes the mulitvector one base or basis blade per line.  Some examples are: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\bs{M} =M  + M^{x} \\boldsymbol{e}_{x} + M^{y} \\boldsymbol{e}_{y} + M^{z} \\boldsymbol{e}_{z} + M^{xy} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + M^{xz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + M^{yz} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} + M^{xyz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\bs{M} = \\begin{align*}  & M  \\\\  &  + M^{x} \\boldsymbol{e}_{x} + M^{y} \\boldsymbol{e}_{y} + M^{z} \\boldsymbol{e}_{z} \\\\  &  + M^{xy} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + M^{xz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + M^{yz} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} \\\\  &  + M^{xyz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}  \\end{align*} \n",
+       "$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\bs{M} = \\begin{align*}  & M  \\\\  &  + M^{x} \\boldsymbol{e}_{x} \\\\  &  + M^{y} \\boldsymbol{e}_{y} \\\\  &  + M^{z} \\boldsymbol{e}_{z} \\\\  &  + M^{xy} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} \\\\  &  + M^{xz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} \\\\  &  + M^{yz} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} \\\\  &  + M^{xyz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}  \\end{align*} \n",
+       "$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "gprint(r'\\bs{M} =',M.Fmt(1))\n",
+    "gprint(r'\\bs{M} =',M.Fmt(2))\n",
+    "gprint(r'\\bs{M} =',M.Fmt(3))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
I've included a commit with his version unmodified, in the hope that it makes merging them together in future easier.

Even if we haven't settled on a "new printer" API, we still could really do with basic tutorials in the docs.

I'll follow up with his calculus tutorial later.

---

Tutorial appears on the docs here: https://galgebra--375.org.readthedocs.build/en/375/tutorials/algebra.html