### PR TITLE
Also fix `Fmt` to work correctly on Lt and Mlt instances

### DIFF
--- a/examples/ipython/simple_ga_test.ipynb
+++ b/examples/ipython/simple_ga_test.ipynb
@@ -328,11 +328,11 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} \\left \\{ \\begin{array}{ll} L \\left ( \\boldsymbol{e}_{x}\\right ) =& A_{xx} \\boldsymbol{e}_{x} + A_{yx} \\boldsymbol{e}_{y} + A_{zx} \\boldsymbol{e}_{z} \\\\ L \\left ( \\boldsymbol{e}_{y}\\right ) =& A_{xy} \\boldsymbol{e}_{x} + A_{yy} \\boldsymbol{e}_{y} + A_{zy} \\boldsymbol{e}_{z} \\\\ L \\left ( \\boldsymbol{e}_{z}\\right ) =& A_{xz} \\boldsymbol{e}_{x} + A_{yz} \\boldsymbol{e}_{y} + A_{zz} \\boldsymbol{e}_{z}  \\end{array} \\right \\} \n",
+       "\\begin{equation*} A = \\left \\{ \\begin{array}{ll} L \\left ( \\boldsymbol{e}_{x}\\right ) =& A_{xx} \\boldsymbol{e}_{x} + A_{yx} \\boldsymbol{e}_{y} + A_{zx} \\boldsymbol{e}_{z} \\\\ L \\left ( \\boldsymbol{e}_{y}\\right ) =& A_{xy} \\boldsymbol{e}_{x} + A_{yy} \\boldsymbol{e}_{y} + A_{zy} \\boldsymbol{e}_{z} \\\\ L \\left ( \\boldsymbol{e}_{z}\\right ) =& A_{xz} \\boldsymbol{e}_{x} + A_{yz} \\boldsymbol{e}_{y} + A_{zz} \\boldsymbol{e}_{z}  \\end{array} \\right \\} \n",
        " \\end{equation*}"
       ],
       "text/plain": [
-       "Lt(e_x) = A_xx*e_x + A_yx*e_y + A_zx*e_z\n",
+       "A = Lt(e_x) = A_xx*e_x + A_yx*e_y + A_zx*e_z\n",
        "Lt(e_y) = A_xy*e_x + A_yy*e_y + A_zy*e_z\n",
        "Lt(e_z) = A_xz*e_x + A_yz*e_y + A_zz*e_z"
       ]
@@ -354,11 +354,11 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} \\left \\{ \\begin{array}{ll} L \\left ( \\boldsymbol{e}_{x}\\right ) =& A_{xx} \\boldsymbol{e}_{x} + A_{yx} \\boldsymbol{e}_{y} + A_{zx} \\boldsymbol{e}_{z} \\\\ L \\left ( \\boldsymbol{e}_{y}\\right ) =& A_{xy} \\boldsymbol{e}_{x} + A_{yy} \\boldsymbol{e}_{y} + A_{zy} \\boldsymbol{e}_{z} \\\\ L \\left ( \\boldsymbol{e}_{z}\\right ) =& A_{xz} \\boldsymbol{e}_{x} + A_{yz} \\boldsymbol{e}_{y} + A_{zz} \\boldsymbol{e}_{z}  \\end{array} \\right \\} \n",
+       "\\begin{equation*} A = \\left \\{ \\begin{array}{ll} L \\left ( \\boldsymbol{e}_{x}\\right ) =& A_{xx} \\boldsymbol{e}_{x} + A_{yx} \\boldsymbol{e}_{y} + A_{zx} \\boldsymbol{e}_{z} \\\\ L \\left ( \\boldsymbol{e}_{y}\\right ) =& A_{xy} \\boldsymbol{e}_{x} + A_{yy} \\boldsymbol{e}_{y} + A_{zy} \\boldsymbol{e}_{z} \\\\ L \\left ( \\boldsymbol{e}_{z}\\right ) =& A_{xz} \\boldsymbol{e}_{x} + A_{yz} \\boldsymbol{e}_{y} + A_{zz} \\boldsymbol{e}_{z}  \\end{array} \\right \\} \n",
        " \\end{equation*}"
       ],
       "text/plain": [
-       "Lt(e_x) = A_xx*e_x + A_yx*e_y + A_zx*e_z\n",
+       "A = Lt(e_x) = A_xx*e_x + A_yx*e_y + A_zx*e_z\n",
        "Lt(e_y) = A_xy*e_x + A_yy*e_y + A_zy*e_z\n",
        "Lt(e_z) = A_xz*e_x + A_yz*e_y + A_zz*e_z"
       ]

--- a/galgebra/lt.py
+++ b/galgebra/lt.py
@@ -12,10 +12,22 @@ from functools import reduce
 from sympy import (
     expand, symbols, Matrix, Transpose, zeros, Symbol, Function, S, Add, Expr
 )
+from sympy.printing.latex import LatexPrinter as _LatexPrinter
+from sympy.printing.str import StrPrinter as _StrPrinter
+
 
 from . import printer
 from . import metric
 from . import mv
