### PR TITLE
Do not make any __str__ or __repr__ output latex

### DIFF
--- a/examples/ipython/simple_ga_test.ipynb
+++ b/examples/ipython/simple_ga_test.ipynb
@@ -304,7 +304,9 @@
        " \\end{equation*}"
       ],
       "text/plain": [
-       "\\left \\{ \\begin{array}{ll} L \\left ( \\boldsymbol{e}_{x}\\right ) =& A_{xx} \\boldsymbol{e}_{x} + A_{yx} \\boldsymbol{e}_{y} + A_{zx} \\boldsymbol{e}_{z} \\\\ L \\left ( \\boldsymbol{e}_{y}\\right ) =& A_{xy} \\boldsymbol{e}_{x} + A_{yy} \\boldsymbol{e}_{y} + A_{zy} \\boldsymbol{e}_{z} \\\\ L \\left ( \\boldsymbol{e}_{z}\\right ) =& A_{xz} \\boldsymbol{e}_{x} + A_{yz} \\boldsymbol{e}_{y} + A_{zz} \\boldsymbol{e}_{z}  \\end{array} \\right \\} "
+       "Lt(e_x) = A_xx*e_x + A_yx*e_y + A_zx*e_z\n",
+       "Lt(e_y) = A_xy*e_x + A_yy*e_y + A_zy*e_z\n",
+       "Lt(e_z) = A_xz*e_x + A_yz*e_y + A_zz*e_z"
       ]
      },
      "execution_count": 18,
@@ -330,7 +332,9 @@
        " \\end{equation*}"
       ],
       "text/plain": [
-       "\\left \\{ \\begin{array}{ll} L \\left ( \\boldsymbol{e}_{x}\\right ) =& A_{xx} \\boldsymbol{e}_{x} + A_{yx} \\boldsymbol{e}_{y} + A_{zx} \\boldsymbol{e}_{z} \\\\ L \\left ( \\boldsymbol{e}_{y}\\right ) =& A_{xy} \\boldsymbol{e}_{x} + A_{yy} \\boldsymbol{e}_{y} + A_{zy} \\boldsymbol{e}_{z} \\\\ L \\left ( \\boldsymbol{e}_{z}\\right ) =& A_{xz} \\boldsymbol{e}_{x} + A_{yz} \\boldsymbol{e}_{y} + A_{zz} \\boldsymbol{e}_{z}  \\end{array} \\right \\} "
+       "Lt(e_x) = A_xx*e_x + A_yx*e_y + A_zx*e_z\n",
+       "Lt(e_y) = A_xy*e_x + A_yy*e_y + A_zy*e_z\n",
+       "Lt(e_z) = A_xz*e_x + A_yz*e_y + A_zz*e_z"
       ]
      },
      "execution_count": 19,
@@ -354,7 +358,9 @@
        " \\end{equation*}"
       ],
       "text/plain": [
-       "\\left \\{ \\begin{array}{ll} L \\left ( \\boldsymbol{e}_{x}\\right ) =& A_{xx} \\boldsymbol{e}_{x} + A_{yx} \\boldsymbol{e}_{y} + A_{zx} \\boldsymbol{e}_{z} \\\\ L \\left ( \\boldsymbol{e}_{y}\\right ) =& A_{xy} \\boldsymbol{e}_{x} + A_{yy} \\boldsymbol{e}_{y} + A_{zy} \\boldsymbol{e}_{z} \\\\ L \\left ( \\boldsymbol{e}_{z}\\right ) =& A_{xz} \\boldsymbol{e}_{x} + A_{yz} \\boldsymbol{e}_{y} + A_{zz} \\boldsymbol{e}_{z}  \\end{array} \\right \\} "
+       "Lt(e_x) = A_xx*e_x + A_yx*e_y + A_zx*e_z\n",
+       "Lt(e_y) = A_xy*e_x + A_yy*e_y + A_zy*e_z\n",
+       "Lt(e_z) = A_xz*e_x + A_yz*e_y + A_zz*e_z"
       ]
      },
      "execution_count": 20,

