### PR TITLE
Update notebook to the behavior from sympy@e31c4cdedb5080325b3fd04f4b4826d9dab65b26

### DIFF
--- a/examples/ipython/printing-galgebra.ipynb
+++ b/examples/ipython/printing-galgebra.ipynb
@@ -166,7 +166,7 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle \\mathbf{e_{1}}\\wedge \\mathbf{e_{2}}\\wedge \\mathbf{e_{3}}\\wedge \\mathbf{e}\\wedge \\mathbf{e_{0}}$"
+       "$\\displaystyle \\mathbf{e}_{1}\\wedge \\mathbf{e}_{2}\\wedge \\mathbf{e}_{3}\\wedge \\mathbf{e}\\wedge \\mathbf{e_{0}}$"
       ],
       "text/plain": [
        "e_1^e_2^e_3^e^e_{0}"
@@ -205,7 +205,7 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle \\left( \\left[ \\mathbf{e_{1}}, \\  \\mathbf{e_{2}}, \\  \\mathbf{e_{3}}\\right], \\  \\left[\\begin{matrix}\\left (\\mathbf{e_{1}}\\cdot \\mathbf{e_{1}}\\right )  & \\left (\\mathbf{e_{1}}\\cdot \\mathbf{e_{2}}\\right )  & \\left (\\mathbf{e_{1}}\\cdot \\mathbf{e_{3}}\\right ) \\\\\\left (\\mathbf{e_{1}}\\cdot \\mathbf{e_{2}}\\right )  & \\left (\\mathbf{e_{2}}\\cdot \\mathbf{e_{2}}\\right )  & \\left (\\mathbf{e_{2}}\\cdot \\mathbf{e_{3}}\\right ) \\\\\\left (\\mathbf{e_{1}}\\cdot \\mathbf{e_{3}}\\right )  & \\left (\\mathbf{e_{2}}\\cdot \\mathbf{e_{3}}\\right )  & \\left (\\mathbf{e_{3}}\\cdot \\mathbf{e_{3}}\\right ) \\end{matrix}\\right]\\right)$"
+       "$\\displaystyle \\left( \\left[ \\mathbf{e}_{1}, \\  \\mathbf{e}_{2}, \\  \\mathbf{e}_{3}\\right], \\  \\left[\\begin{matrix}\\left (\\mathbf{e}_{1}\\cdot \\mathbf{e}_{1}\\right )  & \\left (\\mathbf{e}_{1}\\cdot \\mathbf{e}_{2}\\right )  & \\left (\\mathbf{e}_{1}\\cdot \\mathbf{e}_{3}\\right ) \\\\\\left (\\mathbf{e}_{1}\\cdot \\mathbf{e}_{2}\\right )  & \\left (\\mathbf{e}_{2}\\cdot \\mathbf{e}_{2}\\right )  & \\left (\\mathbf{e}_{2}\\cdot \\mathbf{e}_{3}\\right ) \\\\\\left (\\mathbf{e}_{1}\\cdot \\mathbf{e}_{3}\\right )  & \\left (\\mathbf{e}_{2}\\cdot \\mathbf{e}_{3}\\right )  & \\left (\\mathbf{e}_{3}\\cdot \\mathbf{e}_{3}\\right ) \\end{matrix}\\right]\\right)$"
       ],
       "text/plain": [
        "⎛              ⎡(e₁⋅e₁)  (e₁⋅e₂)  (e₁⋅e₃)⎤⎞\n",
@@ -233,7 +233,7 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle \\left( \\left( 1\\right), \\  \\left( \\mathbf{e_{1}}, \\  \\mathbf{e_{2}}, \\  \\mathbf{e_{3}}\\right), \\  \\left( \\mathbf{e_{12}}, \\  \\mathbf{e_{13}}, \\  \\mathbf{e_{23}}\\right), \\  \\left( \\mathbf{e_{123}}\\right)\\right)$"
+       "$\\displaystyle \\left( \\left( 1,\\right), \\  \\left( \\mathbf{e}_{1}, \\  \\mathbf{e}_{2}, \\  \\mathbf{e}_{3}\\right), \\  \\left( \\mathbf{e}_{12}, \\  \\mathbf{e}_{13}, \\  \\mathbf{e}_{23}\\right), \\  \\left( \\mathbf{e}_{123},\\right)\\right)$"
       ],
       "text/plain": [
        "((1,), (e₁, e₂, e₃), (e₁₂, e₁₃, e₂₃), (e₁₂₃,))"
@@ -384,7 +384,7 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle \\left( \\left( 1\\right), \\  \\left( \\mathbf{e_{x}}, \\  \\mathbf{e_{y}}, \\  \\mathbf{e_{z}}\\right), \\  \\left( \\mathbf{e_{x}}\\wedge \\mathbf{e_{y}}, \\  \\mathbf{e_{x}}\\wedge \\mathbf{e_{z}}, \\  \\mathbf{e_{y}}\\wedge \\mathbf{e_{z}}\\right), \\  \\left( \\mathbf{e_{x}}\\wedge \\mathbf{e_{y}}\\wedge \\mathbf{e_{z}}\\right)\\right)$"
+       "$\\displaystyle \\left( \\left( 1,\\right), \\  \\left( \\mathbf{e}_{x}, \\  \\mathbf{e}_{y}, \\  \\mathbf{e}_{z}\\right), \\  \\left( \\mathbf{e}_{x}\\wedge \\mathbf{e}_{y}, \\  \\mathbf{e}_{x}\\wedge \\mathbf{e}_{z}, \\  \\mathbf{e}_{y}\\wedge \\mathbf{e}_{z}\\right), \\  \\left( \\mathbf{e}_{x}\\wedge \\mathbf{e}_{y}\\wedge \\mathbf{e}_{z},\\right)\\right)$"
       ],
       "text/plain": [
        "((1,), (eₓ, e_y, e_z), (eₓ^e_y, eₓ^e_z, e_y^e_z), (eₓ^e_y^e_z,))"
@@ -426,6 +426,9 @@
    "outputs": [
     {
      "data": {
+      "text/latex": [
+       "$\\displaystyle \\left(  \\mathbf{e}_{u}, \\   \\mathbf{e}_{x}, \\   \\mathbf{e}_{y}, \\   \\mathbf{e}_{z}\\right)$"
+      ],
       "text/plain": [
        "(e_u, e_x, e_y, e_z)"
       ]
@@ -436,7 +439,7 @@
     }
    ],
    "source": [
-    "# FIXME BUG: should be LaTeX\n",
+    "# NBVAL_IGNORE_OUTPUT\n",
     "g4.mv()"
    ]
   },
@@ -447,11 +450,12 @@
    "outputs": [
     {
      "data": {
+      "text/latex": [
+       "$\\displaystyle \\left( -10 \\mathbf{e}_{u} - e^{z} \\mathbf{e}_{y} + \\frac{2}{u} \\mathbf{e}_{z}, \\  \\frac{2 e^{- 4 z}}{u^{2}} \\mathbf{e}_{x}, \\  - e^{z} \\mathbf{e}_{u}, \\  \\frac{2}{u} \\mathbf{e}_{u} + \\frac{2}{u^{2}} \\mathbf{e}_{z}\\right)$"
+      ],
       "text/plain": [
-       "(-10*e_u - exp(z)*e_y + 2*e_z/u,\n",
-       " 2*exp(-4*z)*e_x/u**2,\n",
-       " -exp(z)*e_u,\n",
-       " 2*e_u/u + 2*e_z/u**2)"
+       "(-10*e_u - exp(z)*e_y + 2*e_z/u, 2*exp(-4*z)*e_x/u**2, -exp(z)*e_u, 2*e_u/u + \n",
+       "2*e_z/u**2)"
       ]
      },
      "execution_count": 19,
@@ -460,7 +464,7 @@
     }
    ],
    "source": [
-    "# FIXME BUG: should be LaTeX\n",
+    "# NBVAL_IGNORE_OUTPUT\n",
     "g4.mvr()"
    ]
   },
