### PR TITLE
Remove dummy functions

### DIFF
--- a/examples/LaTeX/curvi_linear_latex.py
+++ b/examples/LaTeX/curvi_linear_latex.py
@@ -172,10 +172,6 @@ def derivatives_in_toroidal_coordinates():
     return
 
 
-def dummy():
-    return
-
-
 def main():
     #Get_Program()
     #Eprint()

--- a/examples/LaTeX/diffeq_sys.py
+++ b/examples/LaTeX/diffeq_sys.py
@@ -35,9 +35,6 @@ def main():
 
     return
 
-def dummy():
-    return
-
 if __name__ == "__main__":
     #Eprint()
     Format()

--- a/examples/LaTeX/em_waves_latex.py
+++ b/examples/LaTeX/em_waves_latex.py
@@ -98,9 +98,6 @@ def EM_Waves_in_Geom_Calculus():
 
     return
 
-def dummy():
-    return
-
 def main():
     #Get_Program()
     Format()

--- a/examples/LaTeX/groups.py
+++ b/examples/LaTeX/groups.py
@@ -65,9 +65,6 @@ def Product_of_Rotors():
           r' is a bivector blade.')
     return
 
-def dummy():
-    return
-
 def main():
     Get_Program()
     Format()

--- a/examples/LaTeX/latex_check.py
+++ b/examples/LaTeX/latex_check.py
@@ -517,9 +517,6 @@ def Fmt_test():
 
     return
 
-def dummy():
-    return
-
 def main():
     Get_Program()
     Format()

--- a/examples/LaTeX/lin_tran_check.py
+++ b/examples/LaTeX/lin_tran_check.py
@@ -156,9 +156,6 @@ def main():
 
     return
 
-def dummy():
-    return
-
 if __name__ == "__main__":
     #Eprint()
     Format()

--- a/examples/LaTeX/linear_EM_waves.py
+++ b/examples/LaTeX/linear_EM_waves.py
@@ -87,9 +87,6 @@ def EM_Waves_in_Geom_Calculus_Real():
 
     return
 
-def dummy():
-    return
-
 def main():
     Get_Program()
     Format()

--- a/examples/LaTeX/physics_check_latex.py
+++ b/examples/LaTeX/physics_check_latex.py
@@ -114,9 +114,6 @@ def Lie_Group():
 
     return
 
-def dummy():
-    return
-
 def main():
     Get_Program()
     Format()

--- a/examples/LaTeX/simple_check_latex.py
+++ b/examples/LaTeX/simple_check_latex.py
@@ -47,9 +47,6 @@ def basic_multivector_operations_2D():
     print((A>X).Fmt(2,'A>X'))
     return
 
-def dummy():
-    return
-
 def main():
     Get_Program(True)
     Format()

--- a/examples/Old Format/latex_check.py
+++ b/examples/Old Format/latex_check.py
@@ -430,9 +430,6 @@ def reciprocal_frame_test():
     print('%(E3\\cdot e3)/E^{2} =',simplify(w/Esq))
     return
 
-def dummy():
-    return
-
 def main():
     Get_Program()
 

--- a/examples/Old Format/mv_setup_options.py
+++ b/examples/Old Format/mv_setup_options.py
@@ -25,9 +25,6 @@ def MV_setup_options():
 
     return
 
-def dummy():
-    return
-
 def main():
     Get_Program(True)
     enhance_print()

--- a/examples/Old Format/outdated/manifold_check.py
+++ b/examples/Old Format/outdated/manifold_check.py
@@ -97,9 +97,6 @@ def Simple_manifold_with_scalar_function_derivative():
     print 'Vector derivative =', dg.subs({u:1,v:0})
     return
 
-def dummy():
-    return
-
 def main():
     Get_Program(True)
     ga_print_on()

--- a/examples/Old Format/outdated/manifold_check_latex.py
+++ b/examples/Old Format/outdated/manifold_check_latex.py
@@ -132,9 +132,6 @@ def Simple_manifold_with_vector_function_derivative():
 
     return
 
-def dummy():
-    return
-
 def main():
     Get_Program()
 

--- a/examples/Old Format/physics_check_latex.py
+++ b/examples/Old Format/physics_check_latex.py
@@ -86,9 +86,6 @@ def Lorentz_Tranformation_in_Geometric_Algebra():
     print(r"%t\bm{\gamma_{t}}+x\bm{\gamma_{x}} =",Xpp.collect())
     return
 
-def dummy():
-    return
-
 def main():
     Get_Program()
     Format()

--- a/examples/Old Format/simple_check_latex.py
+++ b/examples/Old Format/simple_check_latex.py
@@ -47,9 +47,6 @@ def basic_multivector_operations_2D():
     (A>X).Fmt(2,'A>X')
     return
 
-def dummy():
-    return
-
 def main():
     Get_Program(True)
     Format()

--- a/examples/Old Format/spherical_latex.py
+++ b/examples/Old Format/spherical_latex.py
@@ -24,9 +24,6 @@ def derivatives_in_spherical_coordinates():
     print('-I*(grad^A) =',-MV.I*(grad^A))
     print('grad^B =',grad^B)
     return
-def dummy():
-    return
-
 def main():
     Get_Program()
     Format()

--- a/examples/Old Format/terminal_check.py
+++ b/examples/Old Format/terminal_check.py
@@ -439,9 +439,6 @@ def reciprocal_frame_test():
     print('(E3|e3)/E**2 =',simplify(w/Esq))
     return
 
-def dummy():
-    return
-
 def main():
     Get_Program(True)
     enhance_print()

--- a/examples/Terminal/coefs_test.py
+++ b/examples/Terminal/coefs_test.py
@@ -18,9 +18,6 @@ def coefs_test():
     print(A.blade_coefs())
     return
 
-def dummy():
-    return
-
 def main():
     Get_Program()
     Eprint()

--- a/examples/Terminal/mv_setup_options.py
+++ b/examples/Terminal/mv_setup_options.py
@@ -28,9 +28,6 @@ def Mv_setup_options():
 
     return
 
-def dummy():
-    return
-
 def main():
     Get_Program()
     Eprint()

--- a/examples/Terminal/terminal_check.py
+++ b/examples/Terminal/terminal_check.py
@@ -503,9 +503,6 @@ def signature_test():
 
     return
 
-def dummy():
-    return
-
 
 def main():
     Get_Program(True)


### PR DESCRIPTION
These were a workaround for our old implementation of `galgebra.printer.Get_Function` being broken.
It is not longer broken because we now use `inspect.getsource` internally.