### PR TITLE
Fix the broken release links to include the v [ci skip]

### DIFF
--- a/doc/_sphinxext/releases_hack.py
+++ b/doc/_sphinxext/releases_hack.py
@@ -10,6 +10,6 @@ class release_uri:
         self._path = releases_github_path
 
     def __mod__(self, release):
-        if release.isdigit():
+        if release[0].isdigit():
             release = "v" + release
         return 'https://github.com/%s/tree/%s' % (self._path, release)

--- a/doc/_sphinxext/releases_hack.py
+++ b/doc/_sphinxext/releases_hack.py
@@ -1,0 +1,15 @@
+"""
+Workaround for https://github.com/bitprophet/releases/issues/65
+
+This has to be in its own file, as for some reason classes in conf.py cannot
+be pickled.
+"""
+
+class release_uri:
+    def __init__(self, releases_github_path):
+        self._path = releases_github_path
+
+    def __mod__(self, release):
+        if release.isdigit():
+            release = "v" + release
+        return 'https://github.com/%s/tree/%s' % (self._path, release)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -12,14 +12,16 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import os
+import sys
+sys.path.append(os.path.abspath('_sphinxext'))
+
 
 # -- Imports
 
 import sphinx_rtd_theme
 import sphinx
+import releases_hack
 
 # -- Project information -----------------------------------------------------
 
@@ -206,6 +208,7 @@ pygments_style = 'sphinx'
 # to e.g. account/project. Releases will then use an appropriate Github URL for both
 # releases and issues.
 releases_github_path = 'pygae/galgebra'
+releases_release_uri = releases_hack.release_uri(releases_github_path)
 
 # You may optionally set releases_debug = True to see debug output while building your docs.
 releases_debug = True


### PR DESCRIPTION
Our tag names start with v, but the default for releases is to not use a v.

https://galgebra--407.org.readthedocs.build/en/407/changelog.html

This fixes the tags, but breaks the "next release" link...

xref https://github.com/bitprophet/releases/issues/65