### PR TITLE
Use LaTeX to show the galgebra logo in the top left

### DIFF
--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -9,7 +9,7 @@
 
   {# this div is instead of the usual logo. The height is picked to avoid a jump
      when mathjax renders #}
-  <div class="math notranslate nohighlight" style="height: 4.4em; display: table">
+  <div class="math notranslate nohighlight" style="height: 4.4em; display: table; color: transparent">
   	\[\color{white}{\huge\mathcal{G\!A}\hspace{0.01in}\mathbf{lgebra}}\]
   </div>
 

--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -1,0 +1,32 @@
+{% extends "!layout.html" %}
+{% block sidebartitle %}
+
+  {% if logo and theme_logo_only %}
+    <a href="{{ pathto(master_doc) }}">
+  {% else %}
+    <a href="{{ pathto(master_doc) }}" class="icon icon-home" alt="{{ _("Documentation Home") }}"> {{ project }}
+  {% endif %}
+
+  {# this div is instead of the usual logo. The height is picked to avoid a jump
+     when mathjax renders #}
+  <div class="math notranslate nohighlight" style="height: 4.4em; display: table">
+  	\[\color{white}{\huge\mathcal{G\!A}\hspace{0.01in}\mathbf{lgebra}}\]
+  </div>
+
+  </a>
+
+  {% if theme_display_version %}
+    {%- set nav_version = version %}
+    {% if READTHEDOCS and current_version %}
+      {%- set nav_version = current_version %}
+    {% endif %}
+    {% if nav_version %}
+      <div class="version">
+        {{ nav_version }}
+      </div>
+    {% endif %}
+  {% endif %}
+
+  {% include "searchbox.html" %}
+
+{% endblock %}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -72,6 +72,10 @@ def add_source_parser(_old_add_source_parser, self, *args, **kwargs):
         args = args[1:]
     return _old_add_source_parser(self, *args, **kwargs)
 
+# This is not actually used as we have a template overload to render this with
+# latex. Leaving it here in case we change theme.
+html_logo = "images/galgebra.svg"
+
 # -- nbsphinx configuration ---------------------------------------------------
 
 import galgebra
@@ -135,7 +139,7 @@ galgebra_latex_macros = R"""
 # enable autonumbering
 mathjax_config = dict(TeX=dict(
     equationNumbers=dict(autoNumber="AMS"),
-    extensions=["[Contrib]/preamble/preamble.js"],
+    extensions=["[Contrib]/preamble/preamble.js", "color.js"],
     preamble=[galgebra_latex_macros]
 ))
 
@@ -228,7 +232,9 @@ html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-# html_theme_options = {}
+html_theme_options = dict(
+    logo_only=True,
+)
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/425260/83013890-a61e9180-a015-11ea-9083-ee1a6dc01c8c.png)

Albeit briefly at startup

![image](https://user-images.githubusercontent.com/425260/83014017-d6663000-a015-11ea-90ae-1d22f25d6071.png)

