### PR TITLE
Update Migration Guide to mention API changes  [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ This could take more than 10 minutes, please be patient.
 Migration Guide
 ----------------
 
+> Note: The APIs have changed since the era of `sympy.galgebra` and `brombo/galgebra`, same for the supported versions of Python and SymPy, please check [Changelog](https://galgebra.readthedocs.io/en/latest/changelog.html) and further update your scripts accordingly besides the following. If you encounter any problems, feel free to open an issue!
+
 ### Migrating from [sympy.galgebra](https://docs.sympy.org/0.7.6.1/modules/galgebra/)
 
 GAlgebra is no longer part of SymPy since 1.0.0, if you have an import like this in your source:
@@ -178,7 +180,7 @@ Simply remove the `sympy.` prefix before `galgebra` then you are good to go:
 from galgebra.ga import *
 ```
 
-### Migrating from [brombo/galgebra](https://github.com/pygae/galgebra)
+### Migrating from [brombo/galgebra](https://github.com/brombo/galgebra)
 
 The `setgapth.py` way to install is now deprecated by `pip install galgebra` and all modules in GAlgebra should be imported from `galgebra`, for example:
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ This could take more than 10 minutes, please be patient.
 Migration Guide
 ----------------
 
-> Note: The APIs have changed since the era of `sympy.galgebra` and `brombo/galgebra`, some properties and methods are deprecated, the supported versions of Python and SymPy have also changed, please check [Changelog](https://galgebra.readthedocs.io/en/latest/changelog.html) and further update your scripts accordingly besides the following. If you encounter any problems, feel free to open an issue!
+> Note: The APIs have changed since the era of `sympy.galgebra` and `brombo/galgebra`, some properties and methods are deprecated, the supported versions of Python and SymPy have also changed, please check [Changelog](https://galgebra.readthedocs.io/en/latest/changelog.html) and further update your scripts accordingly besides the following. If you encounter any problems, feel free to [open an issue](https://github.com/pygae/galgebra/issues/new)!
 
 ### Migrating from [sympy.galgebra](https://docs.sympy.org/0.7.6.1/modules/galgebra/)
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ This could take more than 10 minutes, please be patient.
 Migration Guide
 ----------------
 
-> Note: The APIs have changed since the era of `sympy.galgebra` and `brombo/galgebra`, same for the supported versions of Python and SymPy, please check [Changelog](https://galgebra.readthedocs.io/en/latest/changelog.html) and further update your scripts accordingly besides the following. If you encounter any problems, feel free to open an issue!
+> Note: The APIs have changed since the era of `sympy.galgebra` and `brombo/galgebra`, some properties and methods are deprecated, the supported versions of Python and SymPy have also changed, please check [Changelog](https://galgebra.readthedocs.io/en/latest/changelog.html) and further update your scripts accordingly besides the following. If you encounter any problems, feel free to open an issue!
 
 ### Migrating from [sympy.galgebra](https://docs.sympy.org/0.7.6.1/modules/galgebra/)
 


### PR DESCRIPTION
Address the second bullet point in #394.

-----
[View rendered README.md](https://github.com/pygae/galgebra/blob/update-migration-guide/README.md)