### PR TITLE
Fix printing antipattern

### DIFF
--- a/galgebra/atoms.py
+++ b/galgebra/atoms.py
@@ -71,7 +71,7 @@ class _JoinedPrinterMixin(Basic):
 
     def _sympystr(self, printer):
         return self._op_sympystr.join(
-            printer.doprint(v)
+            printer._print(v)
             for v in self.args
         )
 

--- a/galgebra/dop.py
+++ b/galgebra/dop.py
@@ -121,8 +121,8 @@ class Sdop(_BaseDop):
         self = self._with_sorted_terms()
         s = ''
         for coef, pdop in self.terms:
-            coef_str = print_obj.doprint(coef)
-            pd_str = print_obj.doprint(pdop)
+            coef_str = print_obj._print(coef)
+            pd_str = print_obj._print(pdop)
 
             if coef == S(1):
                 s += pd_str
@@ -147,8 +147,8 @@ class Sdop(_BaseDop):
 
         s = ''
         for coef, pdop in self.terms:
-            coef_str = print_obj.doprint(coef)
-            pd_str = print_obj.doprint(pdop)
+            coef_str = print_obj._print(coef)
+            pd_str = print_obj._print(pdop)
             if coef == S(1):
                 if pd_str == '':
                     s += '1'
@@ -363,10 +363,10 @@ class Pdop(_BaseDop):
             return 'D{}'
         s = 'D'
         for x in self.pdiffs:
-            s += '{' + print_obj.doprint(x) + '}'
+            s += '{' + print_obj._print(x) + '}'
             n = self.pdiffs[x]
             if n > 1:
-                s += '^' + print_obj.doprint(n)
+                s += '^' + print_obj._print(n)
         return s
 
     def _latex(self, print_obj):
@@ -374,14 +374,14 @@ class Pdop(_BaseDop):
             return ''
         s = r'\frac{\partial'
         if self.order > 1:
-            s += '^{' + print_obj.doprint(self.order) + '}'
+            s += '^{' + print_obj._print(self.order) + '}'
         s += '}{'
         keys = list(self.pdiffs.keys())
         keys.sort(key=lambda x: x.sort_key())
         for key in keys:
             i = self.pdiffs[key]
-            s += r'\partial ' + print_obj.doprint(key)
+            s += r'\partial ' + print_obj._print(key)
             if i > 1:
-                s += '^{' + print_obj.doprint(i) + '}'
+                s += '^{' + print_obj._print(i) + '}'
         s += '}'
         return s

--- a/galgebra/lt.py
+++ b/galgebra/lt.py
@@ -409,15 +409,15 @@ class Lt(printer.GaPrintable):
     def _sympystr(self, print_obj):
 
         if self.spinor:
-            return 'R = ' + print_obj.doprint(self.R)
+            return 'R = ' + print_obj._print(self.R)
         else:
             pre = 'Lt('
             s = ''
             for base in self.Ga.basis:
                 if base in self.lt_dict:
-                    s += pre + print_obj.doprint(base) + ') = ' + print_obj.doprint(mv.Mv(self.lt_dict[base], ga=self.Ga)) + '\n'
+                    s += pre + print_obj._print(base) + ') = ' + print_obj._print(mv.Mv(self.lt_dict[base], ga=self.Ga)) + '\n'
                 else:
-                    s += pre + print_obj.doprint(base) + ') = 0\n'
+                    s += pre + print_obj._print(base) + ') = 0\n'
             return s[:-1]
 
     def _latex(self, print_obj):
@@ -425,16 +425,16 @@ class Lt(printer.GaPrintable):
         if self.spinor:
             s = '\\left \\{ \\begin{array}{ll} '
             for base in self.Ga.basis:
