### PR TITLE
Split the readme into standalone documentation pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Development Status
 
 ![PyPI - Status](https://img.shields.io/pypi/status/galgebra.svg) ![GitHub contributors](https://img.shields.io/github/contributors/pygae/galgebra.svg) [![Codacy Badge](https://api.codacy.com/project/badge/Grade/fe7642c639a54d909a36c75db6c2fa49)](https://app.codacy.com/app/utensilcandel/galgebra?utm_source=github.com&utm_medium=referral&utm_content=pygae/galgebra&utm_campaign=Badge_Grade_Settings) [![Codecov](https://img.shields.io/codecov/c/github/pygae/galgebra.svg)](https://codecov.io/gh/pygae/galgebra)
 
-[brombo/galgebra][] was originally written by Alan Bromborsky, but was no longer actively maintained, and as of 2019-11-25 no longer exists.
+[brombo/galgebra](https://github.com/brombo/galgebra) was originally written by Alan Bromborsky, but was no longer actively maintained, and as of 2019-11-25 no longer exists.
 
 [pygae/galgebra](https://github.com/pygae/galgebra) is a community fork, maintained by [Pythonic Geometric Algebra Enthusiasts](https://github.com/pygae).
 
@@ -74,6 +74,10 @@ o3d = Ga('e', g=[1,1,1], coords=symbols('x,y,z',real=True))
   - out-of-the-box support for Jupyter Notebook
   - PDF generation and croping support if you have `pdflatex`/`pdfcrop` installed
 
+<!-- Note: These comments are parsed by our sphinx documentation -->
+
+<!-- begin: getting-started -->
+
 Getting Started
 ---------------------
 
@@ -104,7 +108,10 @@ You may also check out more examples [here](https://github.com/pygae/galgebra/bl
 
 For detailed documentation, please visit https://galgebra.readthedocs.io/ .
 
-**NOTE:** If you are coming from [sympy.galgebra](https://docs.sympy.org/0.7.6.1/modules/galgebra/) or [brombo/galgebra][], please check out section [Migration Guide](#migration-guide) below.
+**NOTE:** If you are coming from [sympy.galgebra](https://docs.sympy.org/0.7.6.1/modules/galgebra/) or [brombo/galgebra](https://github.com/brombo/galgebra), please check out section [Migration Guide](#migration-guide) below.
+
+<!-- end: getting-started -->
+<!-- begin: installation -->
 
 Installing GAlgebra
 ---------------------
@@ -151,6 +158,9 @@ pytest --nbval examples/ipython/ test --current-env --sanitize-with test/.nbval_
 
 This could take more than 10 minutes, please be patient.
 
+<!-- end: installation -->
+<!-- begin: migration -->
+
 Migration Guide
 ----------------
 
@@ -168,7 +178,7 @@ Simply remove the `sympy.` prefix before `galgebra` then you are good to go:
 from galgebra.ga import *
 ```
 
-### Migrating from [brombo/galgebra][]
+### Migrating from [brombo/galgebra](https://github.com/pygae/galgebra)
 
 The `setgapth.py` way to install is now deprecated by `pip install galgebra` and all modules in GAlgebra should be imported from `galgebra`, for example:
 
@@ -177,6 +187,9 @@ from galgebra.printer import Format, Eprint, Get_Program, latex, GaPrinter
 from galgebra.ga import Ga, one, zero
 from galgebra.mv import Mv, Nga
 ```
+
+<!-- end: migration -->
+<!-- begin: bundled-resources -->
 
 Bundled Resources
 ------------------
@@ -187,4 +200,4 @@ Note that in the [doc/books](https://github.com/pygae/galgebra/blob/master/doc/b
 - `galgebra.pdf` which is the original main doc of GAlgebra in PDF format, while the math part is still valid, the part describing the installation and usage of GAlgebra is outdated, please read with cautious or visit https://galgebra.readthedocs.io/ instead.
 - `Macdonald` which constains bundled supplementary materials for [Linear and Geometric Algebra](http://www.faculty.luther.edu/~macdonal/laga/index.html) and [Vector and Geometric Calculus](http://www.faculty.luther.edu/~macdonal/vagc/index.html) by Alan Macdonald, see [here](https://github.com/pygae/galgebra/blob/master/doc/books/Macdonald/) and [here](https://github.com/pygae/galgebra/blob/master/examples/Macdonald/) for more information.
 
-[brombo/galgebra]: https://web.archive.org/web/20180611145113/https://github.com/brombo/galgebra
+<!-- end: bundled-resources -->

--- a/doc/_sphinxext/md_include.py
+++ b/doc/_sphinxext/md_include.py
@@ -1,0 +1,99 @@
+import sys
+import os.path
+import time
+from docutils import io, nodes, statemachine, utils
+from docutils.utils.error_reporting import SafeString, ErrorString
+from docutils.parsers.rst import Directive
+from docutils.parsers.rst import directives, states
+
+
+from sphinx.directives.code import LiteralIncludeReader
+from recommonmark.parser import CommonMarkParser
+
+
+class MdInclude(Directive):
+
+    """ Include a markdown file in an rst file.  """
+
+    required_arguments = 1
+    optional_arguments = 0
+    final_argument_whitespace = True
+    option_spec = {'start-line': int,
+                   'end-line': int,
+                   'start-after': directives.unchanged_required,
+                   'end-before': directives.unchanged_required,
+                   'encoding': directives.encoding,}
+
+    standard_include_path = os.path.join(os.path.dirname(states.__file__),
+                                         'include')
+
+    def run(self):
+        """Include a file as part of the content of this reST file."""
+
+        # copied from docutils.parsers.rst.directives.misc.Include
+        if not self.state.document.settings.file_insertion_enabled:
+            raise self.warning('"%s" directive disabled.' % self.name)
+        source = self.state_machine.input_lines.source(
+            self.lineno - self.state_machine.input_offset - 1)
+        source_dir = os.path.dirname(os.path.abspath(source))
+        path = directives.path(self.arguments[0])
+        if path.startswith('<') and path.endswith('>'):
+            path = os.path.join(self.standard_include_path, path[1:-1])
+        path = os.path.normpath(os.path.join(source_dir, path))
+        path = utils.relative_path(None, path)
+        path = nodes.reprunicode(path)
+        encoding = self.options.get(
+            'encoding', self.state.document.settings.input_encoding)
+        e_handler=self.state.document.settings.input_encoding_error_handler
+        try:
+            self.state.document.settings.record_dependencies.add(path)
+            include_file = io.FileInput(source_path=path,
+                                        encoding=encoding,
+                                        error_handler=e_handler)
+        except UnicodeEncodeError as error:
+            raise self.severe(u'Problems with "%s" directive path:\n'
+                              'Cannot encode input file path "%s" '
+                              '(wrong locale?).' %
+                              (self.name, SafeString(path)))
+        except IOError as error:
+            raise self.severe(u'Problems with "%s" directive path:\n%s.' %
+                      (self.name, ErrorString(error)))
+        startline = self.options.get('start-line', None)
+        endline = self.options.get('end-line', None)
+        try:
+            if startline or (endline is not None):
+                lines = include_file.readlines()
+                rawtext = ''.join(lines[startline:endline])
+            else:
+                rawtext = include_file.read()
+        except UnicodeError as error:
+            raise self.severe(u'Problem with "%s" directive:\n%s' %
+                              (self.name, ErrorString(error)))
+        # start-after/end-before: no restrictions on newlines in match-text,
+        # and no restrictions on matching inside lines vs. line boundaries
+        after_text = self.options.get('start-after', None)
+        if after_text:
+            # skip content in rawtext before *and incl.* a matching text
+            after_index = rawtext.find(after_text)
+            if after_index < 0:
+                raise self.severe('Problem with "start-after" option of "%s" '
+                                  'directive:\nText not found.' % self.name)
+            rawtext = rawtext[after_index + len(after_text):]
+        before_text = self.options.get('end-before', None)
+        if before_text:
+            # skip content in rawtext after *and incl.* a matching text
+            before_index = rawtext.find(before_text)
+            if before_index < 0:
+                raise self.severe('Problem with "end-before" option of "%s" '
+                                  'directive:\nText not found.' % self.name)
+            rawtext = rawtext[:before_index]
+    
+        # copied code ends
+        parser = CommonMarkParser()
+        md_document = utils.new_document(path, self.state.document.settings)
+        parser.parse(rawtext, md_document)
+        return md_document.children
+
+
+def setup(app):
+    directives.register_directive('mdinclude', MdInclude)

--- a/doc/bundled-resources.rst
+++ b/doc/bundled-resources.rst
@@ -1,0 +1,3 @@
+.. mdinclude:: ../README.md
+    :start-after: <!-- begin: bundled-resources -->
+    :end-before: <!-- end: bundled-resources -->

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -51,28 +51,12 @@ extensions = [
     'IPython.sphinxext.ipython_directive',
     'IPython.sphinxext.ipython_console_highlighting',
     'sphinx_markdown_tables',
-    'm2r',
     'releases',
     'sphinxcontrib.bibtex',
+
+    # local extensions
+    'md_include',
 ]
-
-
-def monkeypatch(cls):
-    """ decorator to monkey-patch methods """
-    def decorator(f):
-        method = f.__name__
-        old_method = getattr(cls, method)
-        setattr(cls, method, lambda self, *args, **kwargs: f(old_method, self, *args, **kwargs))
-    return decorator
-
-# workaround until https://github.com/miyakogi/m2r/pull/55 is merged
-@monkeypatch(sphinx.registry.SphinxComponentRegistry)
-def add_source_parser(_old_add_source_parser, self, *args, **kwargs):
-    # signature is (parser: Type[Parser], **kwargs), but m2r expects
-    # the removed (str, parser: Type[Parser], **kwargs).
-    if isinstance(args[0], str):
-        args = args[1:]
-    return _old_add_source_parser(self, *args, **kwargs)
 
 # -- nbsphinx configuration ---------------------------------------------------
 

--- a/doc/getting-started.rst
+++ b/doc/getting-started.rst
@@ -1,0 +1,3 @@
+.. mdinclude:: ../README.md
+    :start-after: <!-- begin: getting-started -->
+    :end-before: <!-- end: getting-started -->

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,13 +1,18 @@
 .. mdinclude:: ../README.md
+    :end-before: <!-- begin:
+
+.. these are all hidden, because they render more clearly in the sidebar.
 
 .. toctree::
-    :caption: API
-    :maxdepth: 3
-    
-    api
+    :maxdepth: 2
+    :hidden:
+
+    getting-started
+    installation
 
 .. toctree::
     :caption: A guide to GAlgebra
+    :hidden:
 
     galgebra_guide
     sympy-representation
@@ -16,15 +21,26 @@
 .. toctree::
     :caption: Tutorials
     :maxdepth: 2
+    :hidden:
 
     tutorials/algebra
 
 .. toctree::
+    :caption: API
+    :maxdepth: 3
+    :hidden:
+    
+    api
+
+.. toctree::
     :caption: Other information
     :maxdepth: 2
+    :hidden:
 
     changelog
     bibliography
+    migration
+    bundled-resources
 
 Indices and tables
 ==================

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -1,0 +1,3 @@
+.. mdinclude:: ../README.md
+    :start-after: <!-- begin: installation -->
+    :end-before: <!-- end: installation -->

--- a/doc/migration.rst
+++ b/doc/migration.rst
@@ -1,0 +1,3 @@
+.. mdinclude:: ../README.md
+    :start-after: <!-- begin: migration -->
+    :end-before: <!-- end: migration -->

--- a/doc/readthedocs-pip-requirements.txt
+++ b/doc/readthedocs-pip-requirements.txt
@@ -12,7 +12,6 @@ ipykernel
 nbsphinx
 numba
 sphinx_rtd_theme
-recommonmark
 sphinx-markdown-tables
 notedown
 semantic-version==2.6.0
@@ -22,3 +21,6 @@ nbsphinx-link
 
 # the first release to support f-strings
 pygments >= 2.5.0
+
+# previous releases did not render our README badges correctly
+recommonmark>=0.6.0

--- a/doc/readthedocs-pip-requirements.txt
+++ b/doc/readthedocs-pip-requirements.txt
@@ -15,7 +15,6 @@ sphinx_rtd_theme
 recommonmark
 sphinx-markdown-tables
 notedown
-m2r
 semantic-version==2.6.0
 releases>=1.6.1
 sphinxcontrib-bibtex


### PR DESCRIPTION
See commit messages

New TOC is:

![image](https://user-images.githubusercontent.com/425260/83053575-d6335800-a048-11ea-8c1a-836f0aebb5f4.png)

https://galgebra--413.org.readthedocs.build/en/413/

xref https://github.com/readthedocs/recommonmark/issues/191, which I should upstream to at some point.

-----
[View rendered README.md](https://github.com/eric-wieser/galgebra/blob/use-recommonmark/README.md)