### PR TITLE
Remove all the duplicate spellings of one/half/zero

### DIFF
--- a/galgebra/dop.py
+++ b/galgebra/dop.py
@@ -22,7 +22,7 @@ def _consolidate_terms(terms):
     new_coefs = []
     new_pdiffs = []
     for coef, pd in terms:
-        if coef != S(0):
+        if coef != S.Zero:
             if pd in new_pdiffs:
                 index = new_pdiffs.index(pd)
                 new_coefs[index] += coef
@@ -38,7 +38,7 @@ def _merge_terms(terms1, terms2):
     pdiffs2 = [pdiff for _, pdiff in terms2]
 
     pdiffs = pdiffs1 + [x for x in pdiffs2 if x not in pdiffs1]
-    coefs = len(pdiffs) * [S(0)]
+    coefs = len(pdiffs) * [S.Zero]
 
     for coef, pdiff in terms1:
         index = pdiffs.index(pdiff)
@@ -49,7 +49,7 @@ def _merge_terms(terms1, terms2):
         coefs[index] += coef
 
     # remove zeros
-    return [(coef, pdiff) for coef, pdiff in zip(coefs, pdiffs) if coef != S(0)]
+    return [(coef, pdiff) for coef, pdiff in zip(coefs, pdiffs) if coef != S.Zero]
 
 
 def _eval_derivative_n_times_terms(terms, x, n):
@@ -124,9 +124,9 @@ class Sdop(_BaseDop):
             coef_str = print_obj._print(coef)
             pd_str = print_obj._print(pdop)
 
-            if coef == S(1):
+            if coef == S.One:
                 s += pd_str
-            elif coef == S(-1):
+            elif coef == S.NegativeOne:
                 s += '-' + pd_str
             else:
                 if isinstance(coef, Add):
@@ -149,12 +149,12 @@ class Sdop(_BaseDop):
         for coef, pdop in self.terms:
             coef_str = print_obj._print(coef)
             pd_str = print_obj._print(pdop)
-            if coef == S(1):
+            if coef == S.One:
                 if pd_str == '':
                     s += '1'
                 else:
                     s += pd_str
-            elif coef == S(-1):
+            elif coef == S.NegativeOne:
                 if pd_str == '':
                     s += '-1'
                 else:
@@ -170,7 +170,7 @@ class Sdop(_BaseDop):
         return s[:-3]
 
     def __init_from_symbol(self, symbol: Symbol) -> None:
-        self.terms = ((S(1), Pdop(symbol)),)
+        self.terms = ((S.One, Pdop(symbol)),)
 
     def __init_from_coef_and_pdiffs(self, coefs: List[Any], pdiffs: List['Pdop']) -> None:
         if not isinstance(coefs, list) or not isinstance(pdiffs, list):
@@ -204,7 +204,7 @@ class Sdop(_BaseDop):
         # do this by adding `0 * d(arg)/d(nonexistant)`, which must be zero, but
         # will be a zero of the right type.
         dummy_var = Dummy('nonexistant')
-        terms = self.terms or ((S(0), Pdop(dummy_var)),)
+        terms = self.terms or ((S.Zero, Pdop(dummy_var)),)
         return sum([coef * pdiff(arg) for coef, pdiff in terms])
 
     def __neg__(self):
@@ -308,7 +308,7 @@ class Pdop(_BaseDop):
         if isinstance(A, Pdop) and self.pdiffs == A.pdiffs:
             return True
         else:
-            if len(self.pdiffs) == 0 and A == S(1):
+            if len(self.pdiffs) == 0 and A == S.One:
                 return True
             return False
 

--- a/galgebra/ga.py
+++ b/galgebra/ga.py
@@ -10,7 +10,7 @@ from typing import Tuple, TypeVar, Callable, Dict, Sequence, List, Optional, Uni
 from ._backports.typing import OrderedDict
 
 from sympy import (
-    diff, Rational, Symbol, S, Mul, Add, Expr,
+    diff, Symbol, S, Mul, Add, Expr,
     expand, simplify, eye, trigsimp,
     symbols, sqrt, Matrix,
 )
@@ -25,9 +25,11 @@ from .atoms import (
 )
 from ._utils import cached_property as _cached_property
 
-half = Rational(1, 2)
-one = S(1)
-zero = S(0)
+# This file does not and should not use these.
+# Unfortunately, some of our examples do.
+one = S.One
+zero = S.Zero
+half = S.Half
 
 
 # Needed to avoid ambiguity with the methods of the same name, when used in