-                str_base = print_obj.doprint(base)
-                s += 'L \\left ( ' + str_base + '\\right ) =& ' + print_obj.doprint(self.R * mv.Mv(base, ga=self.Ga) * self.Rrev) + ' \\\\ '
+                str_base = print_obj._print(base)
+                s += 'L \\left ( ' + str_base + '\\right ) =& ' + print_obj._print(self.R * mv.Mv(base, ga=self.Ga) * self.Rrev) + ' \\\\ '
             s = s[:-3] + ' \\end{array} \\right \\} \n'
             return s
         else:
             s = '\\left \\{ \\begin{array}{ll} '
             for base in self.Ga.basis:
-                str_base = print_obj.doprint(base)
+                str_base = print_obj._print(base)
                 if base in self.lt_dict:
-                    s += 'L \\left ( ' + str_base + '\\right ) =& ' + print_obj.doprint(mv.Mv(self.lt_dict[base], ga=self.Ga)) + ' \\\\ '
+                    s += 'L \\left ( ' + str_base + '\\right ) =& ' + print_obj._print(mv.Mv(self.lt_dict[base], ga=self.Ga)) + ' \\\\ '
                 else:
                     s += 'L \\left ( ' + str_base + '\\right ) =& 0 \\\\ '
             s = s[:-3] + ' \\end{array} \\right \\} \n'
@@ -563,11 +563,11 @@ class Mlt(printer.GaPrintable):
         return Ga.basis_super_scripts
 
     def _sympystr(self, print_obj):
-        return print_obj.doprint(self.fvalue)
+        return print_obj._print(self.fvalue)
 
     def _latex(self, print_obj):
         if self.nargs <= 1:
-            return print_obj.doprint(self.fvalue)
+            return print_obj._print(self.fvalue)
         expr_lst = Mlt.expand_expr(self.fvalue, self.Ga)
         latex_str = '\\begin{aligned} '
         first = True
@@ -575,7 +575,7 @@ class Mlt(printer.GaPrintable):
         cnt = 1  # Component count on line
         for term in expr_lst:
             coef_str = str(term[0])
-            coef_latex = print_obj.doprint(term[0])
+            coef_latex = print_obj._print(term[0])
             term_add_flg = isinstance(term[0], Add)
             if term_add_flg:
                 coef_latex = r'\left ( ' + coef_latex + r'\right ) '
@@ -585,7 +585,7 @@ class Mlt(printer.GaPrintable):
                 if coef_str[0].strip() != '-' or term_add_flg:
                     coef_latex = ' + ' + coef_latex
             for aij in term[1]:
-                coef_latex += print_obj.doprint(aij) + ' '
+                coef_latex += print_obj._print(aij) + ' '
             if cnt == 1:
                 latex_str += ' & ' + coef_latex
             else:

--- a/galgebra/mv.py
+++ b/galgebra/mv.py
@@ -585,7 +585,7 @@ class Mv(printer.GaPrintable):
             return self * (S(1)/A)
 
     def __str__(self):