--- a/galgebra/dop.py
+++ b/galgebra/dop.py
@@ -178,16 +178,8 @@ class Sdop(_BaseDop):
         latex_str = printer.GaLatexPrinter().doprint(self)
         return ' ' + latex_str + ' '
 
-    def __str__(self):
-        if printer.GaLatexPrinter.latex_flg:
-            Printer = printer.GaLatexPrinter
-        else:
-            Printer = printer.GaPrinter
-
-        return Printer().doprint(self)
-
-    def __repr__(self):
-        return str(self)
+    __ga_print_str__ = printer.default__ga_print_str__
+    __repr__ = printer.default__repr__
 
     def __init_from_symbol(self, symbol: Symbol) -> None:
         self.terms = ((S(1), Pdop(symbol)),)
@@ -410,12 +402,5 @@ class Pdop(_BaseDop):
         latex_str = printer.GaLatexPrinter().doprint(self)
         return ' ' + latex_str + ' '
 
-    def __str__(self):
-        if printer.GaLatexPrinter.latex_flg:
-            Printer = printer.GaLatexPrinter
-        else:
-            Printer = printer.GaPrinter
-        return Printer().doprint(self)
-
-    def __repr__(self):
-        return str(self)
+    __ga_print_str__ = printer.default__ga_print_str__
+    __repr__ = printer.default__repr__

--- a/galgebra/lt.py
+++ b/galgebra/lt.py
@@ -338,9 +338,6 @@ class Lt(object):
         else:
             raise TypeError('Cannot have LT as left argument in Lt __rmul__\n')
 
-    def __repr__(self):
-        return str(self)
-
     def _repr_latex_(self):
         latex_str = printer.GaLatexPrinter().doprint(self)
         if r'\begin{align*}' not in latex_str:
@@ -465,12 +462,8 @@ class Lt(object):
         else:
             return latex_str
 
-    def __str__(self):
-        if printer.GaLatexPrinter.latex_flg:
-            Printer = printer.GaLatexPrinter
-        else:
-            Printer = printer.GaPrinter
-        return Printer().doprint(self)
+    __ga_print_str__ = printer.default__ga_print_str__
+    __repr__ = printer.default__repr__
 
     def matrix(self) -> Matrix:
         r"""
@@ -757,12 +750,8 @@ class Mlt(object):
                 Mlt.increment_slots(self.nargs, Ga)
                 self.fvalue = f
 
-    def __str__(self):
-        if printer.GaLatexPrinter.latex_flg:
-            Printer = printer.GaLatexPrinter
-        else:
-            Printer = printer.GaPrinter
-        return Printer().doprint(self)
+    __ga_print_str__ = printer.default__ga_print_str__
+    __repr__ = printer.default__repr__
 
     def __call__(self, *args):
         """

--- a/galgebra/mv.py
+++ b/galgebra/mv.py
@@ -85,11 +85,7 @@ class _FmtResult:
             latex_str = r'\begin{equation*} ' + latex_str + r' \end{equation*}'
         return latex_str
 
-    def __str__(self):
-        return printer.GaPrinter().doprint(self)
-
-    def __repr__(self):
-        return str(self)
+    __repr__ = printer.default__repr__
 
     def __ga_print_str__(self):
         if printer.GaLatexPrinter.latex_flg:
@@ -654,15 +650,8 @@ class Mv(object):
     def __str__(self):
         return printer.GaPrinter().doprint(self)
 