@@ -111,7 +113,7 @@ def update_and_substitute(expr1, expr2, mul_dict):
     """
     coefs1, bases1 = metric.linear_expand(expr1)
     coefs2, bases2 = metric.linear_expand(expr2)
-    expr = S(0)
+    expr = S.Zero
     for coef1, base1 in zip(coefs1, bases1):
         for coef2, base2 in zip(coefs2, bases2):
             expr += coef1 * coef2 * mul_dict[base1, base2]
@@ -134,7 +136,7 @@ def nc_subs(expr, base_keys, base_values=None):
         args = expr.args
     else:
         args = [expr]
-    s = zero
+    s = S.Zero
     for term in args:
         if term.is_commutative:
             s += term
@@ -251,8 +253,8 @@ class _SingleGradeProductFunction(BladeProductFunction):
             return zero
 
         n = len(index)
-        sgn = S(1)
-        result = S(1)
+        sgn = S.One
+        result = S.One
         ordered = False
         while n > grade:
             ordered = True
@@ -370,7 +372,7 @@ class _WedgeProductFunction(_SingleGradeProductFunction):
         if sgn != 0:
             return sgn * self._ga.indexes_to_blades_dict[tuple(wedge12)]
         else:
-            return S(0)
+            return S.Zero
 
 
 class _GeometricProductFunction(BladeProductFunction):
@@ -424,7 +426,7 @@ class _BaseGeometricProductFunction(BaseProductFunction):
         return sum((
             coef * self._ga.indexes_to_bases_dict[tuple(index)]
             for coef, index in zip(coefs, indexes)
-        ), S(0))
+        ), S.Zero)
 
     @_cached_property
     def table_dict(self) -> OrderedDict[Mul, Expr]:
@@ -611,7 +613,7 @@ class Ga(metric.Metric):
                 \texttt{A << B} \equiv & {\displaystyle\frac{AB + BA}{2}}.
             \end{aligned}
         """
-        return half * (A * B - B * A)
+        return S.Half * (A * B - B * A)
 
     @staticmethod
     def build(*args, **kwargs):
@@ -690,11 +692,11 @@ class Ga(metric.Metric):
         self.sing_flg = False
 
         if self.e_sq.is_number:
-            if self.e_sq == S(0):
+            if self.e_sq == S.Zero:
                 self.sing_flg = True
                 print('!!!!If I**2 = 0, I cannot be normalized!!!!')
                 # raise ValueError('!!!!If I**2 = 0, I cannot be normalized!!!!')
-            if self.e_sq > S(0):
+            if self.e_sq > S.Zero:
                 self.i = self.e/sqrt(self.e_sq)
                 self.i_inv = self.i
             else:  # I**2 = -1
@@ -1022,7 +1024,7 @@ class Ga(metric.Metric):
     def _build_basis_base_symbol(self, base_index: Tuple[int, ...]) -> Symbol:
         """ Build a symbol used for the `base_rep` from the given tuple """
         if not base_index:
-            return S(1)
+            return S.One
         return BasisBaseSymbol(*(self.basis[i] for i in base_index))
 
     def _build_basis_blade_symbol(self, base_index: Tuple[int, ...]) -> Symbol:
@@ -1403,7 +1405,7 @@ class Ga(metric.Metric):
         indicies in list are equal (wedge product is zero) ``sgn = 0`` and
         ``lst = None`` are returned.
         """
-        sgn = S(1)
+        sgn = S.One
         for i in range(1, len(lst)):
             save = lst[i]
             j = i
@@ -1413,7 +1415,7 @@ class Ga(metric.Metric):
                 j -= 1
             lst[j] = save
             if lst[j] == lst[j - 1]:
-                return S(0), None
+                return S.Zero, None
         return sgn, lst
 
     def wedge_product_basis_blades(self, blade12: Tuple[Symbol, Symbol]) -> Expr:
@@ -1510,7 +1512,7 @@ class Ga(metric.Metric):
                 # a^A_{r} = (a*A + (-1)^{r}*A*a)/2
                 # The folowing evaluation takes the most time for setup it is the due to
                 # the substitution required for the multiplications
-                a_W_A = half * (self.basic_mul(a, Aexpand) - ((-1) ** grade) * self.basic_mul(Aexpand, a))
+                a_W_A = S.Half * (self.basic_mul(a, Aexpand) - ((-1) ** grade) * self.basic_mul(Aexpand, a))
                 blade_expansion_dict[blade] = expand(a_W_A)
 
         if self.debug:
@@ -1656,7 +1658,7 @@ class Ga(metric.Metric):
         coefs, blades = metric.linear_expand(Aobj)
         grade_dict = {}
         for coef, blade in zip(coefs, blades):
-            if blade == one:
+            if blade == S.One:
                 if 0 in list(grade_dict.keys()):
                     grade_dict[0] += coef
                 else:
@@ -1741,7 +1743,7 @@ class Ga(metric.Metric):
             if A.is_commutative:
                 return A
             else:
-                return zero
+                return S.Zero
     """
 
     def grades(self, A: Expr) -> List[int]:  # Return list of grades present in A