-        return printer.GaPrinter().doprint(self)
+        return printer.GaPrinter()._print(self)
 
     def __getitem__(self, key: int) -> 'Mv':
         '''
@@ -601,7 +601,7 @@ class Mv(printer.GaPrintable):
         self = Mv(obj, ga=self.Ga)
 
         if self.i_grade == 0:
-            return print_obj.doprint(self.obj)
+            return print_obj._print(self.obj)
 
         if self.is_blade_rep or self.Ga.is_ortho:
             base_keys = self.Ga.blades.flat
@@ -634,14 +634,14 @@ class Mv(printer.GaPrintable):
             terms = list(terms.items())
             sorted_terms = sorted(terms, key=operator.itemgetter(0))  # sort via base indexes
 
-            s = print_obj.doprint(sorted_terms[0][1][0] * sorted_terms[0][1][1])
+            s = print_obj._print(sorted_terms[0][1][0] * sorted_terms[0][1][1])
             if print_obj._settings['galgebra_mv_fmt'] == 3:
                 s = ' ' + s + '\n'
             if print_obj._settings['galgebra_mv_fmt'] == 2:
                 s = ' ' + s
             old_grade = sorted_terms[0][1][2]
             for (key, (c, base, grade)) in sorted_terms[1:]:
-                term = print_obj.doprint(c * base)
+                term = print_obj._print(c * base)
                 if print_obj._settings['galgebra_mv_fmt'] == 2 and old_grade != grade:  # one grade per line
                     old_grade = grade
                     s += '\n'
@@ -657,7 +657,7 @@ class Mv(printer.GaPrintable):
                 s = s[:-1]
             return s
         else:
-            return print_obj.doprint(self.obj)
+            return print_obj._print(self.obj)
 
     def _latex(self, print_obj: _LatexPrinter) -> str:
 
@@ -720,7 +720,7 @@ class Mv(printer.GaPrintable):
         sorted_terms = sorted(terms, key=operator.itemgetter(0))  # sort via base indexes
 
         if len(sorted_terms) == 1 and sorted_terms[0][1][2] == 0:  # scalar
-            return print_obj.doprint(printer.coef_simplify(sorted_terms[0][1][0]))
+            return print_obj._print(printer.coef_simplify(sorted_terms[0][1][0]))
 
         lines = []
         old_grade = -1
@@ -728,7 +728,7 @@ class Mv(printer.GaPrintable):
         for (index, (coef, base, grade)) in sorted_terms:
             coef = printer.coef_simplify(coef)
             # coef = simplify(coef)
-            l_coef = print_obj.doprint(coef)
+            l_coef = print_obj._print(coef)
             if l_coef == '1' and base != S(1):
                 l_coef = ''
             if l_coef == '-1' and base != S(1):
@@ -736,7 +736,7 @@ class Mv(printer.GaPrintable):
             if base == S(1):
                 l_base = ''
             else:
-                l_base = print_obj.doprint(base)
+                l_base = print_obj._print(base)
             if isinstance(coef, Add):
                 cb_str = '\\left ( ' + l_coef + '\\right ) ' + l_base
             else:
@@ -1675,8 +1675,8 @@ class Dop(dop._BaseDop):
         s = ''
 
         for sdop, base in mv_terms:
-            str_base = print_obj.doprint(base)
-            str_sdop = print_obj.doprint(sdop)
+            str_base = print_obj._print(base)
+            str_sdop = print_obj._print(sdop)
             if base == S(1):
                 s += str_sdop
             else:
@@ -1711,8 +1711,8 @@ class Dop(dop._BaseDop):
         s = ''
 
         for sdop, base in mv_terms:
-            str_base = print_obj.doprint(base)
-            str_sdop = print_obj.doprint(sdop)
+            str_base = print_obj._print(base)
+            str_sdop = print_obj._print(sdop)
             if base == S(1):
                 s += str_sdop
             else:

--- a/galgebra/printer.py
+++ b/galgebra/printer.py
@@ -1234,7 +1234,7 @@ class _WithSettings(GaPrintable):
         new_printer = copy.copy(printer)
         new_printer._settings = copy.copy(new_printer._settings)
         new_printer._settings.update(self._settings)
-        return new_printer.doprint(self._obj)
+        return new_printer._print(self._obj)
 
     _latex = _pretty = _sympystr = __do_print
 
@@ -1250,7 +1250,7 @@ class _FmtResult(GaPrintable):
         return self
 
     def _latex(self, printer):
-        return self._label + ' = ' + printer.doprint(self._obj)
+        return self._label + ' = ' + printer._print(self._obj)
 
     def _sympystr(self, printer):
-        return self._label + ' = ' + printer.doprint(self._obj)
+        return self._label + ' = ' + printer._print(self._obj)


### PR DESCRIPTION
This fixes the mistake described as the first item in https://docs.sympy.org/dev/modules/printing.html#common-mistakes

CI will continue to fail on sympy-master with and without this patch, but I think we should merge it as long as it keeps passing on the other CI runs.