### PR TITLE
Small fixes to documentation

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -148,12 +148,13 @@ autoclass_content = "both"  # include both class docstring and __init__
 autodoc_default_options = {
         # Make sure that any autodoc declarations show the right members
         "members": True,
-        "inherited-members": True,
+        # do not show inherited, as this pull in all the sympy members
+        # "inherited-members": True,
         "member-order": "bysource",
         # "undoc-members": True,
         # "special-members": True,
         # "private-members": True,
-        # "show-inheritance": True,
+        "show-inheritance": True,
 }
 
 #autodoc_default_flags='members'

--- a/galgebra/atoms.py
+++ b/galgebra/atoms.py
@@ -1,4 +1,4 @@
-""" Sympy primitives for representing atos ga expressions """
+""" Sympy primitives for representing atoms of ga expressions """
 
 from typing import Union
 


### PR DESCRIPTION
As an example, this page is now much easier to read:

https://galgebra--401.org.readthedocs.build/en/401/generated/galgebra.atoms.html#module-galgebra.atoms