@@ -1758,7 +1760,7 @@ class Ga(metric.Metric):
             if l_blade > 0:
                 blades.add(blade[0])
             else:
-                blades.add(one)
+                blades.add(S.One)
         return sorted({
             self.blades_to_grades_dict[blade]
             for blade in blades
@@ -1788,7 +1790,7 @@ class Ga(metric.Metric):
                     blades[grade] += term
                 else:
                     blades[grade] = term
-        s = zero
+        s = S.Zero
         for grade in blades:
             if (grade * (grade - 1)) / 2 % 2 == 0:
                 s += blades[grade]
@@ -1802,7 +1804,7 @@ class Ga(metric.Metric):
             coef * base
             for coef, base in zip(coefs, bases)
             if self.blades_to_grades_dict[base] == r
-        ), S(0))
+        ), S.Zero)
 
     def even_odd(self, A: Expr, even: bool = True) -> Expr:  # Return even or odd part of A
         A = expand(A)
@@ -1812,7 +1814,7 @@ class Ga(metric.Metric):
             args = A.args
         else:
             args = [A]
-        s = zero
+        s = S.Zero
         for term in args:
             if term.is_commutative:
                 if even:
@@ -2051,7 +2053,7 @@ class Ga(metric.Metric):
 
         if self.connect_flg and self.dslot == -1 and not A.is_scalar():  # Basis blades are function of coordinates
             B = self.remove_scalar_part(A)
-            if B != zero:
+            if B != S.Zero:
                 if isinstance(B, Add):
                     args = B.args
                 else:
@@ -2060,7 +2062,7 @@ class Ga(metric.Metric):
                     if not term.is_commutative:
                         c, nc = term.args_cnc(split_1=False)
                         x = self.blade_derivation(nc[0], coord)
-                        if x != zero:
+                        if x != S.Zero:
                             dA += reduce(operator.mul, c, x)
 
         return dA
@@ -2076,7 +2078,7 @@ class Ga(metric.Metric):
 
         print('grad_sqr:A =', A)
 
-        s = zero
+        s = S.Zero
 
         if Sop is False and Bop is False:
             return s
@@ -2134,7 +2136,7 @@ class Ga(metric.Metric):
             key = key_base * rbase
         if key not in keys:
             keys.append(key)
-            C = zero
+            C = S.Zero
             for ib in self.n_range:
                 x = self.blade_derivation(key_base, ib)
                 if self.norm:
@@ -2179,7 +2181,7 @@ class Ga(metric.Metric):
         for igrade in index[-2:]:
             grade = []
             for iblade in igrade:
-                blade = self.mv(S(1), 'scalar')
+                blade = self.mv(S.One, 'scalar')
                 for ibasis in iblade:
                     blade ^= basis[ibasis]
                 blade = blade.trigsimp()
@@ -2191,7 +2193,7 @@ class Ga(metric.Metric):
         duals = copy.copy(MFbasis[-2])
 
         duals.reverse()
-        sgn = S(1)
+        sgn = S.One
         rbasis = []
         for dual in duals:
             recpv = (sgn * dual * E).trigsimp()
@@ -2330,7 +2332,7 @@ class Sm(Ga):
             n_range = list(range(n_sub))
             for i in n_range:
                 for j in n_range:
-                    s = zero
+                    s = S.Zero
                     for k in ga.n_range:
                         for l in ga.n_range:
                             s += dxdu[k][i] * dxdu[l][j] * g_base[k, l].subs(sub_pairs)

