### PR TITLE
Remove Get_Program, one, and zero from example imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,8 +183,8 @@ from galgebra.ga import *
 The `setgapth.py` way to install is now deprecated by `pip install galgebra` and all modules in GAlgebra should be imported from `galgebra`, for example:
 
 ```python
-from galgebra.printer import Format, Eprint, Get_Program, latex, GaPrinter
-from galgebra.ga import Ga, one, zero
+from galgebra.printer import Format, Eprint, latex, GaPrinter
+from galgebra.ga import Ga
 from galgebra.mv import Mv, Nga
 ```
 

--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ Installing GAlgebra
 ### Prerequisites
 
 - Works on Linux, Windows, Mac OSX
-- [Python](https://www.python.org/) >=3.5
-- [SymPy](https://www.sympy.org) 1.3, 1.4 or preferably 1.5
+- [Python](https://www.python.org/) >= 3.5  (0.4.x was the last supported release series for Python 2.7)
+- [SymPy](https://www.sympy.org) >= 1.3
 
 ### Installing GAlgebra From PyPI (Recommended for users)
 


### PR DESCRIPTION
The first of these is deprecated, the last two are not public API and should be spelt `S.One` and `S.Zero`.

Part of gh-394

-----
[View rendered README.md](https://github.com/pygae/galgebra/blob/eric-wieser/one-zero-readme/README.md)