-    def __ga_print_str__(self):
-        if printer.GaLatexPrinter.latex_flg:
-            Printer = printer.GaLatexPrinter
-        else:
-            Printer = printer.GaPrinter
-        return Printer().doprint(self)
-
-    def __repr__(self):
-        return str(self)
+    __ga_print_str__ = printer.default__ga_print_str__
+    __repr__ = printer.default__repr__
 
     def __getitem__(self, key: int) -> 'Mv':
         '''
@@ -1695,19 +1684,8 @@ class Dop(dop._BaseDop):
         else:
             return NotImplemented
 
-    def __str__(self) -> str:
-        return printer.GaPrinter().doprint(self)
-
-    def __ga_print_str__(self) -> str:
-        if printer.GaLatexPrinter.latex_flg:
-            Printer = printer.GaLatexPrinter
-        else:
-            Printer = printer.GaPrinter
-
-        return Printer().doprint(self)
-
-    def __repr__(self) -> str:
-        return str(self)
+    __ga_print_str__ = printer.default__ga_print_str__
+    __repr__ = printer.default__repr__
 
     def _repr_latex_(self) -> str:
         return self.Fmt(fmt=None, title=self.title)._repr_latex_()

--- a/galgebra/printer.py
+++ b/galgebra/printer.py
@@ -277,10 +277,22 @@ class GaPrinter(StrPrinter):
         )
 
 
-Basic.__ga_print_str__ = lambda self: GaPrinter().doprint(self)
-Matrix.__ga_print_str__ = lambda self: GaPrinter().doprint(self)
-Basic.__repr__ = lambda self: GaPrinter().doprint(self)
-Matrix.__repr__ = lambda self: GaPrinter().doprint(self)
+def default__ga_print_str__(self):
+    if GaLatexPrinter.latex_flg:
+        return GaLatexPrinter().doprint(self)
+    else:
+        return GaPrinter().doprint(self)
+
+
+def default__repr__(self):
+    return GaPrinter().doprint(self)
+
+
+Basic.__ga_print_str__ = default__ga_print_str__
+Matrix.__ga_print_str__ = default__ga_print_str__
+
+Basic.__repr__ = default__repr__
+Matrix.__repr__ = default__repr__
 
 
 # This is the lesser of two evils. Previously, we overwrote `Basic.__str__` in
@@ -446,10 +458,6 @@ class GaLatexPrinter(LatexPrinter):
     @staticmethod
     def redirect():
         GaLatexPrinter.latex_flg = True
-        GaLatexPrinter.Basic__ga_print_str__ = Basic.__ga_print_str__
-        GaLatexPrinter.Matrix__ga_print_str__ = Matrix.__ga_print_str__
-        Basic.__ga_print_str__ = lambda self: GaLatexPrinter().doprint(self)
-        Matrix.__ga_print_str__ = lambda self: GaLatexPrinter().doprint(self)
         if GaLatexPrinter.ipy:
             pass
         else:
@@ -464,8 +472,6 @@ class GaLatexPrinter(LatexPrinter):
             GaLatexPrinter.latex_flg = False
             if not GaLatexPrinter.ipy:
                 sys.stdout = GaLatexPrinter.stdout
-            Basic.__ga_print_str__ = GaLatexPrinter.Basic__ga_print_str__
-            Matrix.__ga_print_str__ = GaLatexPrinter.Matrix__ga_print_str__
 
     def _print_Pow(self, expr):
         base = self._print(expr.base)
@@ -761,9 +767,6 @@ def Format(Fmode: bool = True, Dmode: bool = True, dop=1, inverse='full'):
         GaLatexPrinter.dop = dop
         GaLatexPrinter.latex_flg = True
         GaLatexPrinter.redirect()
-
-        Basic.__ga_print_str__ = lambda self: GaLatexPrinter().doprint(self)
-        Matrix.__ga_print_str__ = lambda self: GaLatexPrinter().doprint(self)
 
         if isinteractive():
             init_printing(use_latex= 'mathjax')


### PR DESCRIPTION
This follows on from #371, and also hitting `Sdop`, `Pdop`, `Lt`, and `Mlt`.

This then moves all the duplicated code to `printer.py`.
As a result of this change, only one line of code outside of `printer.py` uses `GaLatexPrinter.latex_flg`, and it only does so as a workaround:

https://github.com/pygae/galgebra/blob/0366454409fb0ba5c6c9f3509ec886685ad52fdc/galgebra/mv.py#L91-L94

Note that if `__str__` is not defined, it defaults to `__repr__` - so we can save some lines by only defining the latter.