--- a/galgebra/lt.py
+++ b/galgebra/lt.py
@@ -70,13 +70,13 @@ def Symbolic_Matrix(root, coords=None, mode='g', f=False, sub=True):
                 for col in n_range:
                     col_index = str(coords[col])
                     if row <= col:
-                        sign = S(1)
+                        sign = S.One
                         element = root + pos + row_index + col_index
                     else:
-                        sign = -S(1)
+                        sign = -S.One
                         element = root + pos + col_index + row_index
                     if row == col:
-                        sign = S(0)
+                        sign = S.Zero
                     if not f:
                         mat[row, col] = sign * Symbol(element, real=True)
                     else:
@@ -96,7 +96,7 @@ def Matrix_to_dictionary(mat_rep, basis):
         raise ValueError('Matrix and Basis dimensions not equal for Matrix = ' + str(mat_rep))
     n_range = list(range(n))
     for row in n_range:
-        dict_rep[basis[row]] = S(0)
+        dict_rep[basis[row]] = S.Zero
         for col in n_range:
             dict_rep[basis[row]] += mat_rep[col, row]*basis[col]
     return dict_rep
@@ -110,7 +110,7 @@ def Dictionary_to_Matrix(dict_rep, ga):
     lst_mat = []  # list representation of sympy matrix
     for row in n_range:
         e_row = ga.basis[row]
-        lst_mat_row = n * [S(0)]
+        lst_mat_row = n * [S.Zero]
 
         if e_row in basis:  # If not in basis row all zeros
             element = dict_rep[e_row]
@@ -225,7 +225,7 @@ class Lt(printer.GaPrintable):
             self.rho_sq = self.R * self.Rrev
             if self.rho_sq.is_scalar():
                 self.rho_sq = self.rho_sq.scalar()
-                if self.rho_sq == S(1):
+                if self.rho_sq == S.One:
                     self.rho_sq = None
             else:
                 raise ValueError('In Spinor input for Lt, S*S.rev() not a scalar!\n')
@@ -361,7 +361,7 @@ class Lt(printer.GaPrintable):
         """
 
         lt_I = self(self.Ga.i, obj=True)
-        det_lt_I = lt_I.subs(self.Ga.i.obj, S(1))
+        det_lt_I = lt_I.subs(self.Ga.i.obj, S.One)
         return det_lt_I
 
     def tr(self) -> Expr:  # tr(L) defined by tr(L) = grad|L(x)
@@ -389,7 +389,7 @@ class Lt(printer.GaPrintable):
 
         self_adj = []
         for e_j in self.Ga.basis:
-            s = S(0)
+            s = S.Zero
             for e_i, er_i in zip(self.Ga.basis, self.Ga.r_basis):
                 s += er_i * self.Ga.hestenes_dot(e_j, self(e_i, obj=True))
             if self.Ga.is_ortho:
@@ -401,7 +401,7 @@ class Lt(printer.GaPrintable):
     def inv(self):
         if self.spinor:
             Lt_inv = Lt(self.Rrev, ga=self.Ga)
-            Lt_inv.rho_sq = S(1)/(self.rho_sq**2)
+            Lt_inv.rho_sq = S.One/(self.rho_sq**2)
         else:
             raise ValueError('Lt inverse currently implemented only for spinor!\n')
         return Lt_inv
@@ -630,7 +630,7 @@ class Mlt(printer.GaPrintable):
         lst_expr = []
         expr = expand(expr)
         for term in expr.args:
-            coef = S(1)
+            coef = S.One
             a_lst = []
             for factor in term.args:
                 if factor in ga._mlt_acoefs:
@@ -686,7 +686,7 @@ class Mlt(printer.GaPrintable):
             self.f = None
             self.nargs = nargs
             Mlt.increment_slots(nargs, Ga)
-            self.fvalue = S(0)
+            self.fvalue = S.Zero
             for t_index, a_prod in zip(itertools.product(self.Ga.basis_super_scripts, repeat=self.nargs),
                                        itertools.product(*self.Ga._mlt_pdiffs)):
                 name = '{}_{}'.format(f, ''.join(map(str, t_index)))

--- a/galgebra/metric.py
+++ b/galgebra/metric.py
@@ -18,8 +18,6 @@ from .atoms import (
     BasisVectorSymbol, DotProductSymbol, MatrixFunction, Determinant,
 )
 
-half = Rational(1, 2)
-
 
 def apply_function_list(f, x):
     if isinstance(f, (tuple, list)):
@@ -48,24 +46,24 @@ def linear_expand(expr):
 
     if expr == 0:
         coefs = [expr]
-        bases = [S(1)]
+        bases = [S.One]
         return (coefs, bases)
 
     if isinstance(expr, Add):
         args = expr.args
     else:
         if expr.is_commutative:
-            return ([expr], [S(1)])
+            return ([expr], [S.One])
         else:
             args = [expr]
     coefs = []
     bases = []
     for term in args:
         if term.is_commutative:
-            if S(1) in bases:
-                coefs[bases.index(S(1))] += term
+            if S.One in bases:
+                coefs[bases.index(S.One)] += term
             else:
-                bases.append(S(1))
+                bases.append(S.One)
                 coefs.append(term)
         else:
             c, nc = term.args_cnc()
@@ -102,7 +100,7 @@ def collect(A, nc_list):
         are combined into a single coefficient.
     """
     coefs, bases = linear_expand(A)
