### PR TITLE
Remove the unused and undocumented `printer.print_replace`

### DIFF
--- a/galgebra/mv.py
+++ b/galgebra/mv.py
@@ -659,8 +659,6 @@ class Mv(object):
                     s += term
             if s[-1] == '\n':
                 s = s[:-1]
-            if printer.print_replace_old is not None:
-                s = s.replace(printer.print_replace_old, printer.print_replace_new)
             return s
         else:
             return print_obj.doprint(self.obj)

--- a/galgebra/printer.py
+++ b/galgebra/printer.py
@@ -63,20 +63,10 @@ $\DeclareMathOperator{\Tr}{Tr}
 \newcommand{\eval}[2]{\left . {#1} \right |_{#2}}$
 """
 
-print_replace_old = None
-print_replace_new = None
-
 SYS_CMD = {'linux2': {'rm': 'rm', 'evince': 'evince', 'null': ' > /dev/null', '&': '&'},
            'linux': {'rm': 'rm', 'evince': 'evince', 'null': ' > /dev/null', '&': '&'},
            'win32': {'rm': 'del', 'evince': 'start', 'null': ' > NUL', '&': ''},
            'darwin': {'rm': 'rm', 'evince': 'open', 'null': ' > /dev/null', '&': '&'}}
-
-
-def print_replace(old='^', new='*'):
-    global print_replace_old, print_replace_new
-    print_replace_old = old
-    print_replace_new = new
-    return
 
 
 def isinteractive():  #Is ipython running


### PR DESCRIPTION
This function's use-case appeared to be to force blades to print as bases.
However, this isn't at all obvious from the name, and the arguments which can be passed in look outright dangerous.
Additionally, this only worked for plaintext printing, not for LaTeX.

If users want to print the base representation, they can just print `some_mv.base_rep()` instead.
If users want to perform arbitrary and meaningless textual substitutions, we should let them do so explicitly themselves.

This reverts e5a64934c2f965695e69440dbd49817bad0c017a