@@ -472,7 +476,7 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle \\left( \\left( 1\\right), \\  \\left( \\mathbf{e_{u}}, \\  \\mathbf{e_{x}}, \\  \\mathbf{e_{y}}, \\  \\mathbf{e_{z}}\\right), \\  \\left( \\mathbf{e_{u}}\\wedge \\mathbf{e_{x}}, \\  \\mathbf{e_{u}}\\wedge \\mathbf{e_{y}}, \\  \\mathbf{e_{u}}\\wedge \\mathbf{e_{z}}, \\  \\mathbf{e_{x}}\\wedge \\mathbf{e_{y}}, \\  \\mathbf{e_{x}}\\wedge \\mathbf{e_{z}}, \\  \\mathbf{e_{y}}\\wedge \\mathbf{e_{z}}\\right), \\  \\left( \\mathbf{e_{u}}\\wedge \\mathbf{e_{x}}\\wedge \\mathbf{e_{y}}, \\  \\mathbf{e_{u}}\\wedge \\mathbf{e_{x}}\\wedge \\mathbf{e_{z}}, \\  \\mathbf{e_{u}}\\wedge \\mathbf{e_{y}}\\wedge \\mathbf{e_{z}}, \\  \\mathbf{e_{x}}\\wedge \\mathbf{e_{y}}\\wedge \\mathbf{e_{z}}\\right), \\  \\left( \\mathbf{e_{u}}\\wedge \\mathbf{e_{x}}\\wedge \\mathbf{e_{y}}\\wedge \\mathbf{e_{z}}\\right)\\right)$"
+       "$\\displaystyle \\left( \\left( 1,\\right), \\  \\left( \\mathbf{e}_{u}, \\  \\mathbf{e}_{x}, \\  \\mathbf{e}_{y}, \\  \\mathbf{e}_{z}\\right), \\  \\left( \\mathbf{e}_{u}\\wedge \\mathbf{e}_{x}, \\  \\mathbf{e}_{u}\\wedge \\mathbf{e}_{y}, \\  \\mathbf{e}_{u}\\wedge \\mathbf{e}_{z}, \\  \\mathbf{e}_{x}\\wedge \\mathbf{e}_{y}, \\  \\mathbf{e}_{x}\\wedge \\mathbf{e}_{z}, \\  \\mathbf{e}_{y}\\wedge \\mathbf{e}_{z}\\right), \\  \\left( \\mathbf{e}_{u}\\wedge \\mathbf{e}_{x}\\wedge \\mathbf{e}_{y}, \\  \\mathbf{e}_{u}\\wedge \\mathbf{e}_{x}\\wedge \\mathbf{e}_{z}, \\  \\mathbf{e}_{u}\\wedge \\mathbf{e}_{y}\\wedge \\mathbf{e}_{z}, \\  \\mathbf{e}_{x}\\wedge \\mathbf{e}_{y}\\wedge \\mathbf{e}_{z}\\right), \\  \\left( \\mathbf{e}_{u}\\wedge \\mathbf{e}_{x}\\wedge \\mathbf{e}_{y}\\wedge \\mathbf{e}_{z},\\right)\\right)$"
       ],
       "text/plain": [
        "((1,), (eᵤ, eₓ, e_y, e_z), (eᵤ^eₓ, eᵤ^e_y, eᵤ^e_z, eₓ^e_y, eₓ^e_z, e_y^e_z), (\n",
@@ -496,7 +500,7 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle \\mathbf{e_{u}}\\wedge \\mathbf{e_{x}}\\wedge \\mathbf{e_{y}}\\wedge \\mathbf{e_{z}}$"
+       "$\\displaystyle \\mathbf{e}_{u}\\wedge \\mathbf{e}_{x}\\wedge \\mathbf{e}_{y}\\wedge \\mathbf{e}_{z}$"
       ],
       "text/plain": [
        "eᵤ^eₓ^e_y^e_z"
@@ -519,7 +523,7 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle \\left( \\left( 1\\right), \\  \\left( \\mathbf{e_{u}}, \\  \\mathbf{e_{x}}, \\  \\mathbf{e_{y}}, \\  \\mathbf{e_{z}}\\right), \\  \\left( \\mathbf{e_{u}}\\mathbf{e_{x}}, \\  \\mathbf{e_{u}}\\mathbf{e_{y}}, \\  \\mathbf{e_{u}}\\mathbf{e_{z}}, \\  \\mathbf{e_{x}}\\mathbf{e_{y}}, \\  \\mathbf{e_{x}}\\mathbf{e_{z}}, \\  \\mathbf{e_{y}}\\mathbf{e_{z}}\\right), \\  \\left( \\mathbf{e_{u}}\\mathbf{e_{x}}\\mathbf{e_{y}}, \\  \\mathbf{e_{u}}\\mathbf{e_{x}}\\mathbf{e_{z}}, \\  \\mathbf{e_{u}}\\mathbf{e_{y}}\\mathbf{e_{z}}, \\  \\mathbf{e_{x}}\\mathbf{e_{y}}\\mathbf{e_{z}}\\right), \\  \\left( \\mathbf{e_{u}}\\mathbf{e_{x}}\\mathbf{e_{y}}\\mathbf{e_{z}}\\right)\\right)$"
+       "$\\displaystyle \\left( \\left( 1,\\right), \\  \\left( \\mathbf{e}_{u}, \\  \\mathbf{e}_{x}, \\  \\mathbf{e}_{y}, \\  \\mathbf{e}_{z}\\right), \\  \\left( \\mathbf{e}_{u}\\mathbf{e}_{x}, \\  \\mathbf{e}_{u}\\mathbf{e}_{y}, \\  \\mathbf{e}_{u}\\mathbf{e}_{z}, \\  \\mathbf{e}_{x}\\mathbf{e}_{y}, \\  \\mathbf{e}_{x}\\mathbf{e}_{z}, \\  \\mathbf{e}_{y}\\mathbf{e}_{z}\\right), \\  \\left( \\mathbf{e}_{u}\\mathbf{e}_{x}\\mathbf{e}_{y}, \\  \\mathbf{e}_{u}\\mathbf{e}_{x}\\mathbf{e}_{z}, \\  \\mathbf{e}_{u}\\mathbf{e}_{y}\\mathbf{e}_{z}, \\  \\mathbf{e}_{x}\\mathbf{e}_{y}\\mathbf{e}_{z}\\right), \\  \\left( \\mathbf{e}_{u}\\mathbf{e}_{x}\\mathbf{e}_{y}\\mathbf{e}_{z},\\right)\\right)$"
       ],
       "text/plain": [
        "((1,), (eᵤ, eₓ, e_y, e_z), (eᵤ*eₓ, eᵤ*e_y, eᵤ*e_z, eₓ*e_y, eₓ*e_z, e_y*e_z), (\n",


### PR DESCRIPTION
sympy/sympy@e31c4cdedb5080325b3fd04f4b4826d9dab65b26 (sympy/sympy#19389)

The upstream change is in our favor, but it breaks our tests that were demonstrating previously-broken behavior.

For now, we tag those tests with `NBVAL_IGNORE_OUTPUT` to avoid them failing on released versions of sympy.

The other changes in this file are already covered by our nbval sanitization configuration.