-    C = S(0)
+    C = S.Zero
     for x in nc_list:
         if x in bases:
             i = bases.index(x)
@@ -132,7 +130,7 @@ def square_root_of_expr(expr):
     else:
         expr = trigsimp(expr)
         coef, pow_lst = sqf_list(expr)
-        if coef != S(1):
+        if coef != S.One:
             if coef.is_number:
                 coef = square_root_of_expr(coef)
             else:
@@ -278,7 +276,7 @@ class Simp:
 
     @staticmethod
     def apply(expr):
-        obj = S(0)
+        obj = S.Zero
         for coef, base in linear_expand_terms(expr):
             obj += apply_function_list(Simp.modes, coef) * base
         return obj
@@ -501,7 +499,7 @@ class Metric(object):
         if self.is_ortho:  # Orthogonal metric
             g_inv = eye(self.n)
             for i in range(self.n):
-                g_inv[i, i] = S(1)/self.g(i, i)
+                g_inv[i, i] = S.One/self.g(i, i)
             return g_inv
         elif self.gsym is None:
             return simplify(self.g.inv())
@@ -534,9 +532,9 @@ class Metric(object):
             # \partial_{x^{i}}e_{j} = \Gamma_{ijk}e^{k}
 
             def Gamma_ijk(i, j, k):
-                return half * (dg[j][k][i] + dg[i][k][j] - dg[i][j][k])
+                return S.Half * (dg[j][k][i] + dg[i][k][j] - dg[i][j][k])
 
-            # dG[i][j][k] = half * (dg[j][k][i] + dg[i][k][j] - dg[i][j][k])
+            # dG[i][j][k] = S.Half * (dg[j][k][i] + dg[i][k][j] - dg[i][j][k])
             dG = [[[
                 Simp.apply(Gamma_ijk(i, j, k))
                 for k in n_range]

--- a/galgebra/mv.py
+++ b/galgebra/mv.py
@@ -11,7 +11,7 @@ from typing import List, Any, Tuple, Union, TYPE_CHECKING
 from sympy import (
     Symbol, Function, S, expand, Add,
     sin, cos, sinh, cosh, sqrt, trigsimp,
-    simplify, diff, Rational, Expr, Abs, collect, SympifyError,
+    simplify, diff, Expr, Abs, collect, SympifyError,
 )
 from sympy import exp as sympy_exp
 from sympy import N as Nsympy
@@ -27,11 +27,11 @@ from . import dop
 if TYPE_CHECKING:
     from galgebra.ga import Ga
 
-ONE = S(1)
-ZERO = S(0)
-HALF = Rational(1, 2)
-
-half = Rational(1, 2)
+# This file does not and should not use these.
+# Unfortunately, some of our examples do.
+ONE = S.One
+ZERO = S.Zero
+HALF = S.Half
 
 
 # Add custom settings to the builtin latex printer
@@ -264,7 +264,7 @@ class Mv(printer.GaPrintable):
         return reduce(operator.add, (
             Mv._make_grade(ga, __name, grade, **kwargs)
             for grade in range(1, ga.n + 1, 2)
-        ), S(0))  # base case needed in case n == 0
+        ), S.Zero)  # base case needed in case n == 0
 
     # aliases
     _make_grade2 = _make_bivector
