### PR TITLE
Let sympy handle wrapping with `equation*`

### DIFF
--- a/examples/ipython/Smith Sphere.ipynb
+++ b/examples/ipython/Smith Sphere.ipynb
@@ -86,7 +86,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} - \\boldsymbol{e}_{s} \\end{equation*}"
+       "\\begin{equation*}- \\boldsymbol{e}_{s}\\end{equation*}"
       ],
       "text/plain": [
        "-e_s"
@@ -129,7 +129,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} z^{r} \\boldsymbol{e}_{r} + z^{x} \\boldsymbol{e}_{x} \\end{equation*}"
+       "\\begin{equation*}z^{r} \\boldsymbol{e}_{r} + z^{x} \\boldsymbol{e}_{x}\\end{equation*}"
       ],
       "text/plain": [
        "z__r*e_r + z__x*e_x"
@@ -160,7 +160,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} \\frac{2 z^{r}}{{\\left ( z^{r} \\right )}^{2} + {\\left ( z^{x} \\right )}^{2} + 1} \\boldsymbol{e}_{r} + \\frac{2 z^{x}}{{\\left ( z^{r} \\right )}^{2} + {\\left ( z^{x} \\right )}^{2} + 1} \\boldsymbol{e}_{x} + \\frac{{\\left ( z^{r} \\right )}^{2} + {\\left ( z^{x} \\right )}^{2} - 1}{{\\left ( z^{r} \\right )}^{2} + {\\left ( z^{x} \\right )}^{2} + 1} \\boldsymbol{e}_{s} \\end{equation*}"
+       "\\begin{equation*}\\frac{2 z^{r}}{{\\left ( z^{r} \\right )}^{2} + {\\left ( z^{x} \\right )}^{2} + 1} \\boldsymbol{e}_{r} + \\frac{2 z^{x}}{{\\left ( z^{r} \\right )}^{2} + {\\left ( z^{x} \\right )}^{2} + 1} \\boldsymbol{e}_{x} + \\frac{{\\left ( z^{r} \\right )}^{2} + {\\left ( z^{x} \\right )}^{2} - 1}{{\\left ( z^{r} \\right )}^{2} + {\\left ( z^{x} \\right )}^{2} + 1} \\boldsymbol{e}_{s}\\end{equation*}"
       ],
       "text/plain": [
        "2*z__r*e_r/(z__r**2 + z__x**2 + 1) + 2*z__x*e_x/(z__r**2 + z__x**2 + 1) + (z__r**2 + z__x**2 - 1)*e_s/(z__r**2 + z__x**2 + 1)"
@@ -214,7 +214,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} z^{r} \\boldsymbol{e}_{r} + z^{x} \\boldsymbol{e}_{x} \\end{equation*}"
+       "\\begin{equation*}z^{r} \\boldsymbol{e}_{r} + z^{x} \\boldsymbol{e}_{x}\\end{equation*}"
       ],
       "text/plain": [
        "z__r*e_r + z__x*e_x"
@@ -237,7 +237,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} \\frac{2 z^{x}}{{\\left ( z^{r} \\right )}^{2} + 2 z^{r} + {\\left ( z^{x} \\right )}^{2} + 1} \\boldsymbol{e}_{x} + \\frac{{\\left ( z^{r} \\right )}^{2} + {\\left ( z^{x} \\right )}^{2} - 1}{{\\left ( z^{r} \\right )}^{2} + 2 z^{r} + {\\left ( z^{x} \\right )}^{2} + 1} \\boldsymbol{e}_{s} \\end{equation*}"
+       "\\begin{equation*}\\frac{2 z^{x}}{{\\left ( z^{r} \\right )}^{2} + 2 z^{r} + {\\left ( z^{x} \\right )}^{2} + 1} \\boldsymbol{e}_{x} + \\frac{{\\left ( z^{r} \\right )}^{2} + {\\left ( z^{x} \\right )}^{2} - 1}{{\\left ( z^{r} \\right )}^{2} + 2 z^{r} + {\\left ( z^{x} \\right )}^{2} + 1} \\boldsymbol{e}_{s}\\end{equation*}"
       ],
       "text/plain": [
        "2*z__x*e_x/(z__r**2 + 2*z__r + z__x**2 + 1) + (z__r**2 + z__x**2 - 1)*e_s/(z__r**2 + 2*z__r + z__x**2 + 1)"
@@ -260,7 +260,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} \\frac{{\\left ( z^{r} \\right )}^{2} + {\\left ( z^{x} \\right )}^{2} - 1}{{\\left ( z^{r} \\right )}^{2} + 2 z^{r} + {\\left ( z^{x} \\right )}^{2} + 1}  - \\frac{2 z^{x}}{{\\left ( z^{r} \\right )}^{2} + 2 z^{r} + {\\left ( z^{x} \\right )}^{2} + 1} \\boldsymbol{e}_{r}\\wedge \\boldsymbol{e}_{x} \\end{equation*}"
+       "\\begin{equation*}\\frac{{\\left ( z^{r} \\right )}^{2} + {\\left ( z^{x} \\right )}^{2} - 1}{{\\left ( z^{r} \\right )}^{2} + 2 z^{r} + {\\left ( z^{x} \\right )}^{2} + 1}  - \\frac{2 z^{x}}{{\\left ( z^{r} \\right )}^{2} + 2 z^{r} + {\\left ( z^{x} \\right )}^{2} + 1} \\boldsymbol{e}_{r}\\wedge \\boldsymbol{e}_{x}\\end{equation*}"
       ],
       "text/plain": [
        "(z__r**2 + z__x**2 - 1)/(z__r**2 + 2*z__r + z__x**2 + 1) - 2*z__x*e_r^e_x/(z__r**2 + 2*z__r + z__x**2 + 1)"
@@ -283,7 +283,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} \\frac{2 z^{r}}{{\\left ( z^{r} \\right )}^{2} + {\\left ( z^{x} \\right )}^{2} + 1} \\boldsymbol{e}_{r} + \\frac{2 z^{x}}{{\\left ( z^{r} \\right )}^{2} + {\\left ( z^{x} \\right )}^{2} + 1} \\boldsymbol{e}_{x} + \\frac{{\\left ( z^{r} \\right )}^{2} + {\\left ( z^{x} \\right )}^{2} - 1}{{\\left ( z^{r} \\right )}^{2} + {\\left ( z^{x} \\right )}^{2} + 1} \\boldsymbol{e}_{s} \\end{equation*}"
+       "\\begin{equation*}\\frac{2 z^{r}}{{\\left ( z^{r} \\right )}^{2} + {\\left ( z^{x} \\right )}^{2} + 1} \\boldsymbol{e}_{r} + \\frac{2 z^{x}}{{\\left ( z^{r} \\right )}^{2} + {\\left ( z^{x} \\right )}^{2} + 1} \\boldsymbol{e}_{x} + \\frac{{\\left ( z^{r} \\right )}^{2} + {\\left ( z^{x} \\right )}^{2} - 1}{{\\left ( z^{r} \\right )}^{2} + {\\left ( z^{x} \\right )}^{2} + 1} \\boldsymbol{e}_{s}\\end{equation*}"
       ],
       "text/plain": [
        "2*z__r*e_r/(z__r**2 + z__x**2 + 1) + 2*z__x*e_x/(z__r**2 + z__x**2 + 1) + (z__r**2 + z__x**2 - 1)*e_s/(z__r**2 + z__x**2 + 1)"
@@ -306,7 +306,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} \\frac{\\sqrt{2}}{2}  - \\frac{\\sqrt{2}}{2} \\boldsymbol{e}_{r}\\wedge \\boldsymbol{e}_{s} \\end{equation*}"
+       "\\begin{equation*}\\frac{\\sqrt{2}}{2}  - \\frac{\\sqrt{2}}{2} \\boldsymbol{e}_{r}\\wedge \\boldsymbol{e}_{s}\\end{equation*}"
       ],
       "text/plain": [
        "sqrt(2)/2 - sqrt(2)*e_r^e_s/2"
@@ -330,7 +330,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} \\frac{- {\\left ( z^{r} \\right )}^{2} - {\\left ( z^{x} \\right )}^{2} + 1}{{\\left ( z^{r} \\right )}^{2} + {\\left ( z^{x} \\right )}^{2} + 1} \\boldsymbol{e}_{r} + \\frac{2 z^{x}}{{\\left ( z^{r} \\right )}^{2} + {\\left ( z^{x} \\right )}^{2} + 1} \\boldsymbol{e}_{x} + \\frac{2 z^{r}}{{\\left ( z^{r} \\right )}^{2} + {\\left ( z^{x} \\right )}^{2} + 1} \\boldsymbol{e}_{s} \\end{equation*}"
+       "\\begin{equation*}\\frac{- {\\left ( z^{r} \\right )}^{2} - {\\left ( z^{x} \\right )}^{2} + 1}{{\\left ( z^{r} \\right )}^{2} + {\\left ( z^{x} \\right )}^{2} + 1} \\boldsymbol{e}_{r} + \\frac{2 z^{x}}{{\\left ( z^{r} \\right )}^{2} + {\\left ( z^{x} \\right )}^{2} + 1} \\boldsymbol{e}_{x} + \\frac{2 z^{r}}{{\\left ( z^{r} \\right )}^{2} + {\\left ( z^{x} \\right )}^{2} + 1} \\boldsymbol{e}_{s}\\end{equation*}"
       ],
       "text/plain": [
        "(-z__r**2 - z__x**2 + 1)*e_r/(z__r**2 + z__x**2 + 1) + 2*z__x*e_x/(z__r**2 + z__x**2 + 1) + 2*z__r*e_s/(z__r**2 + z__x**2 + 1)"
@@ -353,7 +353,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} \\frac{- {\\left ( z^{r} \\right )}^{2} - {\\left ( z^{x} \\right )}^{2} + 1}{{\\left ( z^{r} \\right )}^{2} - 2 z^{r} + {\\left ( z^{x} \\right )}^{2} + 1} \\boldsymbol{e}_{r} + \\frac{2 z^{x}}{{\\left ( z^{r} \\right )}^{2} - 2 z^{r} + {\\left ( z^{x} \\right )}^{2} + 1} \\boldsymbol{e}_{x} \\end{equation*}"
+       "\\begin{equation*}\\frac{- {\\left ( z^{r} \\right )}^{2} - {\\left ( z^{x} \\right )}^{2} + 1}{{\\left ( z^{r} \\right )}^{2} - 2 z^{r} + {\\left ( z^{x} \\right )}^{2} + 1} \\boldsymbol{e}_{r} + \\frac{2 z^{x}}{{\\left ( z^{r} \\right )}^{2} - 2 z^{r} + {\\left ( z^{x} \\right )}^{2} + 1} \\boldsymbol{e}_{x}\\end{equation*}"
       ],
       "text/plain": [
        "(-z__r**2 - z__x**2 + 1)*e_r/(z__r**2 - 2*z__r + z__x**2 + 1) + 2*z__x*e_x/(z__r**2 - 2*z__r + z__x**2 + 1)"

--- a/examples/ipython/dop.ipynb
+++ b/examples/ipython/dop.ipynb
@@ -49,7 +49,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} f = f  \\end{equation*}"
+       "\\begin{equation*}f = f \\end{equation*}"
       ],
       "text/plain": [
        "f"
@@ -73,7 +73,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} \\nabla^{2} = \\frac{\\partial^{2}}{\\partial x^{2}} + \\frac{\\partial^{2}}{\\partial y^{2}} + \\frac{\\partial^{2}}{\\partial z^{2}} \\end{equation*}"
+       "\\begin{equation*}\\nabla^{2} = \\frac{\\partial^{2}}{\\partial x^{2}} + \\frac{\\partial^{2}}{\\partial y^{2}} + \\frac{\\partial^{2}}{\\partial z^{2}}\\end{equation*}"
       ],
       "text/plain": [
        "\\nabla^{2} = D{x}^2 + D{y}^2 + D{z}^2"
@@ -98,7 +98,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} \\nabla^{2} = \\frac{\\partial^{2}}{\\partial x^{2}} + \\frac{\\partial^{2}}{\\partial y^{2}} + \\frac{\\partial^{2}}{\\partial z^{2}} \\end{equation*}"
+       "\\begin{equation*}\\nabla^{2} = \\frac{\\partial^{2}}{\\partial x^{2}} + \\frac{\\partial^{2}}{\\partial y^{2}} + \\frac{\\partial^{2}}{\\partial z^{2}}\\end{equation*}"
       ],
       "text/plain": [
        "\\nabla^{2} = D{x}^2 + D{y}^2 + D{z}^2"
@@ -121,7 +121,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} \\partial^{2}_{x} f  + \\partial^{2}_{y} f  + \\partial^{2}_{z} f  \\end{equation*}"
+       "\\begin{equation*}\\partial^{2}_{x} f  + \\partial^{2}_{y} f  + \\partial^{2}_{z} f \\end{equation*}"
       ],
       "text/plain": [
        "D{x}^2f + D{y}^2f + D{z}^2f"
@@ -145,7 +145,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} \\nabla \\cdot (\\nabla f) = \\partial^{2}_{x} f  + \\partial^{2}_{y} f  + \\partial^{2}_{z} f  \\end{equation*}"
+       "\\begin{equation*}\\nabla \\cdot (\\nabla f) = \\partial^{2}_{x} f  + \\partial^{2}_{y} f  + \\partial^{2}_{z} f \\end{equation*}"
       ],
       "text/plain": [
        "\\nabla \\cdot (\\nabla f) = D{x}^2f + D{y}^2f + D{z}^2f"
@@ -169,7 +169,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} x = = \\partial_{x} F^{x}  + \\partial_{y} F^{y}  + \\partial_{z} F^{z}  \\end{equation*}"
+       "\\begin{equation*}x = = \\partial_{x} F^{x}  + \\partial_{y} F^{y}  + \\partial_{z} F^{z} \\end{equation*}"
       ],
       "text/plain": [
        "x = = D{x}F__x + D{y}F__y + D{z}F__z"
@@ -193,7 +193,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} \\nabla F = \\left ( \\partial_{x} F^{x}  + \\partial_{y} F^{y}  + \\partial_{z} F^{z} \\right )  + \\left ( - \\partial_{y} F^{x}  + \\partial_{x} F^{y} \\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + \\left ( - \\partial_{z} F^{x}  + \\partial_{x} F^{z} \\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + \\left ( - \\partial_{z} F^{y}  + \\partial_{y} F^{z} \\right ) \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} \\end{equation*}"
+       "\\begin{equation*}\\nabla F = \\left ( \\partial_{x} F^{x}  + \\partial_{y} F^{y}  + \\partial_{z} F^{z} \\right )  + \\left ( - \\partial_{y} F^{x}  + \\partial_{x} F^{y} \\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + \\left ( - \\partial_{z} F^{x}  + \\partial_{x} F^{z} \\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + \\left ( - \\partial_{z} F^{y}  + \\partial_{y} F^{z} \\right ) \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}\\end{equation*}"
       ],
       "text/plain": [
        "\\nabla F = D{x}F__x + D{y}F__y + D{z}F__z + (-D{y}F__x + D{x}F__y)*e_x^e_y + (-D{z}F__x + D{x}F__z)*e_x^e_z + (-D{z}F__y + D{y}F__z)*e_y^e_z"
@@ -245,7 +245,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} \\nabla = \\boldsymbol{e}_{r} \\frac{\\partial}{\\partial r} + \\boldsymbol{e}_{\\theta } \\frac{1}{r} \\frac{\\partial}{\\partial \\theta } + \\boldsymbol{e}_{\\phi } \\frac{1}{r \\sin{\\left (\\theta  \\right )}} \\frac{\\partial}{\\partial \\phi } \\end{equation*}"
+       "\\begin{equation*}\\nabla = \\boldsymbol{e}_{r} \\frac{\\partial}{\\partial r} + \\boldsymbol{e}_{\\theta } \\frac{1}{r} \\frac{\\partial}{\\partial \\theta } + \\boldsymbol{e}_{\\phi } \\frac{1}{r \\sin{\\left (\\theta  \\right )}} \\frac{\\partial}{\\partial \\phi }\\end{equation*}"
       ],
       "text/plain": [
        "\\nabla = e_r*D{r} + e_theta*1/r*D{theta} + e_phi*1/(r*sin(theta))*D{phi}"
@@ -268,7 +268,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} \\nabla^{2}  = \\frac{2}{r} \\frac{\\partial}{\\partial r} + \\frac{1}{r^{2} \\tan{\\left (\\theta  \\right )}} \\frac{\\partial}{\\partial \\theta } + \\frac{1}{r^{2} {\\sin{\\left (\\theta  \\right )}}^{2}} \\frac{\\partial^{2}}{\\partial \\phi ^{2}} + \\frac{\\partial^{2}}{\\partial r^{2}} + r^{-2} \\frac{\\partial^{2}}{\\partial \\theta ^{2}} \\end{equation*}"
+       "\\begin{equation*}\\nabla^{2}  = \\frac{2}{r} \\frac{\\partial}{\\partial r} + \\frac{1}{r^{2} \\tan{\\left (\\theta  \\right )}} \\frac{\\partial}{\\partial \\theta } + \\frac{1}{r^{2} {\\sin{\\left (\\theta  \\right )}}^{2}} \\frac{\\partial^{2}}{\\partial \\phi ^{2}} + \\frac{\\partial^{2}}{\\partial r^{2}} + r^{-2} \\frac{\\partial^{2}}{\\partial \\theta ^{2}}\\end{equation*}"
       ],
       "text/plain": [
        "\\nabla^{2}  = 2/r*D{r} + 1/(r**2*tan(theta))*D{theta} + 1/(r**2*sin(theta)**2)*D{phi}^2 + D{r}^2 + r**(-2)*D{theta}^2"
@@ -296,7 +296,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} \\nabla^{2} f = \\frac{r^{2} \\partial^{2}_{r} f  + 2 r \\partial_{r} f  + \\partial^{2}_{\\theta } f  + \\frac{\\partial_{\\theta } f }{\\tan{\\left (\\theta  \\right )}} + \\frac{\\partial^{2}_{\\phi } f }{{\\sin{\\left (\\theta  \\right )}}^{2}}}{r^{2}} \\end{equation*}"
+       "\\begin{equation*}\\nabla^{2} f = \\frac{r^{2} \\partial^{2}_{r} f  + 2 r \\partial_{r} f  + \\partial^{2}_{\\theta } f  + \\frac{\\partial_{\\theta } f }{\\tan{\\left (\\theta  \\right )}} + \\frac{\\partial^{2}_{\\phi } f }{{\\sin{\\left (\\theta  \\right )}}^{2}}}{r^{2}}\\end{equation*}"
       ],
       "text/plain": [
        "\\nabla^{2} f = (r**2*D{r}^2f + 2*r*D{r}f + D{theta}^2f + D{theta}f/tan(theta) + D{phi}^2f/sin(theta)**2)/r**2"
@@ -320,7 +320,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} \\nabla \\cdot (\\nabla f) = \\frac{r^{2} \\partial^{2}_{r} f  + 2 r \\partial_{r} f  + \\partial^{2}_{\\theta } f  + \\frac{\\partial_{\\theta } f }{\\tan{\\left (\\theta  \\right )}} + \\frac{\\partial^{2}_{\\phi } f }{{\\sin{\\left (\\theta  \\right )}}^{2}}}{r^{2}} \\end{equation*}"
+       "\\begin{equation*}\\nabla \\cdot (\\nabla f) = \\frac{r^{2} \\partial^{2}_{r} f  + 2 r \\partial_{r} f  + \\partial^{2}_{\\theta } f  + \\frac{\\partial_{\\theta } f }{\\tan{\\left (\\theta  \\right )}} + \\frac{\\partial^{2}_{\\phi } f }{{\\sin{\\left (\\theta  \\right )}}^{2}}}{r^{2}}\\end{equation*}"
       ],
       "text/plain": [
        "\\nabla \\cdot (\\nabla f) = (r**2*D{r}^2f + 2*r*D{r}f + D{theta}^2f + D{theta}f/tan(theta) + D{phi}^2f/sin(theta)**2)/r**2"
@@ -344,7 +344,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} \\nabla F = \\partial_{x} F^{x}  + \\partial_{y} F^{y}  + \\partial_{z} F^{z}  \\end{equation*}"
+       "\\begin{equation*}\\nabla F = \\partial_{x} F^{x}  + \\partial_{y} F^{y}  + \\partial_{z} F^{z} \\end{equation*}"
       ],
       "text/plain": [
        "\\nabla F = D{x}F__x + D{y}F__y + D{z}F__z"
@@ -368,7 +368,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} \\nabla \\wedge F = \\frac{r \\partial_{r} F^{\\theta }  + F^{\\theta }  - \\partial_{\\theta } F^{r} }{r} \\boldsymbol{e}_{r}\\wedge \\boldsymbol{e}_{\\theta } + \\frac{r \\partial_{r} F^{\\phi }  + F^{\\phi }  - \\frac{\\partial_{\\phi } F^{r} }{\\sin{\\left (\\theta  \\right )}}}{r} \\boldsymbol{e}_{r}\\wedge \\boldsymbol{e}_{\\phi } + \\frac{\\frac{F^{\\phi } }{\\tan{\\left (\\theta  \\right )}} + \\partial_{\\theta } F^{\\phi }  - \\frac{\\partial_{\\phi } F^{\\theta } }{\\sin{\\left (\\theta  \\right )}}}{r} \\boldsymbol{e}_{\\theta }\\wedge \\boldsymbol{e}_{\\phi } \\end{equation*}"
+       "\\begin{equation*}\\nabla \\wedge F = \\frac{r \\partial_{r} F^{\\theta }  + F^{\\theta }  - \\partial_{\\theta } F^{r} }{r} \\boldsymbol{e}_{r}\\wedge \\boldsymbol{e}_{\\theta } + \\frac{r \\partial_{r} F^{\\phi }  + F^{\\phi }  - \\frac{\\partial_{\\phi } F^{r} }{\\sin{\\left (\\theta  \\right )}}}{r} \\boldsymbol{e}_{r}\\wedge \\boldsymbol{e}_{\\phi } + \\frac{\\frac{F^{\\phi } }{\\tan{\\left (\\theta  \\right )}} + \\partial_{\\theta } F^{\\phi }  - \\frac{\\partial_{\\phi } F^{\\theta } }{\\sin{\\left (\\theta  \\right )}}}{r} \\boldsymbol{e}_{\\theta }\\wedge \\boldsymbol{e}_{\\phi }\\end{equation*}"
       ],
       "text/plain": [
        "\\nabla \\wedge F = (r*D{r}F__theta + F__theta - D{theta}F__r)*e_r^e_theta/r + (r*D{r}F__phi + F__phi - D{phi}F__r/sin(theta))*e_r^e_phi/r + (F__phi/tan(theta) + D{theta}F__phi - D{phi}F__theta/sin(theta))*e_theta^e_phi/r"
@@ -392,7 +392,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} \\nabla \\cdot B = - \\frac{\\frac{B^{r\\theta } }{\\tan{\\left (\\theta  \\right )}} + \\partial_{\\theta } B^{r\\theta }  + \\frac{\\partial_{\\phi } B^{r\\phi } }{\\sin{\\left (\\theta  \\right )}}}{r} \\boldsymbol{e}_{r} + \\frac{r \\partial_{r} B^{r\\theta }  + B^{r\\theta }  - \\frac{\\partial_{\\phi } B^{\\theta \\phi } }{\\sin{\\left (\\theta  \\right )}}}{r} \\boldsymbol{e}_{\\theta } + \\frac{r \\partial_{r} B^{r\\phi }  + B^{r\\phi }  + \\partial_{\\theta } B^{\\theta \\phi } }{r} \\boldsymbol{e}_{\\phi } \\end{equation*}"
+       "\\begin{equation*}\\nabla \\cdot B = - \\frac{\\frac{B^{r\\theta } }{\\tan{\\left (\\theta  \\right )}} + \\partial_{\\theta } B^{r\\theta }  + \\frac{\\partial_{\\phi } B^{r\\phi } }{\\sin{\\left (\\theta  \\right )}}}{r} \\boldsymbol{e}_{r} + \\frac{r \\partial_{r} B^{r\\theta }  + B^{r\\theta }  - \\frac{\\partial_{\\phi } B^{\\theta \\phi } }{\\sin{\\left (\\theta  \\right )}}}{r} \\boldsymbol{e}_{\\theta } + \\frac{r \\partial_{r} B^{r\\phi }  + B^{r\\phi }  + \\partial_{\\theta } B^{\\theta \\phi } }{r} \\boldsymbol{e}_{\\phi }\\end{equation*}"
       ],
       "text/plain": [
        "\\nabla \\cdot B = -(B__rtheta/tan(theta) + D{theta}B__rtheta + D{phi}B__rphi/sin(theta))*e_r/r + (r*D{r}B__rtheta + B__rtheta - D{phi}B__thetaphi/sin(theta))*e_theta/r + (r*D{r}B__rphi + B__rphi + D{theta}B__thetaphi)*e_phi/r"
@@ -416,7 +416,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} F = F^{r}  \\boldsymbol{e}_{r} + F^{\\theta }  \\boldsymbol{e}_{\\theta } + F^{\\phi }  \\boldsymbol{e}_{\\phi } \\end{equation*}"
+       "\\begin{equation*}F = F^{r}  \\boldsymbol{e}_{r} + F^{\\theta }  \\boldsymbol{e}_{\\theta } + F^{\\phi }  \\boldsymbol{e}_{\\phi }\\end{equation*}"
       ],
       "text/plain": [
        "F__r*e_r + F__theta*e_theta + F__phi*e_phi"
@@ -439,7 +439,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} F =  \\begin{aligned}[t]  & F^{r}  \\boldsymbol{e}_{r} \\\\  &  + F^{\\theta }  \\boldsymbol{e}_{\\theta } \\\\  &  + F^{\\phi }  \\boldsymbol{e}_{\\phi }  \\end{aligned}  \\end{equation*}"
+       "\\begin{equation*}F =  \\begin{aligned}[t]  & F^{r}  \\boldsymbol{e}_{r} \\\\  &  + F^{\\theta }  \\boldsymbol{e}_{\\theta } \\\\  &  + F^{\\phi }  \\boldsymbol{e}_{\\phi }  \\end{aligned} \\end{equation*}"
       ],
       "text/plain": [
        "F =  F__r*e_r\n",

--- a/examples/ipython/gsym-printing.ipynb
+++ b/examples/ipython/gsym-printing.ipynb
@@ -122,7 +122,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} - \\det\\left ( f\\right ) \\end{equation*}"
+       "\\begin{equation*}- \\det\\left ( f\\right )\\end{equation*}"
       ],
       "text/plain": [
        "-Determinant(f)"
@@ -134,7 +134,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} - \\det\\left ( g\\right ) \\end{equation*}"
+       "\\begin{equation*}- \\det\\left ( g\\right )\\end{equation*}"
       ],
       "text/plain": [
        "-Determinant(g)"
@@ -146,7 +146,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} - \\det\\left ( f {\\left (u,v \\right )}\\right ) \\end{equation*}"
+       "\\begin{equation*}- \\det\\left ( f {\\left (u,v \\right )}\\right )\\end{equation*}"
       ],
       "text/plain": [
        "-Determinant(f)"
@@ -158,7 +158,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} - \\det\\left ( g {\\left (u,v \\right )}\\right ) \\end{equation*}"
+       "\\begin{equation*}- \\det\\left ( g {\\left (u,v \\right )}\\right )\\end{equation*}"
       ],
       "text/plain": [
        "-Determinant(g)"
@@ -288,7 +288,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} - \\det\\left ( f\\right ) \\end{equation*}"
+       "\\begin{equation*}- \\det\\left ( f\\right )\\end{equation*}"
       ],
       "text/plain": [
        "-Determinant(f)"
@@ -300,7 +300,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} - \\det\\left ( g\\right ) \\end{equation*}"
+       "\\begin{equation*}- \\det\\left ( g\\right )\\end{equation*}"
       ],
       "text/plain": [
        "-Determinant(g)"
@@ -312,7 +312,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} - \\det\\left ( f \\right ) \\end{equation*}"
+       "\\begin{equation*}- \\det\\left ( f \\right )\\end{equation*}"
       ],
       "text/plain": [
        "-Determinant(f)"
@@ -324,7 +324,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} - \\det\\left ( g \\right ) \\end{equation*}"
+       "\\begin{equation*}- \\det\\left ( g \\right )\\end{equation*}"
       ],
       "text/plain": [
        "-Determinant(g)"

--- a/examples/ipython/inner_product.ipynb
+++ b/examples/ipython/inner_product.ipynb
@@ -81,7 +81,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*}  0  \\end{equation*}"
+       "\\begin{equation*} 0 \\end{equation*}"
       ],
       "text/plain": [
        "0"
@@ -104,7 +104,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*}  0  \\end{equation*}"
+       "\\begin{equation*} 0 \\end{equation*}"
       ],
       "text/plain": [
        "0"
@@ -127,7 +127,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*}  0  \\end{equation*}"
+       "\\begin{equation*} 0 \\end{equation*}"
       ],
       "text/plain": [
        "0"
@@ -150,7 +150,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*}  0  \\end{equation*}"
+       "\\begin{equation*} 0 \\end{equation*}"
       ],
       "text/plain": [
        "0"
@@ -182,7 +182,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} \\left ( a^{x} b^{x} + a^{y} b^{y} + a^{z} b^{z}\\right )  + \\left ( a^{x} b^{y} - a^{y} b^{x}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + \\left ( a^{x} b^{z} - a^{z} b^{x}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + \\left ( a^{y} b^{z} - a^{z} b^{y}\\right ) \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} \\end{equation*}"
+       "\\begin{equation*}\\left ( a^{x} b^{x} + a^{y} b^{y} + a^{z} b^{z}\\right )  + \\left ( a^{x} b^{y} - a^{y} b^{x}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + \\left ( a^{x} b^{z} - a^{z} b^{x}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + \\left ( a^{y} b^{z} - a^{z} b^{y}\\right ) \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}\\end{equation*}"
       ],
       "text/plain": [
        "a__x*b__x + a__y*b__y + a__z*b__z + (a__x*b__y - a__y*b__x)*e_x^e_y + (a__x*b__z - a__z*b__x)*e_x^e_z + (a__y*b__z - a__z*b__y)*e_y^e_z"
@@ -205,7 +205,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} \\left ( a^{x} b^{y} - a^{y} b^{x}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + \\left ( a^{x} b^{z} - a^{z} b^{x}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + \\left ( a^{y} b^{z} - a^{z} b^{y}\\right ) \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} \\end{equation*}"
+       "\\begin{equation*}\\left ( a^{x} b^{y} - a^{y} b^{x}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + \\left ( a^{x} b^{z} - a^{z} b^{x}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + \\left ( a^{y} b^{z} - a^{z} b^{y}\\right ) \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}\\end{equation*}"
       ],
       "text/plain": [
        "(a__x*b__y - a__y*b__x)*e_x^e_y + (a__x*b__z - a__z*b__x)*e_x^e_z + (a__y*b__z - a__z*b__y)*e_y^e_z"
@@ -230,7 +230,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} a^{x} b^{x} + a^{y} b^{y} + a^{z} b^{z} \\end{equation*}"
+       "\\begin{equation*}a^{x} b^{x} + a^{y} b^{y} + a^{z} b^{z}\\end{equation*}"
       ],
       "text/plain": [
        "a__x*b__x + a__y*b__y + a__z*b__z"
@@ -255,7 +255,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*}  0  \\end{equation*}"
+       "\\begin{equation*} 0 \\end{equation*}"
       ],
       "text/plain": [
        "0"
@@ -285,7 +285,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} \\left ( A^{x} a^{x} + A^{y} a^{y} + A^{z} a^{z}\\right )  + \\left ( A a^{x} - A^{xy} a^{y} - A^{xz} a^{z}\\right ) \\boldsymbol{e}_{x} + \\left ( A a^{y} + A^{xy} a^{x} - A^{yz} a^{z}\\right ) \\boldsymbol{e}_{y} + \\left ( A a^{z} + A^{xz} a^{x} + A^{yz} a^{y}\\right ) \\boldsymbol{e}_{z} + \\left ( - A^{x} a^{y} + A^{xyz} a^{z} + A^{y} a^{x}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + \\left ( - A^{x} a^{z} - A^{xyz} a^{y} + A^{z} a^{x}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + \\left ( A^{xyz} a^{x} - A^{y} a^{z} + A^{z} a^{y}\\right ) \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} + \\left ( A^{xy} a^{z} - A^{xz} a^{y} + A^{yz} a^{x}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} \\end{equation*}"
+       "\\begin{equation*}\\left ( A^{x} a^{x} + A^{y} a^{y} + A^{z} a^{z}\\right )  + \\left ( A a^{x} - A^{xy} a^{y} - A^{xz} a^{z}\\right ) \\boldsymbol{e}_{x} + \\left ( A a^{y} + A^{xy} a^{x} - A^{yz} a^{z}\\right ) \\boldsymbol{e}_{y} + \\left ( A a^{z} + A^{xz} a^{x} + A^{yz} a^{y}\\right ) \\boldsymbol{e}_{z} + \\left ( - A^{x} a^{y} + A^{xyz} a^{z} + A^{y} a^{x}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + \\left ( - A^{x} a^{z} - A^{xyz} a^{y} + A^{z} a^{x}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + \\left ( A^{xyz} a^{x} - A^{y} a^{z} + A^{z} a^{y}\\right ) \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} + \\left ( A^{xy} a^{z} - A^{xz} a^{y} + A^{yz} a^{x}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}\\end{equation*}"
       ],
       "text/plain": [
        "A__x*a__x + A__y*a__y + A__z*a__z + (A*a__x - A__xy*a__y - A__xz*a__z)*e_x + (A*a__y + A__xy*a__x - A__yz*a__z)*e_y + (A*a__z + A__xz*a__x + A__yz*a__y)*e_z + (-A__x*a__y + A__xyz*a__z + A__y*a__x)*e_x^e_y + (-A__x*a__z - A__xyz*a__y + A__z*a__x)*e_x^e_z + (A__xyz*a__x - A__y*a__z + A__z*a__y)*e_y^e_z + (A__xy*a__z - A__xz*a__y + A__yz*a__x)*e_x^e_y^e_z"
@@ -308,7 +308,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} A a^{x} \\boldsymbol{e}_{x} + A a^{y} \\boldsymbol{e}_{y} + A a^{z} \\boldsymbol{e}_{z} + \\left ( - A^{x} a^{y} + A^{y} a^{x}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + \\left ( - A^{x} a^{z} + A^{z} a^{x}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + \\left ( - A^{y} a^{z} + A^{z} a^{y}\\right ) \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} + \\left ( A^{xy} a^{z} - A^{xz} a^{y} + A^{yz} a^{x}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} \\end{equation*}"
+       "\\begin{equation*}A a^{x} \\boldsymbol{e}_{x} + A a^{y} \\boldsymbol{e}_{y} + A a^{z} \\boldsymbol{e}_{z} + \\left ( - A^{x} a^{y} + A^{y} a^{x}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + \\left ( - A^{x} a^{z} + A^{z} a^{x}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + \\left ( - A^{y} a^{z} + A^{z} a^{y}\\right ) \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} + \\left ( A^{xy} a^{z} - A^{xz} a^{y} + A^{yz} a^{x}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}\\end{equation*}"
       ],
       "text/plain": [
        "A*a__x*e_x + A*a__y*e_y + A*a__z*e_z + (-A__x*a__y + A__y*a__x)*e_x^e_y + (-A__x*a__z + A__z*a__x)*e_x^e_z + (-A__y*a__z + A__z*a__y)*e_y^e_z + (A__xy*a__z - A__xz*a__y + A__yz*a__x)*e_x^e_y^e_z"
@@ -331,7 +331,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} \\left ( A^{x} a^{x} + A^{y} a^{y} + A^{z} a^{z}\\right )  + \\left ( - A^{xy} a^{y} - A^{xz} a^{z}\\right ) \\boldsymbol{e}_{x} + \\left ( A^{xy} a^{x} - A^{yz} a^{z}\\right ) \\boldsymbol{e}_{y} + \\left ( A^{xz} a^{x} + A^{yz} a^{y}\\right ) \\boldsymbol{e}_{z} + A^{xyz} a^{z} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} - A^{xyz} a^{y} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + A^{xyz} a^{x} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} \\end{equation*}"
+       "\\begin{equation*}\\left ( A^{x} a^{x} + A^{y} a^{y} + A^{z} a^{z}\\right )  + \\left ( - A^{xy} a^{y} - A^{xz} a^{z}\\right ) \\boldsymbol{e}_{x} + \\left ( A^{xy} a^{x} - A^{yz} a^{z}\\right ) \\boldsymbol{e}_{y} + \\left ( A^{xz} a^{x} + A^{yz} a^{y}\\right ) \\boldsymbol{e}_{z} + A^{xyz} a^{z} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} - A^{xyz} a^{y} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + A^{xyz} a^{x} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}\\end{equation*}"
       ],
       "text/plain": [
        "A__x*a__x + A__y*a__y + A__z*a__z + (-A__xy*a__y - A__xz*a__z)*e_x + (A__xy*a__x - A__yz*a__z)*e_y + (A__xz*a__x + A__yz*a__y)*e_z + A__xyz*a__z*e_x^e_y - A__xyz*a__y*e_x^e_z + A__xyz*a__x*e_y^e_z"
@@ -354,7 +354,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*}  0  \\end{equation*}"
+       "\\begin{equation*} 0 \\end{equation*}"
       ],
       "text/plain": [
        "0"
@@ -384,7 +384,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} \\left ( A B + A^{x} B^{x} - A^{xy} B^{xy} - A^{xyz} B^{xyz} - A^{xz} B^{xz} + A^{y} B^{y} - A^{yz} B^{yz} + A^{z} B^{z}\\right )  + \\left ( A B^{x} + A^{x} B + A^{xy} B^{y} - A^{xyz} B^{yz} + A^{xz} B^{z} - A^{y} B^{xy} - A^{yz} B^{xyz} - A^{z} B^{xz}\\right ) \\boldsymbol{e}_{x} + \\left ( A B^{y} + A^{x} B^{xy} - A^{xy} B^{x} + A^{xyz} B^{xz} + A^{xz} B^{xyz} + A^{y} B + A^{yz} B^{z} - A^{z} B^{yz}\\right ) \\boldsymbol{e}_{y} + \\left ( A B^{z} + A^{x} B^{xz} - A^{xy} B^{xyz} - A^{xyz} B^{xy} - A^{xz} B^{x} + A^{y} B^{yz} - A^{yz} B^{y} + A^{z} B\\right ) \\boldsymbol{e}_{z} + \\left ( A B^{xy} + A^{x} B^{y} + A^{xy} B + A^{xyz} B^{z} - A^{xz} B^{yz} - A^{y} B^{x} + A^{yz} B^{xz} + A^{z} B^{xyz}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + \\left ( A B^{xz} + A^{x} B^{z} + A^{xy} B^{yz} - A^{xyz} B^{y} + A^{xz} B - A^{y} B^{xyz} - A^{yz} B^{xy} - A^{z} B^{x}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + \\left ( A B^{yz} + A^{x} B^{xyz} - A^{xy} B^{xz} + A^{xyz} B^{x} + A^{xz} B^{xy} + A^{y} B^{z} + A^{yz} B - A^{z} B^{y}\\right ) \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} + \\left ( A B^{xyz} + A^{x} B^{yz} + A^{xy} B^{z} + A^{xyz} B - A^{xz} B^{y} - A^{y} B^{xz} + A^{yz} B^{x} + A^{z} B^{xy}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} \\end{equation*}"
+       "\\begin{equation*}\\left ( A B + A^{x} B^{x} - A^{xy} B^{xy} - A^{xyz} B^{xyz} - A^{xz} B^{xz} + A^{y} B^{y} - A^{yz} B^{yz} + A^{z} B^{z}\\right )  + \\left ( A B^{x} + A^{x} B + A^{xy} B^{y} - A^{xyz} B^{yz} + A^{xz} B^{z} - A^{y} B^{xy} - A^{yz} B^{xyz} - A^{z} B^{xz}\\right ) \\boldsymbol{e}_{x} + \\left ( A B^{y} + A^{x} B^{xy} - A^{xy} B^{x} + A^{xyz} B^{xz} + A^{xz} B^{xyz} + A^{y} B + A^{yz} B^{z} - A^{z} B^{yz}\\right ) \\boldsymbol{e}_{y} + \\left ( A B^{z} + A^{x} B^{xz} - A^{xy} B^{xyz} - A^{xyz} B^{xy} - A^{xz} B^{x} + A^{y} B^{yz} - A^{yz} B^{y} + A^{z} B\\right ) \\boldsymbol{e}_{z} + \\left ( A B^{xy} + A^{x} B^{y} + A^{xy} B + A^{xyz} B^{z} - A^{xz} B^{yz} - A^{y} B^{x} + A^{yz} B^{xz} + A^{z} B^{xyz}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + \\left ( A B^{xz} + A^{x} B^{z} + A^{xy} B^{yz} - A^{xyz} B^{y} + A^{xz} B - A^{y} B^{xyz} - A^{yz} B^{xy} - A^{z} B^{x}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + \\left ( A B^{yz} + A^{x} B^{xyz} - A^{xy} B^{xz} + A^{xyz} B^{x} + A^{xz} B^{xy} + A^{y} B^{z} + A^{yz} B - A^{z} B^{y}\\right ) \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} + \\left ( A B^{xyz} + A^{x} B^{yz} + A^{xy} B^{z} + A^{xyz} B - A^{xz} B^{y} - A^{y} B^{xz} + A^{yz} B^{x} + A^{z} B^{xy}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}\\end{equation*}"
       ],
       "text/plain": [
        "A*B + A__x*B__x - A__xy*B__xy - A__xyz*B__xyz - A__xz*B__xz + A__y*B__y - A__yz*B__yz + A__z*B__z + (A*B__x + A__x*B + A__xy*B__y - A__xyz*B__yz + A__xz*B__z - A__y*B__xy - A__yz*B__xyz - A__z*B__xz)*e_x + (A*B__y + A__x*B__xy - A__xy*B__x + A__xyz*B__xz + A__xz*B__xyz + A__y*B + A__yz*B__z - A__z*B__yz)*e_y + (A*B__z + A__x*B__xz - A__xy*B__xyz - A__xyz*B__xy - A__xz*B__x + A__y*B__yz - A__yz*B__y + A__z*B)*e_z + (A*B__xy + A__x*B__y + A__xy*B + A__xyz*B__z - A__xz*B__yz - A__y*B__x + A__yz*B__xz + A__z*B__xyz)*e_x^e_y + (A*B__xz + A__x*B__z + A__xy*B__yz - A__xyz*B__y + A__xz*B - A__y*B__xyz - A__yz*B__xy - A__z*B__x)*e_x^e_z + (A*B__yz + A__x*B__xyz - A__xy*B__xz + A__xyz*B__x + A__xz*B__xy + A__y*B__z + A__yz*B - A__z*B__y)*e_y^e_z + (A*B__xyz + A__x*B__yz + A__xy*B__z + A__xyz*B - A__xz*B__y - A__y*B__xz + A__yz*B__x + A__z*B__xy)*e_x^e_y^e_z"
@@ -407,7 +407,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} \\left ( A^{x} B^{x} - A^{xy} B^{xy} - A^{xyz} B^{xyz} - A^{xz} B^{xz} + A^{y} B^{y} - A^{yz} B^{yz} + A^{z} B^{z}\\right )  + \\left ( A^{xy} B^{y} - A^{xyz} B^{yz} + A^{xz} B^{z} - A^{y} B^{xy} - A^{yz} B^{xyz} - A^{z} B^{xz}\\right ) \\boldsymbol{e}_{x} + \\left ( A^{x} B^{xy} - A^{xy} B^{x} + A^{xyz} B^{xz} + A^{xz} B^{xyz} + A^{yz} B^{z} - A^{z} B^{yz}\\right ) \\boldsymbol{e}_{y} + \\left ( A^{x} B^{xz} - A^{xy} B^{xyz} - A^{xyz} B^{xy} - A^{xz} B^{x} + A^{y} B^{yz} - A^{yz} B^{y}\\right ) \\boldsymbol{e}_{z} + \\left ( A^{xyz} B^{z} + A^{z} B^{xyz}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + \\left ( - A^{xyz} B^{y} - A^{y} B^{xyz}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + \\left ( A^{x} B^{xyz} + A^{xyz} B^{x}\\right ) \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} \\end{equation*}"
+       "\\begin{equation*}\\left ( A^{x} B^{x} - A^{xy} B^{xy} - A^{xyz} B^{xyz} - A^{xz} B^{xz} + A^{y} B^{y} - A^{yz} B^{yz} + A^{z} B^{z}\\right )  + \\left ( A^{xy} B^{y} - A^{xyz} B^{yz} + A^{xz} B^{z} - A^{y} B^{xy} - A^{yz} B^{xyz} - A^{z} B^{xz}\\right ) \\boldsymbol{e}_{x} + \\left ( A^{x} B^{xy} - A^{xy} B^{x} + A^{xyz} B^{xz} + A^{xz} B^{xyz} + A^{yz} B^{z} - A^{z} B^{yz}\\right ) \\boldsymbol{e}_{y} + \\left ( A^{x} B^{xz} - A^{xy} B^{xyz} - A^{xyz} B^{xy} - A^{xz} B^{x} + A^{y} B^{yz} - A^{yz} B^{y}\\right ) \\boldsymbol{e}_{z} + \\left ( A^{xyz} B^{z} + A^{z} B^{xyz}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + \\left ( - A^{xyz} B^{y} - A^{y} B^{xyz}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + \\left ( A^{x} B^{xyz} + A^{xyz} B^{x}\\right ) \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}\\end{equation*}"
       ],
       "text/plain": [
        "A__x*B__x - A__xy*B__xy - A__xyz*B__xyz - A__xz*B__xz + A__y*B__y - A__yz*B__yz + A__z*B__z + (A__xy*B__y - A__xyz*B__yz + A__xz*B__z - A__y*B__xy - A__yz*B__xyz - A__z*B__xz)*e_x + (A__x*B__xy - A__xy*B__x + A__xyz*B__xz + A__xz*B__xyz + A__yz*B__z - A__z*B__yz)*e_y + (A__x*B__xz - A__xy*B__xyz - A__xyz*B__xy - A__xz*B__x + A__y*B__yz - A__yz*B__y)*e_z + (A__xyz*B__z + A__z*B__xyz)*e_x^e_y + (-A__xyz*B__y - A__y*B__xyz)*e_x^e_z + (A__x*B__xyz + A__xyz*B__x)*e_y^e_z"
@@ -432,7 +432,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} \\left ( - A^{xz} B^{yz} + A^{yz} B^{xz}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + \\left ( A^{xy} B^{yz} - A^{yz} B^{xy}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + \\left ( - A^{xy} B^{xz} + A^{xz} B^{xy}\\right ) \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} \\end{equation*}"
+       "\\begin{equation*}\\left ( - A^{xz} B^{yz} + A^{yz} B^{xz}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + \\left ( A^{xy} B^{yz} - A^{yz} B^{xy}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + \\left ( - A^{xy} B^{xz} + A^{xz} B^{xy}\\right ) \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}\\end{equation*}"
       ],
       "text/plain": [
        "(-A__xz*B__yz + A__yz*B__xz)*e_x^e_y + (A__xy*B__yz - A__yz*B__xy)*e_x^e_z + (-A__xy*B__xz + A__xz*B__xy)*e_y^e_z"
@@ -455,7 +455,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} \\left ( A B + 2 A^{x} B^{x} - 2 A^{xy} B^{xy} - 2 A^{xyz} B^{xyz} - 2 A^{xz} B^{xz} + 2 A^{y} B^{y} - 2 A^{yz} B^{yz} + 2 A^{z} B^{z}\\right )  + \\left ( A^{xy} B^{y} - A^{xyz} B^{yz} + A^{xz} B^{z} - A^{y} B^{xy} - A^{yz} B^{xyz} - A^{z} B^{xz}\\right ) \\boldsymbol{e}_{x} + \\left ( A^{x} B^{xy} - A^{xy} B^{x} + A^{xyz} B^{xz} + A^{xz} B^{xyz} + A^{yz} B^{z} - A^{z} B^{yz}\\right ) \\boldsymbol{e}_{y} + \\left ( A^{x} B^{xz} - A^{xy} B^{xyz} - A^{xyz} B^{xy} - A^{xz} B^{x} + A^{y} B^{yz} - A^{yz} B^{y}\\right ) \\boldsymbol{e}_{z} + \\left ( - A^{x} B^{y} + A^{xyz} B^{z} + A^{xz} B^{yz} + A^{y} B^{x} - A^{yz} B^{xz} + A^{z} B^{xyz}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + \\left ( - A^{x} B^{z} - A^{xy} B^{yz} - A^{xyz} B^{y} - A^{y} B^{xyz} + A^{yz} B^{xy} + A^{z} B^{x}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + \\left ( A^{x} B^{xyz} + A^{xy} B^{xz} + A^{xyz} B^{x} - A^{xz} B^{xy} - A^{y} B^{z} + A^{z} B^{y}\\right ) \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} + \\left ( - A^{x} B^{yz} - A^{xy} B^{z} + A^{xz} B^{y} + A^{y} B^{xz} - A^{yz} B^{x} - A^{z} B^{xy}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} \\end{equation*}"
+       "\\begin{equation*}\\left ( A B + 2 A^{x} B^{x} - 2 A^{xy} B^{xy} - 2 A^{xyz} B^{xyz} - 2 A^{xz} B^{xz} + 2 A^{y} B^{y} - 2 A^{yz} B^{yz} + 2 A^{z} B^{z}\\right )  + \\left ( A^{xy} B^{y} - A^{xyz} B^{yz} + A^{xz} B^{z} - A^{y} B^{xy} - A^{yz} B^{xyz} - A^{z} B^{xz}\\right ) \\boldsymbol{e}_{x} + \\left ( A^{x} B^{xy} - A^{xy} B^{x} + A^{xyz} B^{xz} + A^{xz} B^{xyz} + A^{yz} B^{z} - A^{z} B^{yz}\\right ) \\boldsymbol{e}_{y} + \\left ( A^{x} B^{xz} - A^{xy} B^{xyz} - A^{xyz} B^{xy} - A^{xz} B^{x} + A^{y} B^{yz} - A^{yz} B^{y}\\right ) \\boldsymbol{e}_{z} + \\left ( - A^{x} B^{y} + A^{xyz} B^{z} + A^{xz} B^{yz} + A^{y} B^{x} - A^{yz} B^{xz} + A^{z} B^{xyz}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + \\left ( - A^{x} B^{z} - A^{xy} B^{yz} - A^{xyz} B^{y} - A^{y} B^{xyz} + A^{yz} B^{xy} + A^{z} B^{x}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + \\left ( A^{x} B^{xyz} + A^{xy} B^{xz} + A^{xyz} B^{x} - A^{xz} B^{xy} - A^{y} B^{z} + A^{z} B^{y}\\right ) \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} + \\left ( - A^{x} B^{yz} - A^{xy} B^{z} + A^{xz} B^{y} + A^{y} B^{xz} - A^{yz} B^{x} - A^{z} B^{xy}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}\\end{equation*}"
       ],
       "text/plain": [
        "A*B + 2*A__x*B__x - 2*A__xy*B__xy - 2*A__xyz*B__xyz - 2*A__xz*B__xz + 2*A__y*B__y - 2*A__yz*B__yz + 2*A__z*B__z + (A__xy*B__y - A__xyz*B__yz + A__xz*B__z - A__y*B__xy - A__yz*B__xyz - A__z*B__xz)*e_x + (A__x*B__xy - A__xy*B__x + A__xyz*B__xz + A__xz*B__xyz + A__yz*B__z - A__z*B__yz)*e_y + (A__x*B__xz - A__xy*B__xyz - A__xyz*B__xy - A__xz*B__x + A__y*B__yz - A__yz*B__y)*e_z + (-A__x*B__y + A__xyz*B__z + A__xz*B__yz + A__y*B__x - A__yz*B__xz + A__z*B__xyz)*e_x^e_y + (-A__x*B__z - A__xy*B__yz - A__xyz*B__y - A__y*B__xyz + A__yz*B__xy + A__z*B__x)*e_x^e_z + (A__x*B__xyz + A__xy*B__xz + A__xyz*B__x - A__xz*B__xy - A__y*B__z + A__z*B__y)*e_y^e_z + (-A__x*B__yz - A__xy*B__z + A__xz*B__y + A__y*B__xz - A__yz*B__x - A__z*B__xy)*e_x^e_y^e_z"

--- a/examples/ipython/printing-galgebra.ipynb
+++ b/examples/ipython/printing-galgebra.ipynb
@@ -121,7 +121,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*}  \\boldsymbol{e}_{1}\\wedge \\boldsymbol{e}_{2}\\wedge \\boldsymbol{e}_{3}\\wedge \\boldsymbol{e}\\wedge \\boldsymbol{e}_{{0}} \\end{equation*}"
+       "\\begin{equation*} \\boldsymbol{e}_{1}\\wedge \\boldsymbol{e}_{2}\\wedge \\boldsymbol{e}_{3}\\wedge \\boldsymbol{e}\\wedge \\boldsymbol{e}_{{0}}\\end{equation*}"
       ],
       "text/plain": [
        "e_1^e_2^e_3^e^e_{0}"

--- a/examples/ipython/second_derivative.ipynb
+++ b/examples/ipython/second_derivative.ipynb
@@ -8,7 +8,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} phi = \\phi ^{t}  \\boldsymbol{e}_{t} + \\phi ^{x}  \\boldsymbol{e}_{x} + \\phi ^{y}  \\boldsymbol{e}_{y} + \\phi ^{z}  \\boldsymbol{e}_{z} \\end{equation*}"
+       "\\begin{equation*}phi = \\phi ^{t}  \\boldsymbol{e}_{t} + \\phi ^{x}  \\boldsymbol{e}_{x} + \\phi ^{y}  \\boldsymbol{e}_{y} + \\phi ^{z}  \\boldsymbol{e}_{z}\\end{equation*}"
       ],
       "text/plain": [
        "phi__t*e_t + phi__x*e_x + phi__y*e_y + phi__z*e_z"
@@ -40,7 +40,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} \\left ( \\partial_{t} \\phi ^{t}  + \\partial_{x} \\phi ^{x}  + \\partial_{y} \\phi ^{y}  + \\partial_{z} \\phi ^{z} \\right )  + \\left ( \\partial_{x} \\phi ^{t}  + \\partial_{t} \\phi ^{x} \\right ) \\boldsymbol{e}_{tx} + \\left ( \\partial_{y} \\phi ^{t}  + \\partial_{t} \\phi ^{y} \\right ) \\boldsymbol{e}_{ty} + \\left ( \\partial_{z} \\phi ^{t}  + \\partial_{t} \\phi ^{z} \\right ) \\boldsymbol{e}_{tz} + \\left ( \\partial_{y} \\phi ^{x}  - \\partial_{x} \\phi ^{y} \\right ) \\boldsymbol{e}_{xy} + \\left ( \\partial_{z} \\phi ^{x}  - \\partial_{x} \\phi ^{z} \\right ) \\boldsymbol{e}_{xz} + \\left ( \\partial_{z} \\phi ^{y}  - \\partial_{y} \\phi ^{z} \\right ) \\boldsymbol{e}_{yz} \\end{equation*}"
+       "\\begin{equation*}\\left ( \\partial_{t} \\phi ^{t}  + \\partial_{x} \\phi ^{x}  + \\partial_{y} \\phi ^{y}  + \\partial_{z} \\phi ^{z} \\right )  + \\left ( \\partial_{x} \\phi ^{t}  + \\partial_{t} \\phi ^{x} \\right ) \\boldsymbol{e}_{tx} + \\left ( \\partial_{y} \\phi ^{t}  + \\partial_{t} \\phi ^{y} \\right ) \\boldsymbol{e}_{ty} + \\left ( \\partial_{z} \\phi ^{t}  + \\partial_{t} \\phi ^{z} \\right ) \\boldsymbol{e}_{tz} + \\left ( \\partial_{y} \\phi ^{x}  - \\partial_{x} \\phi ^{y} \\right ) \\boldsymbol{e}_{xy} + \\left ( \\partial_{z} \\phi ^{x}  - \\partial_{x} \\phi ^{z} \\right ) \\boldsymbol{e}_{xz} + \\left ( \\partial_{z} \\phi ^{y}  - \\partial_{y} \\phi ^{z} \\right ) \\boldsymbol{e}_{yz}\\end{equation*}"
       ],
       "text/plain": [
        "D{t}phi__t + D{x}phi__x + D{y}phi__y + D{z}phi__z + (D{x}phi__t + D{t}phi__x)*e_tx + (D{y}phi__t + D{t}phi__y)*e_ty + (D{z}phi__t + D{t}phi__z)*e_tz + (D{y}phi__x - D{x}phi__y)*e_xy + (D{z}phi__x - D{x}phi__z)*e_xz + (D{z}phi__y - D{y}phi__z)*e_yz"
@@ -64,7 +64,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} \\left ( \\partial^{2}_{t} \\phi ^{t}  - \\partial^{2}_{x} \\phi ^{t}  - \\partial^{2}_{y} \\phi ^{t}  - \\partial^{2}_{z} \\phi ^{t} \\right ) \\boldsymbol{e}_{t} + \\left ( \\partial^{2}_{t} \\phi ^{x}  - \\partial^{2}_{x} \\phi ^{x}  - \\partial^{2}_{y} \\phi ^{x}  - \\partial^{2}_{z} \\phi ^{x} \\right ) \\boldsymbol{e}_{x} + \\left ( \\partial^{2}_{t} \\phi ^{y}  - \\partial^{2}_{x} \\phi ^{y}  - \\partial^{2}_{y} \\phi ^{y}  - \\partial^{2}_{z} \\phi ^{y} \\right ) \\boldsymbol{e}_{y} + \\left ( \\partial^{2}_{t} \\phi ^{z}  - \\partial^{2}_{x} \\phi ^{z}  - \\partial^{2}_{y} \\phi ^{z}  - \\partial^{2}_{z} \\phi ^{z} \\right ) \\boldsymbol{e}_{z} \\end{equation*}"
+       "\\begin{equation*}\\left ( \\partial^{2}_{t} \\phi ^{t}  - \\partial^{2}_{x} \\phi ^{t}  - \\partial^{2}_{y} \\phi ^{t}  - \\partial^{2}_{z} \\phi ^{t} \\right ) \\boldsymbol{e}_{t} + \\left ( \\partial^{2}_{t} \\phi ^{x}  - \\partial^{2}_{x} \\phi ^{x}  - \\partial^{2}_{y} \\phi ^{x}  - \\partial^{2}_{z} \\phi ^{x} \\right ) \\boldsymbol{e}_{x} + \\left ( \\partial^{2}_{t} \\phi ^{y}  - \\partial^{2}_{x} \\phi ^{y}  - \\partial^{2}_{y} \\phi ^{y}  - \\partial^{2}_{z} \\phi ^{y} \\right ) \\boldsymbol{e}_{y} + \\left ( \\partial^{2}_{t} \\phi ^{z}  - \\partial^{2}_{x} \\phi ^{z}  - \\partial^{2}_{y} \\phi ^{z}  - \\partial^{2}_{z} \\phi ^{z} \\right ) \\boldsymbol{e}_{z}\\end{equation*}"
       ],
       "text/plain": [
        "(D{t}^2phi__t - D{x}^2phi__t - D{y}^2phi__t - D{z}^2phi__t)*e_t + (D{t}^2phi__x - D{x}^2phi__x - D{y}^2phi__x - D{z}^2phi__x)*e_x + (D{t}^2phi__y - D{x}^2phi__y - D{y}^2phi__y - D{z}^2phi__y)*e_y + (D{t}^2phi__z - D{x}^2phi__z - D{y}^2phi__z - D{z}^2phi__z)*e_z"
@@ -88,7 +88,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} \\left ( \\partial_{x} \\phi ^{t}  + \\partial_{t} \\phi ^{x} \\right ) \\boldsymbol{e}_{tx} \\end{equation*}"
+       "\\begin{equation*}\\left ( \\partial_{x} \\phi ^{t}  + \\partial_{t} \\phi ^{x} \\right ) \\boldsymbol{e}_{tx}\\end{equation*}"
       ],
       "text/plain": [
        "(D{x}phi__t + D{t}phi__x)*e_tx"
@@ -112,7 +112,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} \\left ( - \\partial^{2}_{x} \\phi ^{t}  - \\partial_{t}\\partial_{x} \\phi ^{x} \\right ) \\boldsymbol{e}_{t} + \\left ( \\partial^{2}_{t} \\phi ^{x}  + \\partial_{t}\\partial_{x} \\phi ^{t} \\right ) \\boldsymbol{e}_{x} + \\left ( - \\partial_{x}\\partial_{y} \\phi ^{t}  - \\partial_{t}\\partial_{y} \\phi ^{x} \\right ) \\boldsymbol{e}_{txy} + \\left ( - \\partial_{x}\\partial_{z} \\phi ^{t}  - \\partial_{t}\\partial_{z} \\phi ^{x} \\right ) \\boldsymbol{e}_{txz} \\end{equation*}"
+       "\\begin{equation*}\\left ( - \\partial^{2}_{x} \\phi ^{t}  - \\partial_{t}\\partial_{x} \\phi ^{x} \\right ) \\boldsymbol{e}_{t} + \\left ( \\partial^{2}_{t} \\phi ^{x}  + \\partial_{t}\\partial_{x} \\phi ^{t} \\right ) \\boldsymbol{e}_{x} + \\left ( - \\partial_{x}\\partial_{y} \\phi ^{t}  - \\partial_{t}\\partial_{y} \\phi ^{x} \\right ) \\boldsymbol{e}_{txy} + \\left ( - \\partial_{x}\\partial_{z} \\phi ^{t}  - \\partial_{t}\\partial_{z} \\phi ^{x} \\right ) \\boldsymbol{e}_{txz}\\end{equation*}"
       ],
       "text/plain": [
        "(-D{x}^2phi__t - D{t}{x}phi__x)*e_t + (D{t}^2phi__x + D{t}{x}phi__t)*e_x + (-D{x}{y}phi__t - D{t}{y}phi__x)*e_txy + (-D{x}{z}phi__t - D{t}{z}phi__x)*e_txz"

--- a/examples/ipython/simple_ga_test.ipynb
+++ b/examples/ipython/simple_ga_test.ipynb
@@ -47,7 +47,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} v = v^{x} \\boldsymbol{e}_{x} + v^{y} \\boldsymbol{e}_{y} + v^{z} \\boldsymbol{e}_{z} \\end{equation*}"
+       "\\begin{equation*}v = v^{x} \\boldsymbol{e}_{x} + v^{y} \\boldsymbol{e}_{y} + v^{z} \\boldsymbol{e}_{z}\\end{equation*}"
       ],
       "text/plain": [
        "v__x*e_x + v__y*e_y + v__z*e_z"
@@ -70,7 +70,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} v =  \\begin{aligned}[t]  & v^{x} \\boldsymbol{e}_{x} \\\\  &  + v^{y} \\boldsymbol{e}_{y} \\\\  &  + v^{z} \\boldsymbol{e}_{z}  \\end{aligned}  \\end{equation*}"
+       "\\begin{equation*}v =  \\begin{aligned}[t]  & v^{x} \\boldsymbol{e}_{x} \\\\  &  + v^{y} \\boldsymbol{e}_{y} \\\\  &  + v^{z} \\boldsymbol{e}_{z}  \\end{aligned} \\end{equation*}"
       ],
       "text/plain": [
        "v =  v__x*e_x\n",
@@ -104,7 +104,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} V^{x}  \\boldsymbol{e}_{x} + V^{y}  \\boldsymbol{e}_{y} + V^{z}  \\boldsymbol{e}_{z} \\end{equation*}"
+       "\\begin{equation*}V^{x}  \\boldsymbol{e}_{x} + V^{y}  \\boldsymbol{e}_{y} + V^{z}  \\boldsymbol{e}_{z}\\end{equation*}"
       ],
       "text/plain": [
        "V__x*e_x + V__y*e_y + V__z*e_z"
@@ -129,7 +129,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} V = V^{x}  \\boldsymbol{e}_{x} + V^{y}  \\boldsymbol{e}_{y} + V^{z}  \\boldsymbol{e}_{z} \\end{equation*}"
+       "\\begin{equation*}V = V^{x}  \\boldsymbol{e}_{x} + V^{y}  \\boldsymbol{e}_{y} + V^{z}  \\boldsymbol{e}_{z}\\end{equation*}"
       ],
       "text/plain": [
        "V__x*e_x + V__y*e_y + V__z*e_z"
@@ -161,7 +161,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} \\left ( \\partial_{x} V^{x}  + \\partial_{y} V^{y}  + \\partial_{z} V^{z} \\right )  + \\left ( - \\partial_{y} V^{x}  + \\partial_{x} V^{y} \\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + \\left ( - \\partial_{z} V^{x}  + \\partial_{x} V^{z} \\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + \\left ( - \\partial_{z} V^{y}  + \\partial_{y} V^{z} \\right ) \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} \\end{equation*}"
+       "\\begin{equation*}\\left ( \\partial_{x} V^{x}  + \\partial_{y} V^{y}  + \\partial_{z} V^{z} \\right )  + \\left ( - \\partial_{y} V^{x}  + \\partial_{x} V^{y} \\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + \\left ( - \\partial_{z} V^{x}  + \\partial_{x} V^{z} \\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + \\left ( - \\partial_{z} V^{y}  + \\partial_{y} V^{z} \\right ) \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}\\end{equation*}"
       ],
       "text/plain": [
        "D{x}V__x + D{y}V__y + D{z}V__z + (-D{y}V__x + D{x}V__y)*e_x^e_y + (-D{z}V__x + D{x}V__z)*e_x^e_z + (-D{z}V__y + D{y}V__z)*e_y^e_z"
@@ -184,7 +184,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} \\nabla V =  \\begin{aligned}[t]  & \\left ( \\partial_{x} V^{x}  + \\partial_{y} V^{y}  + \\partial_{z} V^{z} \\right )  \\\\  &  + \\left ( - \\partial_{y} V^{x}  + \\partial_{x} V^{y} \\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} \\\\  &  + \\left ( - \\partial_{z} V^{x}  + \\partial_{x} V^{z} \\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} \\\\  &  + \\left ( - \\partial_{z} V^{y}  + \\partial_{y} V^{z} \\right ) \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}  \\end{aligned}  \\end{equation*}"
+       "\\begin{equation*}\\nabla V =  \\begin{aligned}[t]  & \\left ( \\partial_{x} V^{x}  + \\partial_{y} V^{y}  + \\partial_{z} V^{z} \\right )  \\\\  &  + \\left ( - \\partial_{y} V^{x}  + \\partial_{x} V^{y} \\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} \\\\  &  + \\left ( - \\partial_{z} V^{x}  + \\partial_{x} V^{z} \\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} \\\\  &  + \\left ( - \\partial_{z} V^{y}  + \\partial_{y} V^{z} \\right ) \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}  \\end{aligned} \\end{equation*}"
       ],
       "text/plain": [
        "\\nabla V =  D{x}V__x + D{y}V__y + D{z}V__z\n",
@@ -210,7 +210,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} \\nabla V =  \\begin{aligned}[t]  & \\left ( \\partial_{x} V^{x}  + \\partial_{y} V^{y}  + \\partial_{z} V^{z} \\right )  \\\\  &  + \\left ( - \\partial_{y} V^{x}  + \\partial_{x} V^{y} \\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + \\left ( - \\partial_{z} V^{x}  + \\partial_{x} V^{z} \\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + \\left ( - \\partial_{z} V^{y}  + \\partial_{y} V^{z} \\right ) \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}  \\end{aligned}  \\end{equation*}"
+       "\\begin{equation*}\\nabla V =  \\begin{aligned}[t]  & \\left ( \\partial_{x} V^{x}  + \\partial_{y} V^{y}  + \\partial_{z} V^{z} \\right )  \\\\  &  + \\left ( - \\partial_{y} V^{x}  + \\partial_{x} V^{y} \\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + \\left ( - \\partial_{z} V^{x}  + \\partial_{x} V^{z} \\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + \\left ( - \\partial_{z} V^{y}  + \\partial_{y} V^{z} \\right ) \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}  \\end{aligned} \\end{equation*}"
       ],
       "text/plain": [
        "\\nabla V =  D{x}V__x + D{y}V__y + D{z}V__z\n",
@@ -243,7 +243,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} \\frac{\\partial^{2}}{\\partial x^{2}} + \\frac{\\partial^{2}}{\\partial y^{2}} + \\frac{\\partial^{2}}{\\partial z^{2}} \\end{equation*}"
+       "\\begin{equation*}\\frac{\\partial^{2}}{\\partial x^{2}} + \\frac{\\partial^{2}}{\\partial y^{2}} + \\frac{\\partial^{2}}{\\partial z^{2}}\\end{equation*}"
       ],
       "text/plain": [
        "D{x}^2 + D{y}^2 + D{z}^2"
@@ -266,7 +266,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} \\nabla^{2} = \\frac{\\partial^{2}}{\\partial x^{2}} + \\frac{\\partial^{2}}{\\partial y^{2}} + \\frac{\\partial^{2}}{\\partial z^{2}} \\end{equation*}"
+       "\\begin{equation*}\\nabla^{2} = \\frac{\\partial^{2}}{\\partial x^{2}} + \\frac{\\partial^{2}}{\\partial y^{2}} + \\frac{\\partial^{2}}{\\partial z^{2}}\\end{equation*}"
       ],
       "text/plain": [
        "\\nabla^{2} = D{x}^2 + D{y}^2 + D{z}^2"
@@ -300,8 +300,8 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} \\left \\{ \\begin{array}{ll} L \\left ( \\boldsymbol{e}_{x}\\right ) =& A_{xx} \\boldsymbol{e}_{x} + A_{yx} \\boldsymbol{e}_{y} + A_{zx} \\boldsymbol{e}_{z} \\\\ L \\left ( \\boldsymbol{e}_{y}\\right ) =& A_{xy} \\boldsymbol{e}_{x} + A_{yy} \\boldsymbol{e}_{y} + A_{zy} \\boldsymbol{e}_{z} \\\\ L \\left ( \\boldsymbol{e}_{z}\\right ) =& A_{xz} \\boldsymbol{e}_{x} + A_{yz} \\boldsymbol{e}_{y} + A_{zz} \\boldsymbol{e}_{z}  \\end{array} \\right \\} \n",
-       " \\end{equation*}"
+       "\\begin{equation*}\\left \\{ \\begin{array}{ll} L \\left ( \\boldsymbol{e}_{x}\\right ) =& A_{xx} \\boldsymbol{e}_{x} + A_{yx} \\boldsymbol{e}_{y} + A_{zx} \\boldsymbol{e}_{z} \\\\ L \\left ( \\boldsymbol{e}_{y}\\right ) =& A_{xy} \\boldsymbol{e}_{x} + A_{yy} \\boldsymbol{e}_{y} + A_{zy} \\boldsymbol{e}_{z} \\\\ L \\left ( \\boldsymbol{e}_{z}\\right ) =& A_{xz} \\boldsymbol{e}_{x} + A_{yz} \\boldsymbol{e}_{y} + A_{zz} \\boldsymbol{e}_{z}  \\end{array} \\right \\} \n",
+       "\\end{equation*}"
       ],
       "text/plain": [
        "Lt(e_x) = A_xx*e_x + A_yx*e_y + A_zx*e_z\n",
@@ -328,8 +328,8 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} A = \\left \\{ \\begin{array}{ll} L \\left ( \\boldsymbol{e}_{x}\\right ) =& A_{xx} \\boldsymbol{e}_{x} + A_{yx} \\boldsymbol{e}_{y} + A_{zx} \\boldsymbol{e}_{z} \\\\ L \\left ( \\boldsymbol{e}_{y}\\right ) =& A_{xy} \\boldsymbol{e}_{x} + A_{yy} \\boldsymbol{e}_{y} + A_{zy} \\boldsymbol{e}_{z} \\\\ L \\left ( \\boldsymbol{e}_{z}\\right ) =& A_{xz} \\boldsymbol{e}_{x} + A_{yz} \\boldsymbol{e}_{y} + A_{zz} \\boldsymbol{e}_{z}  \\end{array} \\right \\} \n",
-       " \\end{equation*}"
+       "\\begin{equation*}A = \\left \\{ \\begin{array}{ll} L \\left ( \\boldsymbol{e}_{x}\\right ) =& A_{xx} \\boldsymbol{e}_{x} + A_{yx} \\boldsymbol{e}_{y} + A_{zx} \\boldsymbol{e}_{z} \\\\ L \\left ( \\boldsymbol{e}_{y}\\right ) =& A_{xy} \\boldsymbol{e}_{x} + A_{yy} \\boldsymbol{e}_{y} + A_{zy} \\boldsymbol{e}_{z} \\\\ L \\left ( \\boldsymbol{e}_{z}\\right ) =& A_{xz} \\boldsymbol{e}_{x} + A_{yz} \\boldsymbol{e}_{y} + A_{zz} \\boldsymbol{e}_{z}  \\end{array} \\right \\} \n",
+       "\\end{equation*}"
       ],
       "text/plain": [
        "A = Lt(e_x) = A_xx*e_x + A_yx*e_y + A_zx*e_z\n",
@@ -354,8 +354,8 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} A = \\left \\{ \\begin{array}{ll} L \\left ( \\boldsymbol{e}_{x}\\right ) =& A_{xx} \\boldsymbol{e}_{x} + A_{yx} \\boldsymbol{e}_{y} + A_{zx} \\boldsymbol{e}_{z} \\\\ L \\left ( \\boldsymbol{e}_{y}\\right ) =& A_{xy} \\boldsymbol{e}_{x} + A_{yy} \\boldsymbol{e}_{y} + A_{zy} \\boldsymbol{e}_{z} \\\\ L \\left ( \\boldsymbol{e}_{z}\\right ) =& A_{xz} \\boldsymbol{e}_{x} + A_{yz} \\boldsymbol{e}_{y} + A_{zz} \\boldsymbol{e}_{z}  \\end{array} \\right \\} \n",
-       " \\end{equation*}"
+       "\\begin{equation*}A = \\left \\{ \\begin{array}{ll} L \\left ( \\boldsymbol{e}_{x}\\right ) =& A_{xx} \\boldsymbol{e}_{x} + A_{yx} \\boldsymbol{e}_{y} + A_{zx} \\boldsymbol{e}_{z} \\\\ L \\left ( \\boldsymbol{e}_{y}\\right ) =& A_{xy} \\boldsymbol{e}_{x} + A_{yy} \\boldsymbol{e}_{y} + A_{zy} \\boldsymbol{e}_{z} \\\\ L \\left ( \\boldsymbol{e}_{z}\\right ) =& A_{xz} \\boldsymbol{e}_{x} + A_{yz} \\boldsymbol{e}_{y} + A_{zz} \\boldsymbol{e}_{z}  \\end{array} \\right \\} \n",
+       "\\end{equation*}"
       ],
       "text/plain": [
        "A = Lt(e_x) = A_xx*e_x + A_yx*e_y + A_zx*e_z\n",

--- a/examples/ipython/st4.ipynb
+++ b/examples/ipython/st4.ipynb
@@ -78,7 +78,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} \\mathbf{a} = a^{t}  \\boldsymbol{e}_{t} + a^{x}  \\boldsymbol{e}_{x} + a^{y}  \\boldsymbol{e}_{y} + a^{z}  \\boldsymbol{e}_{z} \\end{equation*}"
+       "\\begin{equation*}\\mathbf{a} = a^{t}  \\boldsymbol{e}_{t} + a^{x}  \\boldsymbol{e}_{x} + a^{y}  \\boldsymbol{e}_{y} + a^{z}  \\boldsymbol{e}_{z}\\end{equation*}"
       ],
       "text/plain": [
        "\\mathbf{a} = a__t*e_t + a__x*e_x + a__y*e_y + a__z*e_z"
@@ -101,7 +101,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} \\mathbf{a} \\mathbf{a} = {a^{t} }^{2} - {a^{x} }^{2} - {a^{y} }^{2} - {a^{z} }^{2} \\end{equation*}"
+       "\\begin{equation*}\\mathbf{a} \\mathbf{a} = {a^{t} }^{2} - {a^{x} }^{2} - {a^{y} }^{2} - {a^{z} }^{2}\\end{equation*}"
       ],
       "text/plain": [
        "\\mathbf{a} \\mathbf{a} = a__t**2 - a__x**2 - a__y**2 - a__z**2"
@@ -124,7 +124,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} \\mathbf{a}^{-1} =  \\begin{aligned}[t]  & \\frac{a^{t} }{{a^{t} }^{2} - {a^{x} }^{2} - {a^{y} }^{2} - {a^{z} }^{2}} \\boldsymbol{e}_{t} \\\\  &  + \\frac{a^{x} }{{a^{t} }^{2} - {a^{x} }^{2} - {a^{y} }^{2} - {a^{z} }^{2}} \\boldsymbol{e}_{x} \\\\  &  + \\frac{a^{y} }{{a^{t} }^{2} - {a^{x} }^{2} - {a^{y} }^{2} - {a^{z} }^{2}} \\boldsymbol{e}_{y} \\\\  &  + \\frac{a^{z} }{{a^{t} }^{2} - {a^{x} }^{2} - {a^{y} }^{2} - {a^{z} }^{2}} \\boldsymbol{e}_{z}  \\end{aligned}  \\end{equation*}"
+       "\\begin{equation*}\\mathbf{a}^{-1} =  \\begin{aligned}[t]  & \\frac{a^{t} }{{a^{t} }^{2} - {a^{x} }^{2} - {a^{y} }^{2} - {a^{z} }^{2}} \\boldsymbol{e}_{t} \\\\  &  + \\frac{a^{x} }{{a^{t} }^{2} - {a^{x} }^{2} - {a^{y} }^{2} - {a^{z} }^{2}} \\boldsymbol{e}_{x} \\\\  &  + \\frac{a^{y} }{{a^{t} }^{2} - {a^{x} }^{2} - {a^{y} }^{2} - {a^{z} }^{2}} \\boldsymbol{e}_{y} \\\\  &  + \\frac{a^{z} }{{a^{t} }^{2} - {a^{x} }^{2} - {a^{y} }^{2} - {a^{z} }^{2}} \\boldsymbol{e}_{z}  \\end{aligned} \\end{equation*}"
       ],
       "text/plain": [
        "\\mathbf{a}^{-1} =  a__t*e_t/(a__t**2 - a__x**2 - a__y**2 - a__z**2)\n",
@@ -150,7 +150,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} \\langle \\mathbf{M} \\rangle _1 \\langle \\mathbf{M} \\rangle _1 = {M^{t} }^{2} - {M^{x} }^{2} - {M^{y} }^{2} - {M^{z} }^{2} \\end{equation*}"
+       "\\begin{equation*}\\langle \\mathbf{M} \\rangle _1 \\langle \\mathbf{M} \\rangle _1 = {M^{t} }^{2} - {M^{x} }^{2} - {M^{y} }^{2} - {M^{z} }^{2}\\end{equation*}"
       ],
       "text/plain": [
        "\\langle \\mathbf{M} \\rangle _1 \\langle \\mathbf{M} \\rangle _1 = M__t**2 - M__x**2 - M__y**2 - M__z**2"
@@ -174,7 +174,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} \\langle \\mathbf{M} \\rangle _1 ^{-1} =  \\begin{aligned}[t]  & \\frac{M^{t} }{{M^{t} }^{2} - {M^{x} }^{2} - {M^{y} }^{2} - {M^{z} }^{2}} \\boldsymbol{e}_{t} \\\\  &  + \\frac{M^{x} }{{M^{t} }^{2} - {M^{x} }^{2} - {M^{y} }^{2} - {M^{z} }^{2}} \\boldsymbol{e}_{x} \\\\  &  + \\frac{M^{y} }{{M^{t} }^{2} - {M^{x} }^{2} - {M^{y} }^{2} - {M^{z} }^{2}} \\boldsymbol{e}_{y} \\\\  &  + \\frac{M^{z} }{{M^{t} }^{2} - {M^{x} }^{2} - {M^{y} }^{2} - {M^{z} }^{2}} \\boldsymbol{e}_{z}  \\end{aligned}  \\end{equation*}"
+       "\\begin{equation*}\\langle \\mathbf{M} \\rangle _1 ^{-1} =  \\begin{aligned}[t]  & \\frac{M^{t} }{{M^{t} }^{2} - {M^{x} }^{2} - {M^{y} }^{2} - {M^{z} }^{2}} \\boldsymbol{e}_{t} \\\\  &  + \\frac{M^{x} }{{M^{t} }^{2} - {M^{x} }^{2} - {M^{y} }^{2} - {M^{z} }^{2}} \\boldsymbol{e}_{x} \\\\  &  + \\frac{M^{y} }{{M^{t} }^{2} - {M^{x} }^{2} - {M^{y} }^{2} - {M^{z} }^{2}} \\boldsymbol{e}_{y} \\\\  &  + \\frac{M^{z} }{{M^{t} }^{2} - {M^{x} }^{2} - {M^{y} }^{2} - {M^{z} }^{2}} \\boldsymbol{e}_{z}  \\end{aligned} \\end{equation*}"
       ],
       "text/plain": [
        "\\langle \\mathbf{M} \\rangle _1 ^{-1} =  M__t*e_t/(M__t**2 - M__x**2 - M__y**2 - M__z**2)\n",
@@ -200,7 +200,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} \\langle \\mathbf{M} \\rangle _3 = M^{txy}  \\boldsymbol{e}_{t}\\wedge \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + M^{txz}  \\boldsymbol{e}_{t}\\wedge \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + M^{tyz}  \\boldsymbol{e}_{t}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} + M^{xyz}  \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} \\end{equation*}"
+       "\\begin{equation*}\\langle \\mathbf{M} \\rangle _3 = M^{txy}  \\boldsymbol{e}_{t}\\wedge \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + M^{txz}  \\boldsymbol{e}_{t}\\wedge \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + M^{tyz}  \\boldsymbol{e}_{t}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} + M^{xyz}  \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}\\end{equation*}"
       ],
       "text/plain": [
        "\\langle \\mathbf{M} \\rangle _3 =  M__txy*e_t^e_x^e_y + M__txz*e_t^e_x^e_z + M__tyz*e_t^e_y^e_z + M__xyz*e_x^e_y^e_z"
@@ -223,7 +223,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} \\langle \\mathbf{M} \\rangle _3 \\langle \\mathbf{M} \\rangle _3 = - {M^{txy} }^{2} - {M^{txz} }^{2} - {M^{tyz} }^{2} + {M^{xyz} }^{2} \\end{equation*}"
+       "\\begin{equation*}\\langle \\mathbf{M} \\rangle _3 \\langle \\mathbf{M} \\rangle _3 = - {M^{txy} }^{2} - {M^{txz} }^{2} - {M^{tyz} }^{2} + {M^{xyz} }^{2}\\end{equation*}"
       ],
       "text/plain": [
        "\\langle \\mathbf{M} \\rangle _3 \\langle \\mathbf{M} \\rangle _3 = -M__txy**2 - M__txz**2 - M__tyz**2 + M__xyz**2"
@@ -247,7 +247,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} \\langle \\mathbf{M} \\rangle _3^{-1} =  \\begin{aligned}[t]  & - \\frac{M^{txy} }{{M^{txy} }^{2} + {M^{txz} }^{2} + {M^{tyz} }^{2} - {M^{xyz} }^{2}} \\boldsymbol{e}_{t}\\wedge \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} \\\\  &  - \\frac{M^{txz} }{{M^{txy} }^{2} + {M^{txz} }^{2} + {M^{tyz} }^{2} - {M^{xyz} }^{2}} \\boldsymbol{e}_{t}\\wedge \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} \\\\  &  - \\frac{M^{tyz} }{{M^{txy} }^{2} + {M^{txz} }^{2} + {M^{tyz} }^{2} - {M^{xyz} }^{2}} \\boldsymbol{e}_{t}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} \\\\  &  - \\frac{M^{xyz} }{{M^{txy} }^{2} + {M^{txz} }^{2} + {M^{tyz} }^{2} - {M^{xyz} }^{2}} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}  \\end{aligned}  \\end{equation*}"
+       "\\begin{equation*}\\langle \\mathbf{M} \\rangle _3^{-1} =  \\begin{aligned}[t]  & - \\frac{M^{txy} }{{M^{txy} }^{2} + {M^{txz} }^{2} + {M^{tyz} }^{2} - {M^{xyz} }^{2}} \\boldsymbol{e}_{t}\\wedge \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} \\\\  &  - \\frac{M^{txz} }{{M^{txy} }^{2} + {M^{txz} }^{2} + {M^{tyz} }^{2} - {M^{xyz} }^{2}} \\boldsymbol{e}_{t}\\wedge \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} \\\\  &  - \\frac{M^{tyz} }{{M^{txy} }^{2} + {M^{txz} }^{2} + {M^{tyz} }^{2} - {M^{xyz} }^{2}} \\boldsymbol{e}_{t}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} \\\\  &  - \\frac{M^{xyz} }{{M^{txy} }^{2} + {M^{txz} }^{2} + {M^{tyz} }^{2} - {M^{xyz} }^{2}} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}  \\end{aligned} \\end{equation*}"
       ],
       "text/plain": [
        "\\langle \\mathbf{M} \\rangle _3^{-1} =  -M__txy*e_t^e_x^e_y/(M__txy**2 + M__txz**2 + M__tyz**2 - M__xyz**2)\n",

--- a/examples/ipython/tutorial_algebra.ipynb
+++ b/examples/ipython/tutorial_algebra.ipynb
@@ -172,7 +172,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} S = S \\end{equation*}"
+       "\\begin{equation*}S = S\\end{equation*}"
       ],
       "text/plain": [
        "S"
@@ -195,7 +195,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} V = V^{x} \\boldsymbol{e}_{x} + V^{y} \\boldsymbol{e}_{y} + V^{z} \\boldsymbol{e}_{z} \\end{equation*}"
+       "\\begin{equation*}V = V^{x} \\boldsymbol{e}_{x} + V^{y} \\boldsymbol{e}_{y} + V^{z} \\boldsymbol{e}_{z}\\end{equation*}"
       ],
       "text/plain": [
        "V__x*e_x + V__y*e_y + V__z*e_z"
@@ -218,7 +218,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} B = B^{xy} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + B^{xz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + B^{yz} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} \\end{equation*}"
+       "\\begin{equation*}B = B^{xy} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + B^{xz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + B^{yz} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}\\end{equation*}"
       ],
       "text/plain": [
        "B__xy*e_x^e_y + B__xz*e_x^e_z + B__yz*e_y^e_z"
@@ -241,7 +241,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} I = I^{xyz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} \\end{equation*}"
+       "\\begin{equation*}I = I^{xyz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}\\end{equation*}"
       ],
       "text/plain": [
        "I__xyz*e_x^e_y^e_z"
@@ -388,7 +388,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} B = B^{xy} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + B^{xz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + B^{yz} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} \\end{equation*}"
+       "\\begin{equation*}B = B^{xy} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + B^{xz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + B^{yz} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}\\end{equation*}"
       ],
       "text/plain": [
        "B__xy*e_x^e_y + B__xz*e_x^e_z + B__yz*e_y^e_z"
@@ -585,7 +585,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} M  + M^{x} \\boldsymbol{e}_{x} + M^{y} \\boldsymbol{e}_{y} + M^{z} \\boldsymbol{e}_{z} + M^{xy} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + M^{xz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + M^{yz} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} + M^{xyz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} \\end{equation*}"
+       "\\begin{equation*}M  + M^{x} \\boldsymbol{e}_{x} + M^{y} \\boldsymbol{e}_{y} + M^{z} \\boldsymbol{e}_{z} + M^{xy} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + M^{xz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + M^{yz} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} + M^{xyz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}\\end{equation*}"
       ],
       "text/plain": [
        "M + M__x*e_x + M__y*e_y + M__z*e_z + M__xy*e_x^e_y + M__xz*e_x^e_z + M__yz*e_y^e_z + M__xyz*e_x^e_y^e_z"
@@ -608,7 +608,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*}  \\begin{aligned}[t]  & M  \\\\  &  + M^{x} \\boldsymbol{e}_{x} + M^{y} \\boldsymbol{e}_{y} + M^{z} \\boldsymbol{e}_{z} \\\\  &  + M^{xy} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + M^{xz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + M^{yz} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} \\\\  &  + M^{xyz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}  \\end{aligned}  \\end{equation*}"
+       "\\begin{equation*} \\begin{aligned}[t]  & M  \\\\  &  + M^{x} \\boldsymbol{e}_{x} + M^{y} \\boldsymbol{e}_{y} + M^{z} \\boldsymbol{e}_{z} \\\\  &  + M^{xy} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + M^{xz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + M^{yz} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} \\\\  &  + M^{xyz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}  \\end{aligned} \\end{equation*}"
       ],
       "text/plain": [
        " M\n",
@@ -634,7 +634,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*}  \\begin{aligned}[t]  & M  \\\\  &  + M^{x} \\boldsymbol{e}_{x} \\\\  &  + M^{y} \\boldsymbol{e}_{y} \\\\  &  + M^{z} \\boldsymbol{e}_{z} \\\\  &  + M^{xy} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} \\\\  &  + M^{xz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} \\\\  &  + M^{yz} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} \\\\  &  + M^{xyz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}  \\end{aligned}  \\end{equation*}"
+       "\\begin{equation*} \\begin{aligned}[t]  & M  \\\\  &  + M^{x} \\boldsymbol{e}_{x} \\\\  &  + M^{y} \\boldsymbol{e}_{y} \\\\  &  + M^{z} \\boldsymbol{e}_{z} \\\\  &  + M^{xy} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} \\\\  &  + M^{xz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} \\\\  &  + M^{yz} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} \\\\  &  + M^{xyz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}  \\end{aligned} \\end{equation*}"
       ],
       "text/plain": [
        " M\n",

--- a/examples/ipython/verify_doc_python.ipynb
+++ b/examples/ipython/verify_doc_python.ipynb
@@ -97,7 +97,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} - \\left (\\boldsymbol{a}\\cdot \\boldsymbol{c}\\right )  \\boldsymbol{b} + \\left (\\boldsymbol{a}\\cdot \\boldsymbol{b}\\right )  \\boldsymbol{c} \\end{equation*}"
+       "\\begin{equation*}- \\left (\\boldsymbol{a}\\cdot \\boldsymbol{c}\\right )  \\boldsymbol{b} + \\left (\\boldsymbol{a}\\cdot \\boldsymbol{b}\\right )  \\boldsymbol{c}\\end{equation*}"
       ],
       "text/plain": [
        "-(a.c)*b + (a.b)*c"
@@ -120,7 +120,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} - \\left (\\boldsymbol{a}\\cdot \\boldsymbol{c}\\right )  \\boldsymbol{b} + \\left (\\boldsymbol{a}\\cdot \\boldsymbol{b}\\right )  \\boldsymbol{c} \\end{equation*}"
+       "\\begin{equation*}- \\left (\\boldsymbol{a}\\cdot \\boldsymbol{c}\\right )  \\boldsymbol{b} + \\left (\\boldsymbol{a}\\cdot \\boldsymbol{b}\\right )  \\boldsymbol{c}\\end{equation*}"
       ],
       "text/plain": [
        "-(a.c)*b + (a.b)*c"
@@ -143,7 +143,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} \\left (\\boldsymbol{a}\\cdot \\boldsymbol{d}\\right )  \\boldsymbol{b}\\wedge \\boldsymbol{c} - \\left (\\boldsymbol{a}\\cdot \\boldsymbol{c}\\right )  \\boldsymbol{b}\\wedge \\boldsymbol{d} + \\left (\\boldsymbol{a}\\cdot \\boldsymbol{b}\\right )  \\boldsymbol{c}\\wedge \\boldsymbol{d} \\end{equation*}"
+       "\\begin{equation*}\\left (\\boldsymbol{a}\\cdot \\boldsymbol{d}\\right )  \\boldsymbol{b}\\wedge \\boldsymbol{c} - \\left (\\boldsymbol{a}\\cdot \\boldsymbol{c}\\right )  \\boldsymbol{b}\\wedge \\boldsymbol{d} + \\left (\\boldsymbol{a}\\cdot \\boldsymbol{b}\\right )  \\boldsymbol{c}\\wedge \\boldsymbol{d}\\end{equation*}"
       ],
       "text/plain": [
        "(a.d)*b^c - (a.c)*b^d + (a.b)*c^d"
@@ -166,7 +166,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*}  0  \\end{equation*}"
+       "\\begin{equation*} 0 \\end{equation*}"
       ],
       "text/plain": [
        "0"
@@ -189,7 +189,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} 3 \\boldsymbol{a}\\wedge \\boldsymbol{b}\\wedge \\boldsymbol{c} \\end{equation*}"
+       "\\begin{equation*}3 \\boldsymbol{a}\\wedge \\boldsymbol{b}\\wedge \\boldsymbol{c}\\end{equation*}"
       ],
       "text/plain": [
        "3*a^b^c"
@@ -212,7 +212,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} 4 \\boldsymbol{a}\\wedge \\boldsymbol{b}\\wedge \\boldsymbol{c}\\wedge \\boldsymbol{d} \\end{equation*}"
+       "\\begin{equation*}4 \\boldsymbol{a}\\wedge \\boldsymbol{b}\\wedge \\boldsymbol{c}\\wedge \\boldsymbol{d}\\end{equation*}"
       ],
       "text/plain": [
        "4*a^b^c^d"
@@ -235,7 +235,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} - \\left (\\boldsymbol{a}\\cdot \\boldsymbol{c}\\right )  \\left (\\boldsymbol{b}\\cdot \\boldsymbol{d}\\right )  + \\left (\\boldsymbol{a}\\cdot \\boldsymbol{d}\\right )  \\left (\\boldsymbol{b}\\cdot \\boldsymbol{c}\\right )  \\end{equation*}"
+       "\\begin{equation*}- \\left (\\boldsymbol{a}\\cdot \\boldsymbol{c}\\right )  \\left (\\boldsymbol{b}\\cdot \\boldsymbol{d}\\right )  + \\left (\\boldsymbol{a}\\cdot \\boldsymbol{d}\\right )  \\left (\\boldsymbol{b}\\cdot \\boldsymbol{c}\\right ) \\end{equation*}"
       ],
       "text/plain": [
        "-(a.c)*(b.d) + (a.d)*(b.c)"
@@ -258,7 +258,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} - \\left (\\boldsymbol{a}\\cdot \\boldsymbol{c}\\right )  \\left (\\boldsymbol{b}\\cdot \\boldsymbol{d}\\right )  + \\left (\\boldsymbol{a}\\cdot \\boldsymbol{d}\\right )  \\left (\\boldsymbol{b}\\cdot \\boldsymbol{c}\\right )  \\end{equation*}"
+       "\\begin{equation*}- \\left (\\boldsymbol{a}\\cdot \\boldsymbol{c}\\right )  \\left (\\boldsymbol{b}\\cdot \\boldsymbol{d}\\right )  + \\left (\\boldsymbol{a}\\cdot \\boldsymbol{d}\\right )  \\left (\\boldsymbol{b}\\cdot \\boldsymbol{c}\\right ) \\end{equation*}"
       ],
       "text/plain": [
        "-(a.c)*(b.d) + (a.d)*(b.c)"
@@ -281,7 +281,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} - \\left (\\boldsymbol{b}\\cdot \\boldsymbol{d}\\right )  \\boldsymbol{a}\\wedge \\boldsymbol{c} + \\left (\\boldsymbol{b}\\cdot \\boldsymbol{c}\\right )  \\boldsymbol{a}\\wedge \\boldsymbol{d} + \\left (\\boldsymbol{a}\\cdot \\boldsymbol{d}\\right )  \\boldsymbol{b}\\wedge \\boldsymbol{c} - \\left (\\boldsymbol{a}\\cdot \\boldsymbol{c}\\right )  \\boldsymbol{b}\\wedge \\boldsymbol{d} \\end{equation*}"
+       "\\begin{equation*}- \\left (\\boldsymbol{b}\\cdot \\boldsymbol{d}\\right )  \\boldsymbol{a}\\wedge \\boldsymbol{c} + \\left (\\boldsymbol{b}\\cdot \\boldsymbol{c}\\right )  \\boldsymbol{a}\\wedge \\boldsymbol{d} + \\left (\\boldsymbol{a}\\cdot \\boldsymbol{d}\\right )  \\boldsymbol{b}\\wedge \\boldsymbol{c} - \\left (\\boldsymbol{a}\\cdot \\boldsymbol{c}\\right )  \\boldsymbol{b}\\wedge \\boldsymbol{d}\\end{equation*}"
       ],
       "text/plain": [
        "-(b.d)*a^c + (b.c)*a^d + (a.d)*b^c - (a.c)*b^d"
@@ -360,7 +360,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*}  \\boldsymbol{\\gamma }_{t} \\end{equation*}"
+       "\\begin{equation*} \\boldsymbol{\\gamma }_{t}\\end{equation*}"
       ],
       "text/plain": [
        "gamma_t"
@@ -383,7 +383,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*}  \\boldsymbol{\\gamma }_{x} \\end{equation*}"
+       "\\begin{equation*} \\boldsymbol{\\gamma }_{x}\\end{equation*}"
       ],
       "text/plain": [
        "gamma_x"
@@ -406,7 +406,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*}  \\boldsymbol{\\gamma }_{y} \\end{equation*}"
+       "\\begin{equation*} \\boldsymbol{\\gamma }_{y}\\end{equation*}"
       ],
       "text/plain": [
        "gamma_y"
@@ -429,7 +429,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*}  \\boldsymbol{\\gamma }_{z} \\end{equation*}"
+       "\\begin{equation*} \\boldsymbol{\\gamma }_{z}\\end{equation*}"
       ],
       "text/plain": [
        "gamma_z"
@@ -452,7 +452,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*}  \\boldsymbol{\\gamma }_{t}\\wedge \\boldsymbol{\\gamma }_{x}\\wedge \\boldsymbol{\\gamma }_{y}\\wedge \\boldsymbol{\\gamma }_{z} \\end{equation*}"
+       "\\begin{equation*} \\boldsymbol{\\gamma }_{t}\\wedge \\boldsymbol{\\gamma }_{x}\\wedge \\boldsymbol{\\gamma }_{y}\\wedge \\boldsymbol{\\gamma }_{z}\\end{equation*}"
       ],
       "text/plain": [
        "gamma_t^gamma_x^gamma_y^gamma_z"
@@ -531,7 +531,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} A = A^{t}  \\boldsymbol{\\gamma }_{t} + A^{x}  \\boldsymbol{\\gamma }_{x} + A^{y}  \\boldsymbol{\\gamma }_{y} + A^{z}  \\boldsymbol{\\gamma }_{z} \\end{equation*}"
+       "\\begin{equation*}A = A^{t}  \\boldsymbol{\\gamma }_{t} + A^{x}  \\boldsymbol{\\gamma }_{x} + A^{y}  \\boldsymbol{\\gamma }_{y} + A^{z}  \\boldsymbol{\\gamma }_{z}\\end{equation*}"
       ],
       "text/plain": [
        "A__t*gamma_t + A__x*gamma_x + A__y*gamma_y + A__z*gamma_z"
@@ -556,7 +556,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} psi = \\psi    + \\psi ^{tx}  \\boldsymbol{\\gamma }_{t}\\wedge \\boldsymbol{\\gamma }_{x} + \\psi ^{ty}  \\boldsymbol{\\gamma }_{t}\\wedge \\boldsymbol{\\gamma }_{y} + \\psi ^{tz}  \\boldsymbol{\\gamma }_{t}\\wedge \\boldsymbol{\\gamma }_{z} + \\psi ^{xy}  \\boldsymbol{\\gamma }_{x}\\wedge \\boldsymbol{\\gamma }_{y} + \\psi ^{xz}  \\boldsymbol{\\gamma }_{x}\\wedge \\boldsymbol{\\gamma }_{z} + \\psi ^{yz}  \\boldsymbol{\\gamma }_{y}\\wedge \\boldsymbol{\\gamma }_{z} + \\psi ^{txyz}  \\boldsymbol{\\gamma }_{t}\\wedge \\boldsymbol{\\gamma }_{x}\\wedge \\boldsymbol{\\gamma }_{y}\\wedge \\boldsymbol{\\gamma }_{z} \\end{equation*}"
+       "\\begin{equation*}psi = \\psi    + \\psi ^{tx}  \\boldsymbol{\\gamma }_{t}\\wedge \\boldsymbol{\\gamma }_{x} + \\psi ^{ty}  \\boldsymbol{\\gamma }_{t}\\wedge \\boldsymbol{\\gamma }_{y} + \\psi ^{tz}  \\boldsymbol{\\gamma }_{t}\\wedge \\boldsymbol{\\gamma }_{z} + \\psi ^{xy}  \\boldsymbol{\\gamma }_{x}\\wedge \\boldsymbol{\\gamma }_{y} + \\psi ^{xz}  \\boldsymbol{\\gamma }_{x}\\wedge \\boldsymbol{\\gamma }_{z} + \\psi ^{yz}  \\boldsymbol{\\gamma }_{y}\\wedge \\boldsymbol{\\gamma }_{z} + \\psi ^{txyz}  \\boldsymbol{\\gamma }_{t}\\wedge \\boldsymbol{\\gamma }_{x}\\wedge \\boldsymbol{\\gamma }_{y}\\wedge \\boldsymbol{\\gamma }_{z}\\end{equation*}"
       ],
       "text/plain": [
        "psi + psi__tx*gamma_t^gamma_x + psi__ty*gamma_t^gamma_y + psi__tz*gamma_t^gamma_z + psi__xy*gamma_x^gamma_y + psi__xz*gamma_x^gamma_z + psi__yz*gamma_y^gamma_z + psi__txyz*gamma_t^gamma_x^gamma_y^gamma_z"
@@ -581,7 +581,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} - \\boldsymbol{\\gamma }_{t}\\wedge \\boldsymbol{\\gamma }_{z} \\end{equation*}"
+       "\\begin{equation*}- \\boldsymbol{\\gamma }_{t}\\wedge \\boldsymbol{\\gamma }_{z}\\end{equation*}"
       ],
       "text/plain": [
        "-gamma_t^gamma_z"
@@ -613,7 +613,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} \\left ( - e A^{t}  \\psi   - e A^{x}  \\psi ^{tx}  - e A^{y}  \\psi ^{ty}  - e A^{z}  \\psi ^{tz}  - m \\psi   - \\partial_{y} \\psi ^{tx}  - \\partial_{z} \\psi ^{txyz}  + \\partial_{x} \\psi ^{ty}  + \\partial_{t} \\psi ^{xy} \\right ) \\boldsymbol{\\gamma }_{t} + \\left ( - e A^{t}  \\psi ^{tx}  - e A^{x}  \\psi   - e A^{y}  \\psi ^{xy}  - e A^{z}  \\psi ^{xz}  + m \\psi ^{tx}  + \\partial_{y} \\psi   - \\partial_{t} \\psi ^{ty}  - \\partial_{x} \\psi ^{xy}  + \\partial_{z} \\psi ^{yz} \\right ) \\boldsymbol{\\gamma }_{x} + \\left ( - e A^{t}  \\psi ^{ty}  + e A^{x}  \\psi ^{xy}  - e A^{y}  \\psi   - e A^{z}  \\psi ^{yz}  + m \\psi ^{ty}  - \\partial_{x} \\psi   + \\partial_{t} \\psi ^{tx}  - \\partial_{y} \\psi ^{xy}  - \\partial_{z} \\psi ^{xz} \\right ) \\boldsymbol{\\gamma }_{y} + \\left ( - e A^{t}  \\psi ^{tz}  + e A^{x}  \\psi ^{xz}  + e A^{y}  \\psi ^{yz}  - e A^{z}  \\psi   + m \\psi ^{tz}  + \\partial_{t} \\psi ^{txyz}  - \\partial_{z} \\psi ^{xy}  + \\partial_{y} \\psi ^{xz}  - \\partial_{x} \\psi ^{yz} \\right ) \\boldsymbol{\\gamma }_{z} + \\left ( - e A^{t}  \\psi ^{xy}  + e A^{x}  \\psi ^{ty}  - e A^{y}  \\psi ^{tx}  - e A^{z}  \\psi ^{txyz}  - m \\psi ^{xy}  - \\partial_{t} \\psi   + \\partial_{x} \\psi ^{tx}  + \\partial_{y} \\psi ^{ty}  + \\partial_{z} \\psi ^{tz} \\right ) \\boldsymbol{\\gamma }_{t}\\wedge \\boldsymbol{\\gamma }_{x}\\wedge \\boldsymbol{\\gamma }_{y} + \\left ( - e A^{t}  \\psi ^{xz}  + e A^{x}  \\psi ^{tz}  + e A^{y}  \\psi ^{txyz}  - e A^{z}  \\psi ^{tx}  - m \\psi ^{xz}  + \\partial_{x} \\psi ^{txyz}  + \\partial_{z} \\psi ^{ty}  - \\partial_{y} \\psi ^{tz}  - \\partial_{t} \\psi ^{yz} \\right ) \\boldsymbol{\\gamma }_{t}\\wedge \\boldsymbol{\\gamma }_{x}\\wedge \\boldsymbol{\\gamma }_{z} + \\left ( - e A^{t}  \\psi ^{yz}  - e A^{x}  \\psi ^{txyz}  + e A^{y}  \\psi ^{tz}  - e A^{z}  \\psi ^{ty}  - m \\psi ^{yz}  - \\partial_{z} \\psi ^{tx}  + \\partial_{y} \\psi ^{txyz}  + \\partial_{x} \\psi ^{tz}  + \\partial_{t} \\psi ^{xz} \\right ) \\boldsymbol{\\gamma }_{t}\\wedge \\boldsymbol{\\gamma }_{y}\\wedge \\boldsymbol{\\gamma }_{z} + \\left ( - e A^{t}  \\psi ^{txyz}  - e A^{x}  \\psi ^{yz}  + e A^{y}  \\psi ^{xz}  - e A^{z}  \\psi ^{xy}  + m \\psi ^{txyz}  + \\partial_{z} \\psi   - \\partial_{t} \\psi ^{tz}  - \\partial_{x} \\psi ^{xz}  - \\partial_{y} \\psi ^{yz} \\right ) \\boldsymbol{\\gamma }_{x}\\wedge \\boldsymbol{\\gamma }_{y}\\wedge \\boldsymbol{\\gamma }_{z} \\end{equation*}"
+       "\\begin{equation*}\\left ( - e A^{t}  \\psi   - e A^{x}  \\psi ^{tx}  - e A^{y}  \\psi ^{ty}  - e A^{z}  \\psi ^{tz}  - m \\psi   - \\partial_{y} \\psi ^{tx}  - \\partial_{z} \\psi ^{txyz}  + \\partial_{x} \\psi ^{ty}  + \\partial_{t} \\psi ^{xy} \\right ) \\boldsymbol{\\gamma }_{t} + \\left ( - e A^{t}  \\psi ^{tx}  - e A^{x}  \\psi   - e A^{y}  \\psi ^{xy}  - e A^{z}  \\psi ^{xz}  + m \\psi ^{tx}  + \\partial_{y} \\psi   - \\partial_{t} \\psi ^{ty}  - \\partial_{x} \\psi ^{xy}  + \\partial_{z} \\psi ^{yz} \\right ) \\boldsymbol{\\gamma }_{x} + \\left ( - e A^{t}  \\psi ^{ty}  + e A^{x}  \\psi ^{xy}  - e A^{y}  \\psi   - e A^{z}  \\psi ^{yz}  + m \\psi ^{ty}  - \\partial_{x} \\psi   + \\partial_{t} \\psi ^{tx}  - \\partial_{y} \\psi ^{xy}  - \\partial_{z} \\psi ^{xz} \\right ) \\boldsymbol{\\gamma }_{y} + \\left ( - e A^{t}  \\psi ^{tz}  + e A^{x}  \\psi ^{xz}  + e A^{y}  \\psi ^{yz}  - e A^{z}  \\psi   + m \\psi ^{tz}  + \\partial_{t} \\psi ^{txyz}  - \\partial_{z} \\psi ^{xy}  + \\partial_{y} \\psi ^{xz}  - \\partial_{x} \\psi ^{yz} \\right ) \\boldsymbol{\\gamma }_{z} + \\left ( - e A^{t}  \\psi ^{xy}  + e A^{x}  \\psi ^{ty}  - e A^{y}  \\psi ^{tx}  - e A^{z}  \\psi ^{txyz}  - m \\psi ^{xy}  - \\partial_{t} \\psi   + \\partial_{x} \\psi ^{tx}  + \\partial_{y} \\psi ^{ty}  + \\partial_{z} \\psi ^{tz} \\right ) \\boldsymbol{\\gamma }_{t}\\wedge \\boldsymbol{\\gamma }_{x}\\wedge \\boldsymbol{\\gamma }_{y} + \\left ( - e A^{t}  \\psi ^{xz}  + e A^{x}  \\psi ^{tz}  + e A^{y}  \\psi ^{txyz}  - e A^{z}  \\psi ^{tx}  - m \\psi ^{xz}  + \\partial_{x} \\psi ^{txyz}  + \\partial_{z} \\psi ^{ty}  - \\partial_{y} \\psi ^{tz}  - \\partial_{t} \\psi ^{yz} \\right ) \\boldsymbol{\\gamma }_{t}\\wedge \\boldsymbol{\\gamma }_{x}\\wedge \\boldsymbol{\\gamma }_{z} + \\left ( - e A^{t}  \\psi ^{yz}  - e A^{x}  \\psi ^{txyz}  + e A^{y}  \\psi ^{tz}  - e A^{z}  \\psi ^{ty}  - m \\psi ^{yz}  - \\partial_{z} \\psi ^{tx}  + \\partial_{y} \\psi ^{txyz}  + \\partial_{x} \\psi ^{tz}  + \\partial_{t} \\psi ^{xz} \\right ) \\boldsymbol{\\gamma }_{t}\\wedge \\boldsymbol{\\gamma }_{y}\\wedge \\boldsymbol{\\gamma }_{z} + \\left ( - e A^{t}  \\psi ^{txyz}  - e A^{x}  \\psi ^{yz}  + e A^{y}  \\psi ^{xz}  - e A^{z}  \\psi ^{xy}  + m \\psi ^{txyz}  + \\partial_{z} \\psi   - \\partial_{t} \\psi ^{tz}  - \\partial_{x} \\psi ^{xz}  - \\partial_{y} \\psi ^{yz} \\right ) \\boldsymbol{\\gamma }_{x}\\wedge \\boldsymbol{\\gamma }_{y}\\wedge \\boldsymbol{\\gamma }_{z}\\end{equation*}"
       ],
       "text/plain": [
        "(-e*A__t*psi - e*A__x*psi__tx - e*A__y*psi__ty - e*A__z*psi__tz - m*psi - D{y}psi__tx - D{z}psi__txyz + D{x}psi__ty + D{t}psi__xy)*gamma_t + (-e*A__t*psi__tx - e*A__x*psi - e*A__y*psi__xy - e*A__z*psi__xz + m*psi__tx + D{y}psi - D{t}psi__ty - D{x}psi__xy + D{z}psi__yz)*gamma_x + (-e*A__t*psi__ty + e*A__x*psi__xy - e*A__y*psi - e*A__z*psi__yz + m*psi__ty - D{x}psi + D{t}psi__tx - D{y}psi__xy - D{z}psi__xz)*gamma_y + (-e*A__t*psi__tz + e*A__x*psi__xz + e*A__y*psi__yz - e*A__z*psi + m*psi__tz + D{t}psi__txyz - D{z}psi__xy + D{y}psi__xz - D{x}psi__yz)*gamma_z + (-e*A__t*psi__xy + e*A__x*psi__ty - e*A__y*psi__tx - e*A__z*psi__txyz - m*psi__xy - D{t}psi + D{x}psi__tx + D{y}psi__ty + D{z}psi__tz)*gamma_t^gamma_x^gamma_y + (-e*A__t*psi__xz + e*A__x*psi__tz + e*A__y*psi__txyz - e*A__z*psi__tx - m*psi__xz + D{x}psi__txyz + D{z}psi__ty - D{y}psi__tz - D{t}psi__yz)*gamma_t^gamma_x^gamma_z + (-e*A__t*psi__yz - e*A__x*psi__txyz + e*A__y*psi__tz - e*A__z*psi__ty - m*psi__yz - D{z}psi__tx + D{y}psi__txyz + D{x}psi__tz + D{t}psi__xz)*gamma_t^gamma_y^gamma_z + (-e*A__t*psi__txyz - e*A__x*psi__yz + e*A__y*psi__xz - e*A__z*psi__xy + m*psi__txyz + D{z}psi - D{t}psi__tz - D{x}psi__xz - D{y}psi__yz)*gamma_x^gamma_y^gamma_z"
@@ -637,7 +637,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*}  \\begin{aligned}[t]  & \\left ( - e A^{t}  \\psi   - e A^{x}  \\psi ^{tx}  - e A^{y}  \\psi ^{ty}  - e A^{z}  \\psi ^{tz}  - m \\psi   - \\partial_{y} \\psi ^{tx}  - \\partial_{z} \\psi ^{txyz}  + \\partial_{x} \\psi ^{ty}  + \\partial_{t} \\psi ^{xy} \\right ) \\boldsymbol{\\gamma }_{t} + \\left ( - e A^{t}  \\psi ^{tx}  - e A^{x}  \\psi   - e A^{y}  \\psi ^{xy}  - e A^{z}  \\psi ^{xz}  + m \\psi ^{tx}  + \\partial_{y} \\psi   - \\partial_{t} \\psi ^{ty}  - \\partial_{x} \\psi ^{xy}  + \\partial_{z} \\psi ^{yz} \\right ) \\boldsymbol{\\gamma }_{x} + \\left ( - e A^{t}  \\psi ^{ty}  + e A^{x}  \\psi ^{xy}  - e A^{y}  \\psi   - e A^{z}  \\psi ^{yz}  + m \\psi ^{ty}  - \\partial_{x} \\psi   + \\partial_{t} \\psi ^{tx}  - \\partial_{y} \\psi ^{xy}  - \\partial_{z} \\psi ^{xz} \\right ) \\boldsymbol{\\gamma }_{y} + \\left ( - e A^{t}  \\psi ^{tz}  + e A^{x}  \\psi ^{xz}  + e A^{y}  \\psi ^{yz}  - e A^{z}  \\psi   + m \\psi ^{tz}  + \\partial_{t} \\psi ^{txyz}  - \\partial_{z} \\psi ^{xy}  + \\partial_{y} \\psi ^{xz}  - \\partial_{x} \\psi ^{yz} \\right ) \\boldsymbol{\\gamma }_{z} \\\\  &  + \\left ( - e A^{t}  \\psi ^{xy}  + e A^{x}  \\psi ^{ty}  - e A^{y}  \\psi ^{tx}  - e A^{z}  \\psi ^{txyz}  - m \\psi ^{xy}  - \\partial_{t} \\psi   + \\partial_{x} \\psi ^{tx}  + \\partial_{y} \\psi ^{ty}  + \\partial_{z} \\psi ^{tz} \\right ) \\boldsymbol{\\gamma }_{t}\\wedge \\boldsymbol{\\gamma }_{x}\\wedge \\boldsymbol{\\gamma }_{y} + \\left ( - e A^{t}  \\psi ^{xz}  + e A^{x}  \\psi ^{tz}  + e A^{y}  \\psi ^{txyz}  - e A^{z}  \\psi ^{tx}  - m \\psi ^{xz}  + \\partial_{x} \\psi ^{txyz}  + \\partial_{z} \\psi ^{ty}  - \\partial_{y} \\psi ^{tz}  - \\partial_{t} \\psi ^{yz} \\right ) \\boldsymbol{\\gamma }_{t}\\wedge \\boldsymbol{\\gamma }_{x}\\wedge \\boldsymbol{\\gamma }_{z} + \\left ( - e A^{t}  \\psi ^{yz}  - e A^{x}  \\psi ^{txyz}  + e A^{y}  \\psi ^{tz}  - e A^{z}  \\psi ^{ty}  - m \\psi ^{yz}  - \\partial_{z} \\psi ^{tx}  + \\partial_{y} \\psi ^{txyz}  + \\partial_{x} \\psi ^{tz}  + \\partial_{t} \\psi ^{xz} \\right ) \\boldsymbol{\\gamma }_{t}\\wedge \\boldsymbol{\\gamma }_{y}\\wedge \\boldsymbol{\\gamma }_{z} + \\left ( - e A^{t}  \\psi ^{txyz}  - e A^{x}  \\psi ^{yz}  + e A^{y}  \\psi ^{xz}  - e A^{z}  \\psi ^{xy}  + m \\psi ^{txyz}  + \\partial_{z} \\psi   - \\partial_{t} \\psi ^{tz}  - \\partial_{x} \\psi ^{xz}  - \\partial_{y} \\psi ^{yz} \\right ) \\boldsymbol{\\gamma }_{x}\\wedge \\boldsymbol{\\gamma }_{y}\\wedge \\boldsymbol{\\gamma }_{z}  \\end{aligned}  \\end{equation*}"
+       "\\begin{equation*} \\begin{aligned}[t]  & \\left ( - e A^{t}  \\psi   - e A^{x}  \\psi ^{tx}  - e A^{y}  \\psi ^{ty}  - e A^{z}  \\psi ^{tz}  - m \\psi   - \\partial_{y} \\psi ^{tx}  - \\partial_{z} \\psi ^{txyz}  + \\partial_{x} \\psi ^{ty}  + \\partial_{t} \\psi ^{xy} \\right ) \\boldsymbol{\\gamma }_{t} + \\left ( - e A^{t}  \\psi ^{tx}  - e A^{x}  \\psi   - e A^{y}  \\psi ^{xy}  - e A^{z}  \\psi ^{xz}  + m \\psi ^{tx}  + \\partial_{y} \\psi   - \\partial_{t} \\psi ^{ty}  - \\partial_{x} \\psi ^{xy}  + \\partial_{z} \\psi ^{yz} \\right ) \\boldsymbol{\\gamma }_{x} + \\left ( - e A^{t}  \\psi ^{ty}  + e A^{x}  \\psi ^{xy}  - e A^{y}  \\psi   - e A^{z}  \\psi ^{yz}  + m \\psi ^{ty}  - \\partial_{x} \\psi   + \\partial_{t} \\psi ^{tx}  - \\partial_{y} \\psi ^{xy}  - \\partial_{z} \\psi ^{xz} \\right ) \\boldsymbol{\\gamma }_{y} + \\left ( - e A^{t}  \\psi ^{tz}  + e A^{x}  \\psi ^{xz}  + e A^{y}  \\psi ^{yz}  - e A^{z}  \\psi   + m \\psi ^{tz}  + \\partial_{t} \\psi ^{txyz}  - \\partial_{z} \\psi ^{xy}  + \\partial_{y} \\psi ^{xz}  - \\partial_{x} \\psi ^{yz} \\right ) \\boldsymbol{\\gamma }_{z} \\\\  &  + \\left ( - e A^{t}  \\psi ^{xy}  + e A^{x}  \\psi ^{ty}  - e A^{y}  \\psi ^{tx}  - e A^{z}  \\psi ^{txyz}  - m \\psi ^{xy}  - \\partial_{t} \\psi   + \\partial_{x} \\psi ^{tx}  + \\partial_{y} \\psi ^{ty}  + \\partial_{z} \\psi ^{tz} \\right ) \\boldsymbol{\\gamma }_{t}\\wedge \\boldsymbol{\\gamma }_{x}\\wedge \\boldsymbol{\\gamma }_{y} + \\left ( - e A^{t}  \\psi ^{xz}  + e A^{x}  \\psi ^{tz}  + e A^{y}  \\psi ^{txyz}  - e A^{z}  \\psi ^{tx}  - m \\psi ^{xz}  + \\partial_{x} \\psi ^{txyz}  + \\partial_{z} \\psi ^{ty}  - \\partial_{y} \\psi ^{tz}  - \\partial_{t} \\psi ^{yz} \\right ) \\boldsymbol{\\gamma }_{t}\\wedge \\boldsymbol{\\gamma }_{x}\\wedge \\boldsymbol{\\gamma }_{z} + \\left ( - e A^{t}  \\psi ^{yz}  - e A^{x}  \\psi ^{txyz}  + e A^{y}  \\psi ^{tz}  - e A^{z}  \\psi ^{ty}  - m \\psi ^{yz}  - \\partial_{z} \\psi ^{tx}  + \\partial_{y} \\psi ^{txyz}  + \\partial_{x} \\psi ^{tz}  + \\partial_{t} \\psi ^{xz} \\right ) \\boldsymbol{\\gamma }_{t}\\wedge \\boldsymbol{\\gamma }_{y}\\wedge \\boldsymbol{\\gamma }_{z} + \\left ( - e A^{t}  \\psi ^{txyz}  - e A^{x}  \\psi ^{yz}  + e A^{y}  \\psi ^{xz}  - e A^{z}  \\psi ^{xy}  + m \\psi ^{txyz}  + \\partial_{z} \\psi   - \\partial_{t} \\psi ^{tz}  - \\partial_{x} \\psi ^{xz}  - \\partial_{y} \\psi ^{yz} \\right ) \\boldsymbol{\\gamma }_{x}\\wedge \\boldsymbol{\\gamma }_{y}\\wedge \\boldsymbol{\\gamma }_{z}  \\end{aligned} \\end{equation*}"
       ],
       "text/plain": [
        " (-e*A__t*psi - e*A__x*psi__tx - e*A__y*psi__ty - e*A__z*psi__tz - m*psi - D{y}psi__tx - D{z}psi__txyz + D{x}psi__ty + D{t}psi__xy)*gamma_t + (-e*A__t*psi__tx - e*A__x*psi - e*A__y*psi__xy - e*A__z*psi__xz + m*psi__tx + D{y}psi - D{t}psi__ty - D{x}psi__xy + D{z}psi__yz)*gamma_x + (-e*A__t*psi__ty + e*A__x*psi__xy - e*A__y*psi - e*A__z*psi__yz + m*psi__ty - D{x}psi + D{t}psi__tx - D{y}psi__xy - D{z}psi__xz)*gamma_y + (-e*A__t*psi__tz + e*A__x*psi__xz + e*A__y*psi__yz - e*A__z*psi + m*psi__tz + D{t}psi__txyz - D{z}psi__xy + D{y}psi__xz - D{x}psi__yz)*gamma_z\n",
@@ -661,7 +661,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*} \\left ( - e A^{t}  \\psi   - e A^{x}  \\psi ^{tx}  - e A^{y}  \\psi ^{ty}  - e A^{z}  \\psi ^{tz}  - m \\psi   - \\partial_{y} \\psi ^{tx}  - \\partial_{z} \\psi ^{txyz}  + \\partial_{x} \\psi ^{ty}  + \\partial_{t} \\psi ^{xy} \\right ) \\boldsymbol{\\gamma }_{t} + \\left ( - e A^{t}  \\psi ^{tx}  - e A^{x}  \\psi   - e A^{y}  \\psi ^{xy}  - e A^{z}  \\psi ^{xz}  + m \\psi ^{tx}  + \\partial_{y} \\psi   - \\partial_{t} \\psi ^{ty}  - \\partial_{x} \\psi ^{xy}  + \\partial_{z} \\psi ^{yz} \\right ) \\boldsymbol{\\gamma }_{x} + \\left ( - e A^{t}  \\psi ^{ty}  + e A^{x}  \\psi ^{xy}  - e A^{y}  \\psi   - e A^{z}  \\psi ^{yz}  + m \\psi ^{ty}  - \\partial_{x} \\psi   + \\partial_{t} \\psi ^{tx}  - \\partial_{y} \\psi ^{xy}  - \\partial_{z} \\psi ^{xz} \\right ) \\boldsymbol{\\gamma }_{y} + \\left ( - e A^{t}  \\psi ^{tz}  + e A^{x}  \\psi ^{xz}  + e A^{y}  \\psi ^{yz}  - e A^{z}  \\psi   + m \\psi ^{tz}  + \\partial_{t} \\psi ^{txyz}  - \\partial_{z} \\psi ^{xy}  + \\partial_{y} \\psi ^{xz}  - \\partial_{x} \\psi ^{yz} \\right ) \\boldsymbol{\\gamma }_{z} + \\left ( - e A^{t}  \\psi ^{xy}  + e A^{x}  \\psi ^{ty}  - e A^{y}  \\psi ^{tx}  - e A^{z}  \\psi ^{txyz}  - m \\psi ^{xy}  - \\partial_{t} \\psi   + \\partial_{x} \\psi ^{tx}  + \\partial_{y} \\psi ^{ty}  + \\partial_{z} \\psi ^{tz} \\right ) \\boldsymbol{\\gamma }_{t}\\wedge \\boldsymbol{\\gamma }_{x}\\wedge \\boldsymbol{\\gamma }_{y} + \\left ( - e A^{t}  \\psi ^{xz}  + e A^{x}  \\psi ^{tz}  + e A^{y}  \\psi ^{txyz}  - e A^{z}  \\psi ^{tx}  - m \\psi ^{xz}  + \\partial_{x} \\psi ^{txyz}  + \\partial_{z} \\psi ^{ty}  - \\partial_{y} \\psi ^{tz}  - \\partial_{t} \\psi ^{yz} \\right ) \\boldsymbol{\\gamma }_{t}\\wedge \\boldsymbol{\\gamma }_{x}\\wedge \\boldsymbol{\\gamma }_{z} + \\left ( - e A^{t}  \\psi ^{yz}  - e A^{x}  \\psi ^{txyz}  + e A^{y}  \\psi ^{tz}  - e A^{z}  \\psi ^{ty}  - m \\psi ^{yz}  - \\partial_{z} \\psi ^{tx}  + \\partial_{y} \\psi ^{txyz}  + \\partial_{x} \\psi ^{tz}  + \\partial_{t} \\psi ^{xz} \\right ) \\boldsymbol{\\gamma }_{t}\\wedge \\boldsymbol{\\gamma }_{y}\\wedge \\boldsymbol{\\gamma }_{z} + \\left ( - e A^{t}  \\psi ^{txyz}  - e A^{x}  \\psi ^{yz}  + e A^{y}  \\psi ^{xz}  - e A^{z}  \\psi ^{xy}  + m \\psi ^{txyz}  + \\partial_{z} \\psi   - \\partial_{t} \\psi ^{tz}  - \\partial_{x} \\psi ^{xz}  - \\partial_{y} \\psi ^{yz} \\right ) \\boldsymbol{\\gamma }_{x}\\wedge \\boldsymbol{\\gamma }_{y}\\wedge \\boldsymbol{\\gamma }_{z} \\end{equation*}"
+       "\\begin{equation*}\\left ( - e A^{t}  \\psi   - e A^{x}  \\psi ^{tx}  - e A^{y}  \\psi ^{ty}  - e A^{z}  \\psi ^{tz}  - m \\psi   - \\partial_{y} \\psi ^{tx}  - \\partial_{z} \\psi ^{txyz}  + \\partial_{x} \\psi ^{ty}  + \\partial_{t} \\psi ^{xy} \\right ) \\boldsymbol{\\gamma }_{t} + \\left ( - e A^{t}  \\psi ^{tx}  - e A^{x}  \\psi   - e A^{y}  \\psi ^{xy}  - e A^{z}  \\psi ^{xz}  + m \\psi ^{tx}  + \\partial_{y} \\psi   - \\partial_{t} \\psi ^{ty}  - \\partial_{x} \\psi ^{xy}  + \\partial_{z} \\psi ^{yz} \\right ) \\boldsymbol{\\gamma }_{x} + \\left ( - e A^{t}  \\psi ^{ty}  + e A^{x}  \\psi ^{xy}  - e A^{y}  \\psi   - e A^{z}  \\psi ^{yz}  + m \\psi ^{ty}  - \\partial_{x} \\psi   + \\partial_{t} \\psi ^{tx}  - \\partial_{y} \\psi ^{xy}  - \\partial_{z} \\psi ^{xz} \\right ) \\boldsymbol{\\gamma }_{y} + \\left ( - e A^{t}  \\psi ^{tz}  + e A^{x}  \\psi ^{xz}  + e A^{y}  \\psi ^{yz}  - e A^{z}  \\psi   + m \\psi ^{tz}  + \\partial_{t} \\psi ^{txyz}  - \\partial_{z} \\psi ^{xy}  + \\partial_{y} \\psi ^{xz}  - \\partial_{x} \\psi ^{yz} \\right ) \\boldsymbol{\\gamma }_{z} + \\left ( - e A^{t}  \\psi ^{xy}  + e A^{x}  \\psi ^{ty}  - e A^{y}  \\psi ^{tx}  - e A^{z}  \\psi ^{txyz}  - m \\psi ^{xy}  - \\partial_{t} \\psi   + \\partial_{x} \\psi ^{tx}  + \\partial_{y} \\psi ^{ty}  + \\partial_{z} \\psi ^{tz} \\right ) \\boldsymbol{\\gamma }_{t}\\wedge \\boldsymbol{\\gamma }_{x}\\wedge \\boldsymbol{\\gamma }_{y} + \\left ( - e A^{t}  \\psi ^{xz}  + e A^{x}  \\psi ^{tz}  + e A^{y}  \\psi ^{txyz}  - e A^{z}  \\psi ^{tx}  - m \\psi ^{xz}  + \\partial_{x} \\psi ^{txyz}  + \\partial_{z} \\psi ^{ty}  - \\partial_{y} \\psi ^{tz}  - \\partial_{t} \\psi ^{yz} \\right ) \\boldsymbol{\\gamma }_{t}\\wedge \\boldsymbol{\\gamma }_{x}\\wedge \\boldsymbol{\\gamma }_{z} + \\left ( - e A^{t}  \\psi ^{yz}  - e A^{x}  \\psi ^{txyz}  + e A^{y}  \\psi ^{tz}  - e A^{z}  \\psi ^{ty}  - m \\psi ^{yz}  - \\partial_{z} \\psi ^{tx}  + \\partial_{y} \\psi ^{txyz}  + \\partial_{x} \\psi ^{tz}  + \\partial_{t} \\psi ^{xz} \\right ) \\boldsymbol{\\gamma }_{t}\\wedge \\boldsymbol{\\gamma }_{y}\\wedge \\boldsymbol{\\gamma }_{z} + \\left ( - e A^{t}  \\psi ^{txyz}  - e A^{x}  \\psi ^{yz}  + e A^{y}  \\psi ^{xz}  - e A^{z}  \\psi ^{xy}  + m \\psi ^{txyz}  + \\partial_{z} \\psi   - \\partial_{t} \\psi ^{tz}  - \\partial_{x} \\psi ^{xz}  - \\partial_{y} \\psi ^{yz} \\right ) \\boldsymbol{\\gamma }_{x}\\wedge \\boldsymbol{\\gamma }_{y}\\wedge \\boldsymbol{\\gamma }_{z}\\end{equation*}"
       ],
       "text/plain": [
        "(-e*A__t*psi - e*A__x*psi__tx - e*A__y*psi__ty - e*A__z*psi__tz - m*psi - D{y}psi__tx - D{z}psi__txyz + D{x}psi__ty + D{t}psi__xy)*gamma_t + (-e*A__t*psi__tx - e*A__x*psi - e*A__y*psi__xy - e*A__z*psi__xz + m*psi__tx + D{y}psi - D{t}psi__ty - D{x}psi__xy + D{z}psi__yz)*gamma_x + (-e*A__t*psi__ty + e*A__x*psi__xy - e*A__y*psi - e*A__z*psi__yz + m*psi__ty - D{x}psi + D{t}psi__tx - D{y}psi__xy - D{z}psi__xz)*gamma_y + (-e*A__t*psi__tz + e*A__x*psi__xz + e*A__y*psi__yz - e*A__z*psi + m*psi__tz + D{t}psi__txyz - D{z}psi__xy + D{y}psi__xz - D{x}psi__yz)*gamma_z + (-e*A__t*psi__xy + e*A__x*psi__ty - e*A__y*psi__tx - e*A__z*psi__txyz - m*psi__xy - D{t}psi + D{x}psi__tx + D{y}psi__ty + D{z}psi__tz)*gamma_t^gamma_x^gamma_y + (-e*A__t*psi__xz + e*A__x*psi__tz + e*A__y*psi__txyz - e*A__z*psi__tx - m*psi__xz + D{x}psi__txyz + D{z}psi__ty - D{y}psi__tz - D{t}psi__yz)*gamma_t^gamma_x^gamma_z + (-e*A__t*psi__yz - e*A__x*psi__txyz + e*A__y*psi__tz - e*A__z*psi__ty - m*psi__yz - D{z}psi__tx + D{y}psi__txyz + D{x}psi__tz + D{t}psi__xz)*gamma_t^gamma_y^gamma_z + (-e*A__t*psi__txyz - e*A__x*psi__yz + e*A__y*psi__xz - e*A__z*psi__xy + m*psi__txyz + D{z}psi - D{t}psi__tz - D{x}psi__xz - D{y}psi__yz)*gamma_x^gamma_y^gamma_z"
@@ -685,7 +685,7 @@
     {
      "data": {
       "text/latex": [
-       "\\begin{equation*}  \\begin{aligned}[t]  & \\left ( - e A^{t}  \\psi   - e A^{x}  \\psi ^{tx}  - e A^{y}  \\psi ^{ty}  - e A^{z}  \\psi ^{tz}  - m \\psi   - \\partial_{y} \\psi ^{tx}  - \\partial_{z} \\psi ^{txyz}  + \\partial_{x} \\psi ^{ty}  + \\partial_{t} \\psi ^{xy} \\right ) \\boldsymbol{\\gamma }_{t} + \\left ( - e A^{t}  \\psi ^{tx}  - e A^{x}  \\psi   - e A^{y}  \\psi ^{xy}  - e A^{z}  \\psi ^{xz}  + m \\psi ^{tx}  + \\partial_{y} \\psi   - \\partial_{t} \\psi ^{ty}  - \\partial_{x} \\psi ^{xy}  + \\partial_{z} \\psi ^{yz} \\right ) \\boldsymbol{\\gamma }_{x} + \\left ( - e A^{t}  \\psi ^{ty}  + e A^{x}  \\psi ^{xy}  - e A^{y}  \\psi   - e A^{z}  \\psi ^{yz}  + m \\psi ^{ty}  - \\partial_{x} \\psi   + \\partial_{t} \\psi ^{tx}  - \\partial_{y} \\psi ^{xy}  - \\partial_{z} \\psi ^{xz} \\right ) \\boldsymbol{\\gamma }_{y} + \\left ( - e A^{t}  \\psi ^{tz}  + e A^{x}  \\psi ^{xz}  + e A^{y}  \\psi ^{yz}  - e A^{z}  \\psi   + m \\psi ^{tz}  + \\partial_{t} \\psi ^{txyz}  - \\partial_{z} \\psi ^{xy}  + \\partial_{y} \\psi ^{xz}  - \\partial_{x} \\psi ^{yz} \\right ) \\boldsymbol{\\gamma }_{z} \\\\  &  + \\left ( - e A^{t}  \\psi ^{xy}  + e A^{x}  \\psi ^{ty}  - e A^{y}  \\psi ^{tx}  - e A^{z}  \\psi ^{txyz}  - m \\psi ^{xy}  - \\partial_{t} \\psi   + \\partial_{x} \\psi ^{tx}  + \\partial_{y} \\psi ^{ty}  + \\partial_{z} \\psi ^{tz} \\right ) \\boldsymbol{\\gamma }_{t}\\wedge \\boldsymbol{\\gamma }_{x}\\wedge \\boldsymbol{\\gamma }_{y} + \\left ( - e A^{t}  \\psi ^{xz}  + e A^{x}  \\psi ^{tz}  + e A^{y}  \\psi ^{txyz}  - e A^{z}  \\psi ^{tx}  - m \\psi ^{xz}  + \\partial_{x} \\psi ^{txyz}  + \\partial_{z} \\psi ^{ty}  - \\partial_{y} \\psi ^{tz}  - \\partial_{t} \\psi ^{yz} \\right ) \\boldsymbol{\\gamma }_{t}\\wedge \\boldsymbol{\\gamma }_{x}\\wedge \\boldsymbol{\\gamma }_{z} + \\left ( - e A^{t}  \\psi ^{yz}  - e A^{x}  \\psi ^{txyz}  + e A^{y}  \\psi ^{tz}  - e A^{z}  \\psi ^{ty}  - m \\psi ^{yz}  - \\partial_{z} \\psi ^{tx}  + \\partial_{y} \\psi ^{txyz}  + \\partial_{x} \\psi ^{tz}  + \\partial_{t} \\psi ^{xz} \\right ) \\boldsymbol{\\gamma }_{t}\\wedge \\boldsymbol{\\gamma }_{y}\\wedge \\boldsymbol{\\gamma }_{z} + \\left ( - e A^{t}  \\psi ^{txyz}  - e A^{x}  \\psi ^{yz}  + e A^{y}  \\psi ^{xz}  - e A^{z}  \\psi ^{xy}  + m \\psi ^{txyz}  + \\partial_{z} \\psi   - \\partial_{t} \\psi ^{tz}  - \\partial_{x} \\psi ^{xz}  - \\partial_{y} \\psi ^{yz} \\right ) \\boldsymbol{\\gamma }_{x}\\wedge \\boldsymbol{\\gamma }_{y}\\wedge \\boldsymbol{\\gamma }_{z}  \\end{aligned}  \\end{equation*}"
+       "\\begin{equation*} \\begin{aligned}[t]  & \\left ( - e A^{t}  \\psi   - e A^{x}  \\psi ^{tx}  - e A^{y}  \\psi ^{ty}  - e A^{z}  \\psi ^{tz}  - m \\psi   - \\partial_{y} \\psi ^{tx}  - \\partial_{z} \\psi ^{txyz}  + \\partial_{x} \\psi ^{ty}  + \\partial_{t} \\psi ^{xy} \\right ) \\boldsymbol{\\gamma }_{t} + \\left ( - e A^{t}  \\psi ^{tx}  - e A^{x}  \\psi   - e A^{y}  \\psi ^{xy}  - e A^{z}  \\psi ^{xz}  + m \\psi ^{tx}  + \\partial_{y} \\psi   - \\partial_{t} \\psi ^{ty}  - \\partial_{x} \\psi ^{xy}  + \\partial_{z} \\psi ^{yz} \\right ) \\boldsymbol{\\gamma }_{x} + \\left ( - e A^{t}  \\psi ^{ty}  + e A^{x}  \\psi ^{xy}  - e A^{y}  \\psi   - e A^{z}  \\psi ^{yz}  + m \\psi ^{ty}  - \\partial_{x} \\psi   + \\partial_{t} \\psi ^{tx}  - \\partial_{y} \\psi ^{xy}  - \\partial_{z} \\psi ^{xz} \\right ) \\boldsymbol{\\gamma }_{y} + \\left ( - e A^{t}  \\psi ^{tz}  + e A^{x}  \\psi ^{xz}  + e A^{y}  \\psi ^{yz}  - e A^{z}  \\psi   + m \\psi ^{tz}  + \\partial_{t} \\psi ^{txyz}  - \\partial_{z} \\psi ^{xy}  + \\partial_{y} \\psi ^{xz}  - \\partial_{x} \\psi ^{yz} \\right ) \\boldsymbol{\\gamma }_{z} \\\\  &  + \\left ( - e A^{t}  \\psi ^{xy}  + e A^{x}  \\psi ^{ty}  - e A^{y}  \\psi ^{tx}  - e A^{z}  \\psi ^{txyz}  - m \\psi ^{xy}  - \\partial_{t} \\psi   + \\partial_{x} \\psi ^{tx}  + \\partial_{y} \\psi ^{ty}  + \\partial_{z} \\psi ^{tz} \\right ) \\boldsymbol{\\gamma }_{t}\\wedge \\boldsymbol{\\gamma }_{x}\\wedge \\boldsymbol{\\gamma }_{y} + \\left ( - e A^{t}  \\psi ^{xz}  + e A^{x}  \\psi ^{tz}  + e A^{y}  \\psi ^{txyz}  - e A^{z}  \\psi ^{tx}  - m \\psi ^{xz}  + \\partial_{x} \\psi ^{txyz}  + \\partial_{z} \\psi ^{ty}  - \\partial_{y} \\psi ^{tz}  - \\partial_{t} \\psi ^{yz} \\right ) \\boldsymbol{\\gamma }_{t}\\wedge \\boldsymbol{\\gamma }_{x}\\wedge \\boldsymbol{\\gamma }_{z} + \\left ( - e A^{t}  \\psi ^{yz}  - e A^{x}  \\psi ^{txyz}  + e A^{y}  \\psi ^{tz}  - e A^{z}  \\psi ^{ty}  - m \\psi ^{yz}  - \\partial_{z} \\psi ^{tx}  + \\partial_{y} \\psi ^{txyz}  + \\partial_{x} \\psi ^{tz}  + \\partial_{t} \\psi ^{xz} \\right ) \\boldsymbol{\\gamma }_{t}\\wedge \\boldsymbol{\\gamma }_{y}\\wedge \\boldsymbol{\\gamma }_{z} + \\left ( - e A^{t}  \\psi ^{txyz}  - e A^{x}  \\psi ^{yz}  + e A^{y}  \\psi ^{xz}  - e A^{z}  \\psi ^{xy}  + m \\psi ^{txyz}  + \\partial_{z} \\psi   - \\partial_{t} \\psi ^{tz}  - \\partial_{x} \\psi ^{xz}  - \\partial_{y} \\psi ^{yz} \\right ) \\boldsymbol{\\gamma }_{x}\\wedge \\boldsymbol{\\gamma }_{y}\\wedge \\boldsymbol{\\gamma }_{z}  \\end{aligned} \\end{equation*}"
       ],
       "text/plain": [
        " (-e*A__t*psi - e*A__x*psi__tx - e*A__y*psi__ty - e*A__z*psi__tz - m*psi - D{y}psi__tx - D{z}psi__txyz + D{x}psi__ty + D{t}psi__xy)*gamma_t + (-e*A__t*psi__tx - e*A__x*psi - e*A__y*psi__xy - e*A__z*psi__xz + m*psi__tx + D{y}psi - D{t}psi__ty - D{x}psi__xy + D{z}psi__yz)*gamma_x + (-e*A__t*psi__ty + e*A__x*psi__xy - e*A__y*psi - e*A__z*psi__yz + m*psi__ty - D{x}psi + D{t}psi__tx - D{y}psi__xy - D{z}psi__xz)*gamma_y + (-e*A__t*psi__tz + e*A__x*psi__xz + e*A__y*psi__yz - e*A__z*psi + m*psi__tz + D{t}psi__txyz - D{z}psi__xy + D{y}psi__xz - D{x}psi__yz)*gamma_z\n",

--- a/galgebra/printer.py
+++ b/galgebra/printer.py
@@ -379,9 +379,7 @@ class GaPrintable:
         return GaPrinter().doprint(self)
 
     def _repr_latex_(self):
-        # IPython expects latex in text mode, so we wrap in an environment
-        latex_str = GaLatexPrinter().doprint(self)
-        return r'\begin{equation*} ' + latex_str + r' \end{equation*}'
+        return GaLatexPrinter(dict(mode="equation*")).doprint(self)
 
 
 # Change sympy builtins to use our printer by default.


### PR DESCRIPTION
Annoyingly this results in a massive diff removing spaces in every file.

Making this change will eventually allow us to remove `GaPrintable._repr_latex_` entirely, in favor of using sympy builtins.
LaTeX does not care about the presence or absence of these spaces.

(note: this PR summary has typo fixes not present in the commit message!)