### PR TITLE
Patch the new sympy printing base class instead of Basic

### DIFF
--- a/galgebra/printer.py
+++ b/galgebra/printer.py
@@ -98,6 +98,11 @@ from sympy.core.operations import AssocOp
 from sympy import init_printing
 
 try:
+    from sympy.printing.defaults import Printable as SympyPrintable
+except ImportError:
+    # sympy < 1.7
+    SympyPrintable = object
+try:
     from IPython.display import display, Latex, Math, display_latex
 except ImportError:
     pass
@@ -379,10 +384,20 @@ class GaPrintable:
         return r'\begin{equation*} ' + latex_str + r' \end{equation*}'
 
 
-Basic.__ga_print_str__ = GaPrintable.__ga_print_str__
-Matrix.__ga_print_str__ = GaPrintable.__ga_print_str__
+# Change sympy builtins to use our printer by default.
+# We do this because we always have done, and stopping now would break
+# compatibility.
+if SympyPrintable is not object:
+    SympyPrintable.__ga_print_str__ = GaPrintable.__ga_print_str__
+    SympyPrintable.__repr__ = GaPrintable.__repr__
+else:
+    # sympy < 1.7
+    Basic.__ga_print_str__ = GaPrintable.__ga_print_str__
+    Basic.__repr__ = GaPrintable.__repr__
 
-Basic.__repr__ = GaPrintable.__repr__
+# TODO: Change this to MatrixBase on sympy < 1.7, remove if for >= 1.7.
+#       Doing so will change test outputs to have unicode printing.
+Matrix.__ga_print_str__ = GaPrintable.__ga_print_str__
 Matrix.__repr__ = GaPrintable.__repr__
 
 


### PR DESCRIPTION
Patching `Basic.__repr__` results in the pretty-printer on `SympyPrintable` being ignored, which makes the notebook tests fail CI.

If we patch `SympyPrintable.__repr__` instead, then the pretty-printer is still respected.

Note that `sympy.printing.defaults.Printable` is new in the unreleased sympy 1.7

---

To make CI pass, this will need (at least) sympy/sympy#19902, which should now be merged.

A failing CI run from before this patch with 13 failures: https://app.circleci.com/pipelines/github/pygae/galgebra/1134/workflows/3944fa71-53e0-4eff-ad91-d57e26a223d8/jobs/6545

One from after this patch with only 7 failures:
https://app.circleci.com/pipelines/github/pygae/galgebra/1137/workflows/d6e511b1-82a8-4825-bd35-9013d5a3bb43/jobs/6572/tests