@@ -355,7 +355,7 @@ class Mv(printer.GaPrintable):
         self.title = None
 
         if len(args) == 0:  # default constructor 0
-            self.obj = S(0)
+            self.obj = S.Zero
             self.i_grade = 0
             kw.reject_remaining()
         elif len(args) == 1 and not isinstance(args[0], str):  # copy constructor
@@ -469,7 +469,7 @@ class Mv(printer.GaPrintable):
         if isinstance(A, Mv):
             diff = (self - A).expand().simplify()
             # diff = (self - A).expand()
-            return diff.obj == S(0)
+            return diff.obj == S.Zero
         else:
             return self.is_scalar() and self.obj == A
 
@@ -582,7 +582,7 @@ class Mv(printer.GaPrintable):
         if isinstance(A, Mv):
             return self * A.inv()
         else:
-            return self * (S(1)/A)
+            return self * (S.One/A)
 
     def __str__(self):
         return printer.GaPrinter()._print(self)
@@ -614,10 +614,10 @@ class Mv(printer.GaPrintable):
                 return self.obj
             args = self.obj.args
             terms = {}  # dictionary with base indexes as keys
-            grade0 = S(0)
+            grade0 = S.Zero
             for arg in args:
                 c, nc = arg.args_cnc()
-                c = reduce(operator.mul, c, S(1))
+                c = reduce(operator.mul, c, S.One)
                 if len(nc) > 0:
                     base = nc[0]
                     if base in base_keys:
@@ -629,8 +629,8 @@ class Mv(printer.GaPrintable):
                             terms[index] = (c, base, grade_keys[base])
                 else:
                     grade0 += c
-            if grade0 != S(0):
-                terms[-1] = (grade0, S(1), -1)
+            if grade0 != S.Zero:
+                terms[-1] = (grade0, S.One, -1)
             terms = list(terms.items())
             sorted_terms = sorted(terms, key=operator.itemgetter(0))  # sort via base indexes
 
@@ -684,7 +684,7 @@ class Mv(printer.GaPrintable):
         obj = metric.Simp.apply(obj)
         self = Mv(obj, ga=self.Ga)
 
-        if self.obj == S(0):
+        if self.obj == S.Zero:
             return ZERO_STR
 
         if self.is_blade_rep or self.Ga.is_ortho:
@@ -698,10 +698,10 @@ class Mv(printer.GaPrintable):
         else:
             args = [self.obj]
         terms = {}  # dictionary with base indexes as keys
-        grade0 = S(0)
+        grade0 = S.Zero
         for arg in args:
             c, nc = arg.args_cnc(split_1=False)
-            c = reduce(operator.mul, c, S(1))
+            c = reduce(operator.mul, c, S.One)
             if len(nc) > 0:
                 base = nc[0]
                 if base in base_keys:
@@ -713,8 +713,8 @@ class Mv(printer.GaPrintable):
                         terms[index] = (c, base, grade_keys[base])
             else:
                 grade0 += c
-        if grade0 != S(0):
-            terms[-1] = (grade0, S(1), 0)
+        if grade0 != S.Zero:
+            terms[-1] = (grade0, S.One, 0)
         terms = list(terms.items())
 
         sorted_terms = sorted(terms, key=operator.itemgetter(0))  # sort via base indexes
@@ -729,11 +729,11 @@ class Mv(printer.GaPrintable):
             coef = printer.coef_simplify(coef)
             # coef = simplify(coef)
             l_coef = print_obj._print(coef)
-            if l_coef == '1' and base != S(1):
+            if l_coef == '1' and base != S.One:
                 l_coef = ''
-            if l_coef == '-1' and base != S(1):
+            if l_coef == '-1' and base != S.One:
                 l_coef = '-'
-            if base == S(1):
+            if base == S.One:
                 l_base = ''
             else:
                 l_base = print_obj._print(base)
@@ -811,22 +811,22 @@ class Mv(printer.GaPrintable):
         if not isinstance(n, int):
             raise ValueError('!!!!Multivector power can only be to integer power!!!!')
 
-        result = S(1)
+        result = S.One
         for x in range(n):
             result *= self
         return result
 
     def __lshift__(self, A):  # anti-comutator (<<)
-        return half * (self * A + A * self)
+        return S.Half * (self * A + A * self)
 
     def __rshift__(self, A):  # comutator (>>)
