### PR TITLE
Respect customizations made in sympy.init_printing

### DIFF
--- a/examples/ipython/gsym-printing.ipynb
+++ b/examples/ipython/gsym-printing.ipynb
@@ -111,7 +111,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Printed within an Mv. Note that galgebra's default printer shows determinants with $\\det (M)$."
+    "Printed within an Mv. No change."
    ]
   },
   {
@@ -122,7 +122,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*}- \\det\\left ( f\\right )\\end{equation*}"
+       "$\\displaystyle - \\left|{f}\\right|$"
       ],
       "text/plain": [
        "-Determinant(f)"
@@ -134,7 +134,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*}- \\det\\left ( g\\right )\\end{equation*}"
+       "$\\displaystyle - \\left|{g}\\right|$"
       ],
       "text/plain": [
        "-Determinant(g)"
@@ -146,7 +146,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*}- \\det\\left ( f {\\left (u,v \\right )}\\right )\\end{equation*}"
+       "$\\displaystyle - \\left|{f{\\left(u,v \\right)}}\\right|$"
       ],
       "text/plain": [
        "-Determinant(f)"
@@ -158,7 +158,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*}- \\det\\left ( g {\\left (u,v \\right )}\\right )\\end{equation*}"
+       "$\\displaystyle - \\left|{g{\\left(u,v \\right)}}\\right|$"
       ],
       "text/plain": [
        "-Determinant(g)"

--- a/examples/ipython/printing-galgebra.ipynb
+++ b/examples/ipython/printing-galgebra.ipynb
@@ -121,7 +121,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} \\boldsymbol{e}_{1}\\wedge \\boldsymbol{e}_{2}\\wedge \\boldsymbol{e}_{3}\\wedge \\boldsymbol{e}\\wedge \\boldsymbol{e}_{{0}}\\end{equation*}"
+       "$\\displaystyle  \\mathbf{e_{1}}\\wedge \\mathbf{e_{2}}\\wedge \\mathbf{e_{3}}\\wedge \\mathbf{e}\\wedge \\mathbf{e_{0}}$"
       ],
       "text/plain": [
        "e_1^e_2^e_3^e^e_{0}"

--- a/examples/ipython/tutorial_algebra.ipynb
+++ b/examples/ipython/tutorial_algebra.ipynb
@@ -172,7 +172,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*}S = S\\end{equation*}"
+       "$\\displaystyle S = S$"
       ],
       "text/plain": [
        "S"
@@ -195,7 +195,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*}V = V^{x} \\boldsymbol{e}_{x} + V^{y} \\boldsymbol{e}_{y} + V^{z} \\boldsymbol{e}_{z}\\end{equation*}"
+       "$\\displaystyle V = V^{x} \\boldsymbol{e}_{x} + V^{y} \\boldsymbol{e}_{y} + V^{z} \\boldsymbol{e}_{z}$"
       ],
       "text/plain": [
        "V__x*e_x + V__y*e_y + V__z*e_z"
@@ -218,7 +218,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*}B = B^{xy} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + B^{xz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + B^{yz} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}\\end{equation*}"
+       "$\\displaystyle B = B^{xy} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + B^{xz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + B^{yz} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}$"
       ],
       "text/plain": [
        "B__xy*e_x^e_y + B__xz*e_x^e_z + B__yz*e_y^e_z"
@@ -241,7 +241,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*}I = I^{xyz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}\\end{equation*}"
+       "$\\displaystyle I = I^{xyz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}$"
       ],
       "text/plain": [
        "I__xyz*e_x^e_y^e_z"
@@ -388,7 +388,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*}B = B^{xy} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + B^{xz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + B^{yz} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}\\end{equation*}"
+       "$\\displaystyle B = B^{xy} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + B^{xz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + B^{yz} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}$"
       ],
       "text/plain": [
        "B__xy*e_x^e_y + B__xz*e_x^e_z + B__yz*e_y^e_z"
@@ -585,7 +585,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*}M  + M^{x} \\boldsymbol{e}_{x} + M^{y} \\boldsymbol{e}_{y} + M^{z} \\boldsymbol{e}_{z} + M^{xy} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + M^{xz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + M^{yz} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} + M^{xyz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}\\end{equation*}"
+       "$\\displaystyle M  + M^{x} \\boldsymbol{e}_{x} + M^{y} \\boldsymbol{e}_{y} + M^{z} \\boldsymbol{e}_{z} + M^{xy} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + M^{xz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + M^{yz} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} + M^{xyz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}$"
       ],
       "text/plain": [
        "M + M__x*e_x + M__y*e_y + M__z*e_z + M__xy*e_x^e_y + M__xz*e_x^e_z + M__yz*e_y^e_z + M__xyz*e_x^e_y^e_z"
@@ -608,7 +608,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} \\begin{aligned}[t]  & M  \\\\  &  + M^{x} \\boldsymbol{e}_{x} + M^{y} \\boldsymbol{e}_{y} + M^{z} \\boldsymbol{e}_{z} \\\\  &  + M^{xy} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + M^{xz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + M^{yz} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} \\\\  &  + M^{xyz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}  \\end{aligned} \\end{equation*}"
+       "$\\displaystyle  \\begin{aligned}[t]  & M  \\\\  &  + M^{x} \\boldsymbol{e}_{x} + M^{y} \\boldsymbol{e}_{y} + M^{z} \\boldsymbol{e}_{z} \\\\  &  + M^{xy} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + M^{xz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + M^{yz} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} \\\\  &  + M^{xyz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}  \\end{aligned} $"
       ],
       "text/plain": [
        " M\n",
@@ -634,7 +634,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} \\begin{aligned}[t]  & M  \\\\  &  + M^{x} \\boldsymbol{e}_{x} \\\\  &  + M^{y} \\boldsymbol{e}_{y} \\\\  &  + M^{z} \\boldsymbol{e}_{z} \\\\  &  + M^{xy} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} \\\\  &  + M^{xz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} \\\\  &  + M^{yz} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} \\\\  &  + M^{xyz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}  \\end{aligned} \\end{equation*}"
+       "$\\displaystyle  \\begin{aligned}[t]  & M  \\\\  &  + M^{x} \\boldsymbol{e}_{x} \\\\  &  + M^{y} \\boldsymbol{e}_{y} \\\\  &  + M^{z} \\boldsymbol{e}_{z} \\\\  &  + M^{xy} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} \\\\  &  + M^{xz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} \\\\  &  + M^{yz} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} \\\\  &  + M^{xyz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}  \\end{aligned} $"
       ],
       "text/plain": [
        " M\n",


### PR DESCRIPTION
In sympy 1.7, we can use the new base class to inherit the printer.
In earlier versions, we have to poke around in IPython internals to find the appropriate printer.

This means that `GaLatexPrinter` is no longer used by default, but that's ok because:

* All our examples either call `Format` to enable it, or use `init_printing`
* `GaLatexPrinter` no longer does anything essential like it used to - all galgebra objects print to latex without it, all it adds is subjective tweaks to:
  * Determinant printing
  * Derivative printing
  * Function printing (omitting arguments, subscripts)