+
+
+# Add custom settings to the builtin latex printer
+_LatexPrinter._default_settings.update({
+    'galgebra_mlt_lcnt': 1
+})
+_StrPrinter._default_settings.update({
+    'galgebra_mlt_lcnt': 1
+})
 
 
 def Symbolic_Matrix(root, coords=None, mode='g', f=False, sub=True):
@@ -430,37 +442,8 @@ class Lt(object):
             s = s[:-3] + ' \\end{array} \\right \\} \n'
             return s
 
-    def Fmt(self, fmt=1, title=None):
-
-        if printer.isinteractive():
-            return self
-
-        latex_str = printer.GaLatexPrinter().doprint(self)
-
-        r"""
-        if printer.GaLatexPrinter.ipy:
-            if title is None:
-                if r'\begin{align*}' not in latex_str:
-                    latex_str = r'\begin{equation*} ' + latex_str + r' \end{equation*}'
-            else:
-                if r'\begin{align*}' not in latex_str:
-                    latex_str = r'\begin{equation*} ' + title + ' = ' + latex_str + r' \end{equation*}'
-                else:
-                    latex_str = latex_str.replace(r'\begin{align*}', r'\begin{align*} ' + title)
-                    latex_str = latex_str.replace('&', '=&', 1)
-
-            from IPython.core.display import display, Math
-            display(Math(latex_str))
-        else:
-            if title is not None:
-                return title + ' = ' + latex_str
-            else:
-                    return latex_str
-        """
-        if title is not None:
-            return title + ' = ' + latex_str
-        else:
-            return latex_str
+    def Fmt(self, fmt=1, title=None) -> printer._FmtResult:
+        return printer._FmtResult(self, title)
 
     __ga_print_str__ = printer.default__ga_print_str__
     __repr__ = printer.default__repr__
@@ -593,6 +576,7 @@ class Mlt(object):
         expr_lst = Mlt.expand_expr(self.fvalue, self.Ga)
         latex_str = '\\begin{align*} '
         first = True
+        lcnt = print_obj._settings['galgebra_mlt_lcnt']
         cnt = 1  # Component count on line
         for term in expr_lst:
             coef_str = str(term[0])
@@ -611,17 +595,17 @@ class Mlt(object):
                 latex_str += ' & ' + coef_latex
             else:
                 latex_str += coef_latex
-            if cnt % self.lcnt == 0:
+            if cnt % lcnt == 0:
                 latex_str += '\\\\ '
                 cnt = 1
             else:
                 cnt += 1
-        if self.lcnt == len(expr_lst) or self.lcnt == 1:
+        if lcnt == len(expr_lst) or lcnt == 1:
             latex_str = latex_str[:-3]
         latex_str = latex_str + ' \\end{align*} \n'
         return latex_str
 
-    def Fmt(self, lcnt=1, title=None):
+    def Fmt(self, lcnt=1, title=None) -> printer._FmtResult:
         """
         Set format for printing of Tensors
 
@@ -643,27 +627,8 @@ class Mlt(object):
         with two components per line.  Works for both standard printing and
         for latex.
         """
-        self.lcnt = lcnt
-        latex_str = printer.GaLatexPrinter().doprint(self)
-        self.lcnt = 1
-
-        if printer.GaLatexPrinter.ipy:
-            if title is None:
-                if r'\begin{align*}' not in latex_str:
-                    latex_str = r'\begin{equation*} ' + latex_str + r' \end{equation*}'
-            else:
-                if r'\begin{align*}' not in latex_str:
-                    latex_str = r'\begin{equation*} ' + title + ' = ' + latex_str + r' \end{equation*}'
-                else:
-                    latex_str = latex_str.replace(r'\begin{align*}', r'\begin{align*} ' + title)
-                    latex_str = latex_str.replace('&', '=&', 1)
-            from IPython.core.display import display, Math
-            display(Math(latex_str))
-        else:
-            if title is not None:
-                print(title + ' = ' + latex_str)
-            else:
-                print(latex_str)
+        obj = printer._WithSettings(self, dict(galgebra_mlt_lcnt=lcnt))
+        return printer._FmtResult(obj, title)
 
     @staticmethod
     def expand_expr(expr, ga):
@@ -707,7 +672,6 @@ class Mlt(object):
         #  T_x*a_1__x+T_y*a_1__y+T_z*a_1__z for a rank 1 tensor in 3 space and all
         #  symbols are sympy real scalar symbols
         self.Ga = Ga
-        self.lcnt = 1
         if isinstance(f, mv.Mv):
             if f.is_vector():  # f is vector T = f | a1
                 self.nargs = 1


### PR DESCRIPTION
Follow-up to #369, I forgot to check `lt.py` for the same pattern.

`Mlt.Fmt` was a weird outlier that called `print` rather than returning an object to be printed.
`Lt.Fmt` had the same code commented out, so I guess this was just an incomplete transition to the return-style of `Fmt`.

The main effect of this will be to fix plaintext output in ipython of `Lt` and `Mlt` instances. I suspect we have no tests for that, but thankfully almost all of this code path is shared by `Mv` and `Dop`, so I think that's ok.