-        return half * (self * A - A * self)
+        return S.Half * (self * A - A * self)
 
     def __rlshift__(self, A):  # anti-comutator (<<)
-        return half * (A * self + self * A)
+        return S.Half * (A * self + self * A)
 
     def __rrshift__(self, A):  # comutator (>>)
-        return half * (A * self - self * A)
+        return S.Half * (A * self - self * A)
 
     def __lt__(self, A):  # left contraction (<)
         if isinstance(A, Dop):
@@ -888,7 +888,7 @@ class Mv(printer.GaPrintable):
                 obj_dict[base] += coef
             else:
                 obj_dict[base] = coef
-        obj = S(0)
+        obj = S.Zero
         for base in list(obj_dict.keys()):
             if deep:
                 obj += collect(obj_dict[base])*base
@@ -923,7 +923,7 @@ class Mv(printer.GaPrintable):
 
     def is_base(self) -> bool:
         coefs, _bases = metric.linear_expand(self.obj)
-        return coefs == [ONE]
+        return coefs == [S.One]
 
     def is_versor(self) -> bool:
         """
@@ -1009,7 +1009,7 @@ class Mv(printer.GaPrintable):
             if blade in bases:
                 coef_lst.append(coefs[bases.index(blade)])
             else:
-                coef_lst.append(ZERO)
+                coef_lst.append(S.Zero)
         return coef_lst
 
     def proj(self, bases_lst: List['Mv']) -> 'Mv':
@@ -1026,7 +1026,7 @@ class Mv(printer.GaPrintable):
 
     def dual(self) -> 'Mv':
         mode = self.Ga.dual_mode_value
-        sign = S(1)
+        sign = S.One
         if '-' in mode:
             sign = -sign
         if 'Iinv' in mode:
@@ -1064,7 +1064,7 @@ class Mv(printer.GaPrintable):
                 obj = diff(self.obj, coord)
                 for x_coord in self.Ga.coords:
                     f = self.Ga.par_coords[x_coord]
-                    if f != S(0):
+                    if f != S.Zero:
                         tmp1 = self.Ga.pDiff(self.obj, x_coord)
                         tmp2 = diff(f, coord)
                         obj += tmp1 * tmp2
@@ -1102,8 +1102,8 @@ class Mv(printer.GaPrintable):
         self_sq = self * self
         if self_sq.is_scalar():
             sq = simplify(self_sq.obj)  # sympy expression for self**2
-            if sq == S(0):  # sympy expression for self**2 = 0
-                return self + S(1)
+            if sq == S.Zero:  # sympy expression for self**2 = 0
+                return self + S.One
             coefs, bases = metric.linear_expand(self.obj)
             if len(coefs) == 1:  # Exponential of scalar * base
                 base = bases[0]
@@ -1116,7 +1116,7 @@ class Mv(printer.GaPrintable):
                     base_n = sqrt(base_sq)
                     return self.Ga.mv(cosh(base_n*coefs[0]) + sinh(base_n*coefs[0])*(bases[0]/base_n))
             if sq.is_number:  # Square is number, can test for sign
-                if sq > S(0):
+                if sq > S.Zero:
                     norm = sqrt(sq)
                     value = self.obj / norm
                     tmp = Mv(cosh(norm) + sinh(norm) * value, ga=self.Ga)
@@ -1224,7 +1224,7 @@ class Mv(printer.GaPrintable):
         if product.is_scalar():
             product = product.scalar()
             if product.is_number:
-                if product >= S(0):
+                if product >= S.Zero:
                     return sqrt(product)
                 else:
                     return sqrt(-product)
@@ -1242,26 +1242,26 @@ class Mv(printer.GaPrintable):
 
     def inv(self) -> 'Mv':
         if self.is_scalar():  # self is a scalar
-            return self.Ga.mv(S(1)/self.obj)
+            return self.Ga.mv(S.One/self.obj)
         self_sq = self * self
         if self_sq.is_scalar():  # self*self is a scalar
             """
-            if self_sq.scalar() == S(0):
+            if self_sq.scalar() == S.Zero:
                 raise ValueError('!!!!In multivector inverse, A*A is zero!!!!')
             """
-            return (S(1)/self_sq.obj)*self
+            return (S.One/self_sq.obj)*self
         self_rev = self.rev()
         self_self_rev = self * self_rev
         if(self_self_rev.is_scalar()):  # self*self.rev() is a scalar
             """
