### PR TITLE
Simplify the common printing methods between classes

### DIFF
--- a/galgebra/dop.py
+++ b/galgebra/dop.py
@@ -69,7 +69,7 @@ def _eval_derivative_n_times_terms(terms, x, n):
 
 ################ Scalar Partial Differential Operator Class ############
 
-class _BaseDop(object):
+class _BaseDop(printer.GaPrintable):
     """ Base class for differential operators - used to avoid accidental promotion """
     pass
 
@@ -173,13 +173,6 @@ class Sdop(_BaseDop):
 
         s = s.replace('+ -', '- ')
         return s[:-3]
-
-    def _repr_latex_(self):
-        latex_str = printer.GaLatexPrinter().doprint(self)
-        return ' ' + latex_str + ' '
-
-    __ga_print_str__ = printer.default__ga_print_str__
-    __repr__ = printer.default__repr__
 
     def __init_from_symbol(self, symbol: Symbol) -> None:
         self.terms = ((S(1), Pdop(symbol)),)
@@ -397,10 +390,3 @@ class Pdop(_BaseDop):
                 s += '^{' + print_obj.doprint(i) + '}'
         s += '}'
         return s
-
-    def _repr_latex_(self):
-        latex_str = printer.GaLatexPrinter().doprint(self)
-        return ' ' + latex_str + ' '
-
-    __ga_print_str__ = printer.default__ga_print_str__
-    __repr__ = printer.default__repr__

--- a/galgebra/lt.py
+++ b/galgebra/lt.py
@@ -125,7 +125,7 @@ def Dictionary_to_Matrix(dict_rep, ga):
     return Transpose(Matrix(lst_mat))
 
 
-class Lt(object):
+class Lt(printer.GaPrintable):
     r"""
     A Linear Transformation
 
@@ -436,12 +436,8 @@ class Lt(object):
             s = s[:-3] + ' \\end{array} \\right \\} \n'
             return s
 
-    def Fmt(self, fmt=1, title=None) -> printer._FmtResult:
+    def Fmt(self, fmt=1, title=None) -> printer.GaPrintable:
         return printer._FmtResult(self, title)
-
-    __ga_print_str__ = printer.default__ga_print_str__
-    __repr__ = printer.default__repr__
-    _repr_latex_ = printer.default_repr_latex_
 
     def matrix(self) -> Matrix:
         r"""
@@ -485,7 +481,7 @@ class Lt(object):
                 return self.mat
 
 
-class Mlt(object):
+class Mlt(printer.GaPrintable):
     r"""
     A multilinear transformation (mlt) is a multilinear multivector function of
     a list of vectors (``*args``) :math:`F(v_1,...,v_r)` where for any argument slot
@@ -600,7 +596,7 @@ class Mlt(object):
         latex_str = latex_str + ' \\end{aligned} '
         return latex_str
 
-    def Fmt(self, lcnt=1, title=None) -> printer._FmtResult:
+    def Fmt(self, lcnt=1, title=None) -> printer.GaPrintable:
         """
         Set format for printing of Tensors
 
@@ -708,10 +704,6 @@ class Mlt(object):
                 self.nargs = len(args)
                 Mlt.increment_slots(self.nargs, Ga)
                 self.fvalue = f
-
-    __ga_print_str__ = printer.default__ga_print_str__
-    __repr__ = printer.default__repr__
-    _repr_latex_ = printer.default_repr_latex_
 
     def __call__(self, *args):
         """

--- a/galgebra/mv.py
+++ b/galgebra/mv.py
@@ -46,7 +46,7 @@ _StrPrinter._default_settings.update({
 ########################### Multivector Class ##########################
 
 
-class Mv(object):
+class Mv(printer.GaPrintable):
     """
     Wrapper class for multivector objects (``self.obj``) so that it is easy
     to overload operators (``*``, ``^``, ``|``, ``<``, ``>``)  for the various
@@ -587,9 +587,6 @@ class Mv(object):
 
     def __str__(self):
         return printer.GaPrinter().doprint(self)
-
-    __ga_print_str__ = printer.default__ga_print_str__
-    __repr__ = printer.default__repr__
 
     def __getitem__(self, key: int) -> 'Mv':
         '''
@@ -1158,7 +1155,7 @@ class Mv(object):
         else:
             self.obj += value * base
 
-    def Fmt(self, fmt: int = 1, title: str = None) -> printer._FmtResult:
+    def Fmt(self, fmt: int = 1, title: str = None) -> printer.GaPrintable:
         """
         Set format for printing of multivectors
 
@@ -1184,7 +1181,10 @@ class Mv(object):
         return printer._FmtResult(obj, title)
 
     def _repr_latex_(self) -> str:
-        return self.Fmt(fmt=None, title=self.title)._repr_latex_()
+        # overloaded to include the inferred title
+        if self.title is not None:
+            return printer._FmtResult(self, self.title)._repr_latex_()
+        return super()._repr_latex_()
 
     def norm2(self) -> Expr:
         reverse = self.rev()
@@ -1451,7 +1451,6 @@ class Dop(dop._BaseDop):
 
         self.cmpflg = cmpflg
         self.Ga = ga
-        self.title = None
 
         if len(args) == 2:
             self.__init_from_coef_and_pdop(*args)
@@ -1624,12 +1623,6 @@ class Dop(dop._BaseDop):
         else:
             return NotImplemented
 
-    __ga_print_str__ = printer.default__ga_print_str__
-    __repr__ = printer.default__repr__
-
-    def _repr_latex_(self) -> str:
-        return self.Fmt(fmt=None, title=self.title)._repr_latex_()
-
     def is_scalar(self) -> bool:
         return all(
             not isinstance(coef, Mv) or coef.is_scalar()
@@ -1751,7 +1744,7 @@ class Dop(dop._BaseDop):
         dop.Sdop.str_mode = False
         return s[:-3]
 
-    def Fmt(self, fmt: int = 1, title: str = None) -> printer._FmtResult:
+    def Fmt(self, fmt: int = 1, title: str = None) -> printer.GaPrintable:
         if fmt is not None:
             obj = printer._WithSettings(self, dict(galgebra_mv_fmt=fmt))
         else:


### PR DESCRIPTION
It's easier to make these a base class than it is to import them separately at each layer.

This also:

* Fixes `Sdop._repr_latex_` and `Pdop._repr_latex_`, which forgot to enter math mode (by removing their broken implementations).
* Removes `Dop.title`, which was always `None`, never set, and not used until a very recent commit.
* Simplifies `_FmtResult` to always have a title.