-            if self_self_rev.scalar() == S(0):
+            if self_self_rev.scalar() == S.Zero:
                 raise ValueError('!!!!In multivector inverse A*A.rev() is zero!!!!')
             """
-            return (S(1)/self_self_rev.obj) * self_rev
+            return (S.One/self_self_rev.obj) * self_rev
         raise TypeError('In inv() for self =' + str(self) + 'self, or self*self or self*self.rev() is not a scalar')
 
     def func(self, fct) -> 'Mv':  # Apply function, fct, to each coefficient of multivector
-        s = S(0)
+        s = S.Zero
         for coef, base in metric.linear_expand_terms(self.obj):
             s += fct(coef) * base
         fct_self = Mv(s, ga=self.Ga)
@@ -1281,7 +1281,7 @@ class Mv(printer.GaPrintable):
         if not isinstance(modes, (list, tuple)):
             modes = [modes]
 
-        obj = S(0)
+        obj = S.Zero
         for coef, base in metric.linear_expand_terms(self.obj):
             for mode in modes:
                 coef = mode(coef)
@@ -1292,13 +1292,13 @@ class Mv(printer.GaPrintable):
         """ Perform a substitution on each coefficient separately """
         obj = sum((
             coef.subs(*args, **kwargs) * base for coef, base in metric.linear_expand_terms(self.obj)
-        ), S(0))
+        ), S.Zero)
         return Mv(obj, ga=self.Ga)
 
     def expand(self) -> 'Mv':
         obj = sum((
             expand(coef) * base for coef, base in metric.linear_expand_terms(self.obj)
-        ), S(0))
+        ), S.Zero)
         return Mv(obj, ga=self.Ga)
 
     def list(self) -> List[Expr]:
@@ -1655,11 +1655,11 @@ class Dop(dop._BaseDop):
                     mv_coef = coef.obj
                 else:
                     mv_coef = coef
-                if S(1) in bases:
-                    index = bases.index(S(1))
+                if S.One in bases:
+                    index = bases.index(S.One)
                     coefs[index] += dop.Sdop([(mv_coef, pdiff)])
                 else:
-                    bases.append(S(1))
+                    bases.append(S.One)
                     coefs.append(dop.Sdop([(mv_coef, pdiff)]))
         if modes is not None:
             for i in range(len(coefs)):
@@ -1677,7 +1677,7 @@ class Dop(dop._BaseDop):
         for sdop, base in mv_terms:
             str_base = print_obj._print(base)
             str_sdop = print_obj._print(sdop)
-            if base == S(1):
+            if base == S.One:
                 s += str_sdop
             else:
                 if len(sdop.terms) > 1:
@@ -1713,7 +1713,7 @@ class Dop(dop._BaseDop):
         for sdop, base in mv_terms:
             str_base = print_obj._print(base)
             str_sdop = print_obj._print(sdop)
-            if base == S(1):
+            if base == S.One:
                 s += str_sdop
             else:
                 if str_sdop == '1':

--- a/test/test_test.py
+++ b/test/test_test.py
@@ -1,21 +1,23 @@
 import sys
 import pytest
-from sympy import symbols, sin, cos, Rational, expand, collect, simplify, Symbol, S, Add
+from sympy import symbols, sin, cos, Rational, expand, collect, simplify, Symbol, Add, S
 from galgebra.printer import Format, Eprint, latex, GaPrinter
-from galgebra.ga import Ga, one, zero
+from galgebra.ga import Ga
 from galgebra.mv import Mv, Nga
 # for backward compatibility
-from galgebra.mv import ONE, ZERO, HALF
 from galgebra import ga, metric
+
+one = S.One
+
 
 def F(x):
     global n, nbar
-    Fx =  HALF * ((x * x) * n + 2 * x - nbar)
+    Fx =  S.Half * ((x * x) * n + 2 * x - nbar)
     return Fx
 
 def make_vector(a, n=3, ga=None):
     if isinstance(a, str):
-        v = zero
+        v = S.Zero
         for i in range(n):
             a_i = Symbol(a+str(i+1))
             v += a_i*ga.basis[i]


### PR DESCRIPTION
We don't need these at all, sympy provides them as `S.One`, `S.Half`, and `S.Zero`.

Note that `S.One` is about 20x faster than `S(1)`, although this won't really make any difference.

Unlike #267, this does not remove the ones that are used in examples from the public API.