### PR TITLE
Use our printer as the default in jupyter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,11 +72,11 @@ jobs:
       USE_SYMENGINE: 1
     docker:
       - image: circleci/python:3.7
-  # sympy 1.3 does not claim to support Python 3.8
-  "python-3.7-sympy-1.3":
+  # sympy 1.4 does not claim to support Python 3.8
+  "python-3.7-sympy-1.4":
     <<: *defaults
     environment:
-      PIP_EXTRA_INSTALLATION: sympy==1.3
+      PIP_EXTRA_INSTALLATION: sympy==1.4
     docker:
       - image: circleci/python:3.7
 
@@ -141,7 +141,7 @@ workflows:
           requires: ["flake8"]
       - "python-3.7-symengine":
           requires: ["flake8"]
-      - "python-3.7-sympy-1.3":
+      - "python-3.7-sympy-1.4":
           requires: ["flake8"]
       - "python-3.8-sympy-master":
           requires: ["flake8"]

--- a/examples/ipython/Smith Sphere.ipynb
+++ b/examples/ipython/Smith Sphere.ipynb
@@ -184,7 +184,7 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle 1$"
+       "\\begin{equation*}1\\end{equation*}"
       ],
       "text/plain": [
        "1"

--- a/examples/ipython/dop.ipynb
+++ b/examples/ipython/dop.ipynb
@@ -21,7 +21,7 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle \\left[\\begin{matrix}1 & 0 & 0\\\\0 & 1 & 0\\\\0 & 0 & 1\\end{matrix}\\right]$"
+       "\\begin{equation*}\\left[\\begin{array}{ccc}1 & 0 & 0\\\\0 & 1 & 0\\\\0 & 0 & 1\\end{array}\\right]\\end{equation*}"
       ],
       "text/plain": [
        "Matrix([\n",
@@ -217,7 +217,7 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle \\left[\\begin{matrix}1 & 0 & 0\\\\0 & r^{2} & 0\\\\0 & 0 & r^{2} \\sin^{2}{\\left(\\theta \\right)}\\end{matrix}\\right]$"
+       "\\begin{equation*}\\left[\\begin{array}{ccc}1 & 0 & 0\\\\0 & r^{2} & 0\\\\0 & 0 & r^{2} {\\sin{\\left (\\theta  \\right )}}^{2}\\end{array}\\right]\\end{equation*}"
       ],
       "text/plain": [
        "Matrix([\n",
@@ -464,7 +464,7 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle \\sqrt{\\left(\\operatorname{F^{\\phi}}\\right)^{2}{\\left(r,\\theta,\\phi \\right)} + \\left(\\operatorname{F^{r}}\\right)^{2}{\\left(r,\\theta,\\phi \\right)} + \\left(\\operatorname{F^{\\theta}}\\right)^{2}{\\left(r,\\theta,\\phi \\right)}}$"
+       "\\begin{equation*}\\sqrt{{F^{\\phi } }^{2} + {F^{r} }^{2} + {F^{\\theta } }^{2}}\\end{equation*}"
       ],
       "text/plain": [
        "   __________________________________________________\n",

--- a/examples/ipython/gr_metrics.ipynb
+++ b/examples/ipython/gr_metrics.ipynb
@@ -86,7 +86,7 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle \\left[ \\mathbf{e_{t}}, \\  \\mathbf{e_{x}}, \\  \\mathbf{e_{y}}, \\  \\mathbf{e_{z}}\\right]$"
+       "\\begin{equation*}\\left[ \\boldsymbol{e}_{t}, \\  \\boldsymbol{e}_{x}, \\  \\boldsymbol{e}_{y}, \\  \\boldsymbol{e}_{z}\\right]\\end{equation*}"
       ],
       "text/plain": [
        "[eₜ, eₓ, e_y, e_z]"
@@ -110,7 +110,7 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle \\left[\\begin{matrix}1 & 0 & 0 & 0\\\\0 & -1 & 0 & 0\\\\0 & 0 & -1 & 0\\\\0 & 0 & 0 & -1\\end{matrix}\\right]$"
+       "\\begin{equation*}\\left[\\begin{array}{cccc}1 & 0 & 0 & 0\\\\0 & -1 & 0 & 0\\\\0 & 0 & -1 & 0\\\\0 & 0 & 0 & -1\\end{array}\\right]\\end{equation*}"
       ],
       "text/plain": [
        "Matrix([\n",
@@ -137,7 +137,7 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle \\left[ 1, \\  1, \\  1, \\  1\\right]$"
+       "\\begin{equation*}\\left[ 1, \\  1, \\  1, \\  1\\right]\\end{equation*}"
       ],
       "text/plain": [
        "[1, 1, 1, 1]"
@@ -160,7 +160,7 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle \\left[\\begin{matrix}1 & 0 & 0 & 0\\\\0 & 1 & 0 & 0\\\\0 & 0 & 1 & 0\\\\0 & 0 & 0 & 1\\end{matrix}\\right]$"
+       "\\begin{equation*}\\left[\\begin{array}{cccc}1 & 0 & 0 & 0\\\\0 & 1 & 0 & 0\\\\0 & 0 & 1 & 0\\\\0 & 0 & 0 & 1\\end{array}\\right]\\end{equation*}"
       ],
       "text/plain": [
        "⎡1  0  0  0⎤\n",
@@ -212,7 +212,7 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle \\left[ \\mathbf{e_{u}}, \\  \\mathbf{e_{x}}, \\  \\mathbf{e_{y}}, \\  \\mathbf{e_{z}}\\right]$"
+       "\\begin{equation*}\\left[ \\boldsymbol{e}_{u}, \\  \\boldsymbol{e}_{x}, \\  \\boldsymbol{e}_{y}, \\  \\boldsymbol{e}_{z}\\right]\\end{equation*}"
       ],
       "text/plain": [
        "[eᵤ, eₓ, e_y, e_z]"
@@ -235,7 +235,7 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle \\left[\\begin{matrix}0 & 0 & - e^{- z} & 0\\\\0 & \\frac{u^{2} e^{4 z}}{2} & 0 & 0\\\\- e^{- z} & 0 & 12 e^{- 2 z} & u e^{- z}\\\\0 & 0 & u e^{- z} & \\frac{u^{2}}{2}\\end{matrix}\\right]$"
+       "\\begin{equation*}\\left[\\begin{array}{cccc}0 & 0 & - e^{- z} & 0\\\\0 & \\frac{u^{2} e^{4 z}}{2} & 0 & 0\\\\- e^{- z} & 0 & 12 e^{- 2 z} & u e^{- z}\\\\0 & 0 & u e^{- z} & \\frac{u^{2}}{2}\\end{array}\\right]\\end{equation*}"
       ],
       "text/plain": [
        "Matrix([\n",
@@ -262,7 +262,7 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle - \\frac{u^{4} e^{2 z}}{4}$"
+       "\\begin{equation*}- \\frac{u^{4} e^{2 z}}{4}\\end{equation*}"
       ],
       "text/plain": [
        "  4  2⋅z \n",
@@ -288,7 +288,7 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle \\left[ - \\frac{u^{4} e^{2 z}}{4}, \\  - \\frac{u^{4} e^{2 z}}{4}, \\  - \\frac{u^{4} e^{2 z}}{4}, \\  - \\frac{u^{4} e^{2 z}}{4}\\right]$"
+       "\\begin{equation*}\\left[ - \\frac{u^{4} e^{2 z}}{4}, \\  - \\frac{u^{4} e^{2 z}}{4}, \\  - \\frac{u^{4} e^{2 z}}{4}, \\  - \\frac{u^{4} e^{2 z}}{4}\\right]\\end{equation*}"
       ],
       "text/plain": [
        "⎡  4  2⋅z     4  2⋅z     4  2⋅z     4  2⋅z ⎤\n",
@@ -314,7 +314,7 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle \\left[\\begin{matrix}1 & 0 & 0 & 0\\\\0 & 1 & 0 & 0\\\\0 & 0 & 1 & 0\\\\0 & 0 & 0 & 1\\end{matrix}\\right]$"
+       "\\begin{equation*}\\left[\\begin{array}{cccc}1 & 0 & 0 & 0\\\\0 & 1 & 0 & 0\\\\0 & 0 & 1 & 0\\\\0 & 0 & 0 & 1\\end{array}\\right]\\end{equation*}"
       ],
       "text/plain": [
        "⎡1  0  0  0⎤\n",
@@ -343,7 +343,7 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle \\left[\\begin{matrix}\\left[\\begin{matrix}0 & 0 & 0 & 0\\\\0 & - \\frac{u e^{4 z}}{2} & 0 & 0\\\\0 & 0 & 0 & 0\\\\0 & 0 & 0 & - \\frac{u}{2}\\end{matrix}\\right] & \\left[\\begin{matrix}0 & \\frac{u e^{4 z}}{2} & 0 & 0\\\\\\frac{u e^{4 z}}{2} & 0 & 0 & u^{2} e^{4 z}\\\\0 & 0 & 0 & 0\\\\0 & u^{2} e^{4 z} & 0 & 0\\end{matrix}\\right] & \\left[\\begin{matrix}0 & 0 & 0 & e^{- z}\\\\0 & 0 & 0 & 0\\\\0 & 0 & 0 & - 12 e^{- 2 z}\\\\e^{- z} & 0 & - 12 e^{- 2 z} & - u e^{- z}\\end{matrix}\\right] & \\left[\\begin{matrix}0 & 0 & 0 & \\frac{u}{2}\\\\0 & - u^{2} e^{4 z} & 0 & 0\\\\0 & 0 & 12 e^{- 2 z} & 0\\\\\\frac{u}{2} & 0 & 0 & 0\\end{matrix}\\right]\\end{matrix}\\right]$"
+       "\\begin{equation*}\\left[\\begin{array}\\left[\\begin{array}0 & 0 & 0 & 0\\\\0 & - \\frac{u e^{4 z}}{2} & 0 & 0\\\\0 & 0 & 0 & 0\\\\0 & 0 & 0 & - \\frac{u}{2}\\end{array}\\right] & \\left[\\begin{array}0 & \\frac{u e^{4 z}}{2} & 0 & 0\\\\\\frac{u e^{4 z}}{2} & 0 & 0 & u^{2} e^{4 z}\\\\0 & 0 & 0 & 0\\\\0 & u^{2} e^{4 z} & 0 & 0\\end{array}\\right] & \\left[\\begin{array}0 & 0 & 0 & e^{- z}\\\\0 & 0 & 0 & 0\\\\0 & 0 & 0 & - 12 e^{- 2 z}\\\\e^{- z} & 0 & - 12 e^{- 2 z} & - u e^{- z}\\end{array}\\right] & \\left[\\begin{array}0 & 0 & 0 & \\frac{u}{2}\\\\0 & - u^{2} e^{4 z} & 0 & 0\\\\0 & 0 & 12 e^{- 2 z} & 0\\\\\\frac{u}{2} & 0 & 0 & 0\\end{array}\\right]\\end{array}\\right]\\end{equation*}"
       ],
       "text/plain": [
        "⎡                       ⎡           4⋅z             ⎤                         \n",
@@ -383,7 +383,7 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle \\left[\\begin{matrix}\\left[\\begin{matrix}0 & 0 & 0 & 0\\\\0 & 3 u e^{4 z} & 0 & 0\\\\0 & 0 & \\frac{24 e^{- 2 z}}{u} & 12 e^{- z}\\\\0 & 0 & 12 e^{- z} & 6 u\\end{matrix}\\right] & \\left[\\begin{matrix}0 & \\frac{1}{u} & 0 & 0\\\\\\frac{1}{u} & 0 & 0 & 2\\\\0 & 0 & 0 & 0\\\\0 & 2 & 0 & 0\\end{matrix}\\right] & \\left[\\begin{matrix}0 & 0 & 0 & 0\\\\0 & \\frac{u e^{5 z}}{2} & 0 & 0\\\\0 & 0 & 0 & 0\\\\0 & 0 & 0 & \\frac{u e^{z}}{2}\\end{matrix}\\right] & \\left[\\begin{matrix}0 & 0 & 0 & \\frac{1}{u}\\\\0 & - 3 e^{4 z} & 0 & 0\\\\0 & 0 & \\frac{24 e^{- 2 z}}{u^{2}} & 0\\\\\\frac{1}{u} & 0 & 0 & -1\\end{matrix}\\right]\\end{matrix}\\right]$"
+       "\\begin{equation*}\\left[\\begin{array}\\left[\\begin{array}0 & 0 & 0 & 0\\\\0 & 3 u e^{4 z} & 0 & 0\\\\0 & 0 & \\frac{24 e^{- 2 z}}{u} & 12 e^{- z}\\\\0 & 0 & 12 e^{- z} & 6 u\\end{array}\\right] & \\left[\\begin{array}0 & \\frac{1}{u} & 0 & 0\\\\\\frac{1}{u} & 0 & 0 & 2\\\\0 & 0 & 0 & 0\\\\0 & 2 & 0 & 0\\end{array}\\right] & \\left[\\begin{array}0 & 0 & 0 & 0\\\\0 & \\frac{u e^{5 z}}{2} & 0 & 0\\\\0 & 0 & 0 & 0\\\\0 & 0 & 0 & \\frac{u e^{z}}{2}\\end{array}\\right] & \\left[\\begin{array}0 & 0 & 0 & \\frac{1}{u}\\\\0 & - 3 e^{4 z} & 0 & 0\\\\0 & 0 & \\frac{24 e^{- 2 z}}{u^{2}} & 0\\\\\\frac{1}{u} & 0 & 0 & -1\\end{array}\\right]\\end{array}\\right]\\end{equation*}"
       ],
       "text/plain": [
        "⎡                                                                     ⎡       \n",
@@ -461,7 +461,7 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle \\left[ \\mathbf{e_{t}}, \\  \\mathbf{e_{r}}, \\  \\mathbf{e_{\\theta}}, \\  \\mathbf{e_{\\phi}}\\right]$"
+       "\\begin{equation*}\\left[ \\boldsymbol{e}_{t}, \\  \\boldsymbol{e}_{r}, \\  \\boldsymbol{e}_{\\theta }, \\  \\boldsymbol{e}_{\\phi }\\right]\\end{equation*}"
       ],
       "text/plain": [
        "[eₜ, eᵣ, eₜₕₑₜₐ, eᵩ]"
@@ -485,7 +485,7 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle \\left[\\begin{matrix}- \\frac{2 G M}{c^{2} r} + 1 & 0 & 0 & 0\\\\0 & - \\frac{1}{- \\frac{2 G M}{c^{2} r} + 1} & 0 & 0\\\\0 & 0 & - r^{2} & 0\\\\0 & 0 & 0 & - r^{2} \\sin^{2}{\\left(\\theta \\right)}\\end{matrix}\\right]$"
+       "\\begin{equation*}\\left[\\begin{array}{cccc}- \\frac{2 G M}{c^{2} r} + 1 & 0 & 0 & 0\\\\0 & - \\frac{1}{- \\frac{2 G M}{c^{2} r} + 1} & 0 & 0\\\\0 & 0 & - r^{2} & 0\\\\0 & 0 & 0 & - r^{2} {\\sin{\\left (\\theta  \\right )}}^{2}\\end{array}\\right]\\end{equation*}"
       ],
       "text/plain": [
        "Matrix([\n",
@@ -512,7 +512,7 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle - r^{4} \\sin^{2}{\\left(\\theta \\right)}$"
+       "\\begin{equation*}- r^{4} {\\sin{\\left (\\theta  \\right )}}^{2}\\end{equation*}"
       ],
       "text/plain": [
        "  4    2   \n",
@@ -536,7 +536,7 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle \\left[ 1, \\  - \\frac{\\frac{2 G M}{c^{2} r} - 1}{- \\frac{2 G M}{c^{2} r} + 1}, \\  1, \\  1\\right]$"
+       "\\begin{equation*}\\left[ 1, \\  - \\frac{\\frac{2 G M}{c^{2} r} - 1}{- \\frac{2 G M}{c^{2} r} + 1}, \\  1, \\  1\\right]\\end{equation*}"
       ],
       "text/plain": [
        "⎡    ⎛2⋅G⋅M    ⎞       ⎤\n",
@@ -567,7 +567,7 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle \\left[\\begin{matrix}1 & 0 & 0 & 0\\\\0 & 1 & 0 & 0\\\\0 & 0 & 1 & 0\\\\0 & 0 & 0 & 1\\end{matrix}\\right]$"
+       "\\begin{equation*}\\left[\\begin{array}{cccc}1 & 0 & 0 & 0\\\\0 & 1 & 0 & 0\\\\0 & 0 & 1 & 0\\\\0 & 0 & 0 & 1\\end{array}\\right]\\end{equation*}"
       ],
       "text/plain": [
        "⎡1  0  0  0⎤\n",
@@ -596,7 +596,7 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle \\left[\\begin{matrix}\\left[\\begin{matrix}0 & \\frac{G M}{c^{2} r^{2}} & 0 & 0\\\\\\frac{G M}{c^{2} r^{2}} & 0 & 0 & 0\\\\0 & 0 & 0 & 0\\\\0 & 0 & 0 & 0\\end{matrix}\\right] & \\left[\\begin{matrix}- \\frac{G M}{c^{2} r^{2}} & 0 & 0 & 0\\\\0 & \\frac{G M c^{2}}{4 G^{2} M^{2} + c^{2} r \\left(- 4 G M + c^{2} r\\right)} & 0 & 0\\\\0 & 0 & r & 0\\\\0 & 0 & 0 & r \\sin^{2}{\\left(\\theta \\right)}\\end{matrix}\\right] & \\left[\\begin{matrix}0 & 0 & 0 & 0\\\\0 & 0 & - r & 0\\\\0 & - r & 0 & 0\\\\0 & 0 & 0 & \\frac{r^{2} \\sin{\\left(2 \\theta \\right)}}{2}\\end{matrix}\\right] & \\left[\\begin{matrix}0 & 0 & 0 & 0\\\\0 & 0 & 0 & - r \\sin^{2}{\\left(\\theta \\right)}\\\\0 & 0 & 0 & - \\frac{r^{2} \\sin{\\left(2 \\theta \\right)}}{2}\\\\0 & - r \\sin^{2}{\\left(\\theta \\right)} & - \\frac{r^{2} \\sin{\\left(2 \\theta \\right)}}{2} & 0\\end{matrix}\\right]\\end{matrix}\\right]$"
+       "\\begin{equation*}\\left[\\begin{array}\\left[\\begin{array}0 & \\frac{G M}{c^{2} r^{2}} & 0 & 0\\\\\\frac{G M}{c^{2} r^{2}} & 0 & 0 & 0\\\\0 & 0 & 0 & 0\\\\0 & 0 & 0 & 0\\end{array}\\right] & \\left[\\begin{array}- \\frac{G M}{c^{2} r^{2}} & 0 & 0 & 0\\\\0 & \\frac{G M c^{2}}{4 G^{2} M^{2} + c^{2} r \\left(- 4 G M + c^{2} r\\right)} & 0 & 0\\\\0 & 0 & r & 0\\\\0 & 0 & 0 & r {\\sin{\\left (\\theta  \\right )}}^{2}\\end{array}\\right] & \\left[\\begin{array}0 & 0 & 0 & 0\\\\0 & 0 & - r & 0\\\\0 & - r & 0 & 0\\\\0 & 0 & 0 & \\frac{r^{2} \\sin{\\left (2 \\theta  \\right )}}{2}\\end{array}\\right] & \\left[\\begin{array}0 & 0 & 0 & 0\\\\0 & 0 & 0 & - r {\\sin{\\left (\\theta  \\right )}}^{2}\\\\0 & 0 & 0 & - \\frac{r^{2} \\sin{\\left (2 \\theta  \\right )}}{2}\\\\0 & - r {\\sin{\\left (\\theta  \\right )}}^{2} & - \\frac{r^{2} \\sin{\\left (2 \\theta  \\right )}}{2} & 0\\end{array}\\right]\\end{array}\\right]\\end{equation*}"
       ],
       "text/plain": [
        "⎡                      ⎡-G⋅M                                               ⎤  \n",
@@ -638,7 +638,7 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle \\left[\\begin{matrix}\\left[\\begin{matrix}0 & \\frac{G M}{r \\left(- 2 G M + c^{2} r\\right)} & 0 & 0\\\\\\frac{G M}{r \\left(- 2 G M + c^{2} r\\right)} & 0 & 0 & 0\\\\0 & 0 & 0 & 0\\\\0 & 0 & 0 & 0\\end{matrix}\\right] & \\left[\\begin{matrix}\\frac{G M \\left(- 2 G M + c^{2} r\\right)}{c^{4} r^{3}} & 0 & 0 & 0\\\\0 & \\frac{G M}{r \\left(2 G M - c^{2} r\\right)} & 0 & 0\\\\0 & 0 & \\frac{2 G M}{c^{2}} - r & 0\\\\0 & 0 & 0 & \\frac{\\left(2 G M - c^{2} r\\right) \\sin^{2}{\\left(\\theta \\right)}}{c^{2}}\\end{matrix}\\right] & \\left[\\begin{matrix}0 & 0 & 0 & 0\\\\0 & 0 & \\frac{1}{r} & 0\\\\0 & \\frac{1}{r} & 0 & 0\\\\0 & 0 & 0 & - \\frac{\\sin{\\left(2 \\theta \\right)}}{2}\\end{matrix}\\right] & \\left[\\begin{matrix}0 & 0 & 0 & 0\\\\0 & 0 & 0 & \\frac{1}{r}\\\\0 & 0 & 0 & \\frac{1}{\\tan{\\left(\\theta \\right)}}\\\\0 & \\frac{1}{r} & \\frac{1}{\\tan{\\left(\\theta \\right)}} & 0\\end{matrix}\\right]\\end{matrix}\\right]$"
+       "\\begin{equation*}\\left[\\begin{array}\\left[\\begin{array}0 & \\frac{G M}{r \\left(- 2 G M + c^{2} r\\right)} & 0 & 0\\\\\\frac{G M}{r \\left(- 2 G M + c^{2} r\\right)} & 0 & 0 & 0\\\\0 & 0 & 0 & 0\\\\0 & 0 & 0 & 0\\end{array}\\right] & \\left[\\begin{array}\\frac{G M \\left(- 2 G M + c^{2} r\\right)}{c^{4} r^{3}} & 0 & 0 & 0\\\\0 & \\frac{G M}{r \\left(2 G M - c^{2} r\\right)} & 0 & 0\\\\0 & 0 & \\frac{2 G M}{c^{2}} - r & 0\\\\0 & 0 & 0 & \\frac{\\left(2 G M - c^{2} r\\right) {\\sin{\\left (\\theta  \\right )}}^{2}}{c^{2}}\\end{array}\\right] & \\left[\\begin{array}0 & 0 & 0 & 0\\\\0 & 0 & \\frac{1}{r} & 0\\\\0 & \\frac{1}{r} & 0 & 0\\\\0 & 0 & 0 & - \\frac{\\sin{\\left (2 \\theta  \\right )}}{2}\\end{array}\\right] & \\left[\\begin{array}0 & 0 & 0 & 0\\\\0 & 0 & 0 & \\frac{1}{r}\\\\0 & 0 & 0 & \\frac{1}{\\tan{\\left (\\theta  \\right )}}\\\\0 & \\frac{1}{r} & \\frac{1}{\\tan{\\left (\\theta  \\right )}} & 0\\end{array}\\right]\\end{array}\\right]\\end{equation*}"
       ],
       "text/plain": [
        "⎡                                              ⎡    ⎛          2  ⎞           \n",
@@ -715,13 +715,6 @@
    "source": [
     "show_christoffel_symbols(schwarzschild)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/examples/ipython/gsym-printing.ipynb
+++ b/examples/ipython/gsym-printing.ipynb
@@ -220,7 +220,7 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle - \\left|{f}\\right|$"
+       "\\begin{equation*}- \\det\\left ( f\\right )\\end{equation*}"
       ],
       "text/plain": [
        "-│f│"
@@ -232,7 +232,7 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle - \\left|{g}\\right|$"
+       "\\begin{equation*}- \\det\\left ( g\\right )\\end{equation*}"
       ],
       "text/plain": [
        "-│g│"
@@ -244,7 +244,7 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle - \\left|{f{\\left(u,v \\right)}}\\right|$"
+       "\\begin{equation*}- \\det\\left ( f \\right )\\end{equation*}"
       ],
       "text/plain": [
        "-│f(u, v)│"
@@ -256,7 +256,7 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle - \\left|{g{\\left(u,v \\right)}}\\right|$"
+       "\\begin{equation*}- \\det\\left ( g \\right )\\end{equation*}"
       ],
       "text/plain": [
        "-│g(u, v)│"

--- a/examples/ipython/printing-galgebra.ipynb
+++ b/examples/ipython/printing-galgebra.ipynb
@@ -166,7 +166,7 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle \\mathbf{e}_{1}\\wedge \\mathbf{e}_{2}\\wedge \\mathbf{e}_{3}\\wedge \\mathbf{e}\\wedge \\mathbf{e_{0}}$"
+       "$\\displaystyle \\mathbf{e_{1}}\\wedge \\mathbf{e_{2}}\\wedge \\mathbf{e_{3}}\\wedge \\mathbf{e}\\wedge \\mathbf{e_{0}}$"
       ],
       "text/plain": [
        "e_1^e_2^e_3^e^e_{0}"
@@ -205,7 +205,7 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle \\left( \\left[ \\mathbf{e}_{1}, \\  \\mathbf{e}_{2}, \\  \\mathbf{e}_{3}\\right], \\  \\left[\\begin{matrix}\\left (\\mathbf{e}_{1}\\cdot \\mathbf{e}_{1}\\right )  & \\left (\\mathbf{e}_{1}\\cdot \\mathbf{e}_{2}\\right )  & \\left (\\mathbf{e}_{1}\\cdot \\mathbf{e}_{3}\\right ) \\\\\\left (\\mathbf{e}_{1}\\cdot \\mathbf{e}_{2}\\right )  & \\left (\\mathbf{e}_{2}\\cdot \\mathbf{e}_{2}\\right )  & \\left (\\mathbf{e}_{2}\\cdot \\mathbf{e}_{3}\\right ) \\\\\\left (\\mathbf{e}_{1}\\cdot \\mathbf{e}_{3}\\right )  & \\left (\\mathbf{e}_{2}\\cdot \\mathbf{e}_{3}\\right )  & \\left (\\mathbf{e}_{3}\\cdot \\mathbf{e}_{3}\\right ) \\end{matrix}\\right]\\right)$"
+       "$\\displaystyle \\left( \\left[ \\mathbf{e_{1}}, \\  \\mathbf{e_{2}}, \\  \\mathbf{e_{3}}\\right], \\  \\left[\\begin{matrix}\\left (\\mathbf{e_{1}}\\cdot \\mathbf{e_{1}}\\right )  & \\left (\\mathbf{e_{1}}\\cdot \\mathbf{e_{2}}\\right )  & \\left (\\mathbf{e_{1}}\\cdot \\mathbf{e_{3}}\\right ) \\\\\\left (\\mathbf{e_{1}}\\cdot \\mathbf{e_{2}}\\right )  & \\left (\\mathbf{e_{2}}\\cdot \\mathbf{e_{2}}\\right )  & \\left (\\mathbf{e_{2}}\\cdot \\mathbf{e_{3}}\\right ) \\\\\\left (\\mathbf{e_{1}}\\cdot \\mathbf{e_{3}}\\right )  & \\left (\\mathbf{e_{2}}\\cdot \\mathbf{e_{3}}\\right )  & \\left (\\mathbf{e_{3}}\\cdot \\mathbf{e_{3}}\\right ) \\end{matrix}\\right]\\right)$"
       ],
       "text/plain": [
        "⎛              ⎡(e₁⋅e₁)  (e₁⋅e₂)  (e₁⋅e₃)⎤⎞\n",
@@ -233,7 +233,7 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle \\left( \\left( 1,\\right), \\  \\left( \\mathbf{e}_{1}, \\  \\mathbf{e}_{2}, \\  \\mathbf{e}_{3}\\right), \\  \\left( \\mathbf{e}_{12}, \\  \\mathbf{e}_{13}, \\  \\mathbf{e}_{23}\\right), \\  \\left( \\mathbf{e}_{123},\\right)\\right)$"
+       "$\\displaystyle \\left( \\left( 1\\right), \\  \\left( \\mathbf{e_{1}}, \\  \\mathbf{e_{2}}, \\  \\mathbf{e_{3}}\\right), \\  \\left( \\mathbf{e_{12}}, \\  \\mathbf{e_{13}}, \\  \\mathbf{e_{23}}\\right), \\  \\left( \\mathbf{e_{123}}\\right)\\right)$"
       ],
       "text/plain": [
        "((1,), (e₁, e₂, e₃), (e₁₂, e₁₃, e₂₃), (e₁₂₃,))"
@@ -384,7 +384,7 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle \\left( \\left( 1,\\right), \\  \\left( \\mathbf{e}_{x}, \\  \\mathbf{e}_{y}, \\  \\mathbf{e}_{z}\\right), \\  \\left( \\mathbf{e}_{x}\\wedge \\mathbf{e}_{y}, \\  \\mathbf{e}_{x}\\wedge \\mathbf{e}_{z}, \\  \\mathbf{e}_{y}\\wedge \\mathbf{e}_{z}\\right), \\  \\left( \\mathbf{e}_{x}\\wedge \\mathbf{e}_{y}\\wedge \\mathbf{e}_{z},\\right)\\right)$"
+       "\\begin{equation*}\\left( \\left( 1\\right), \\  \\left( \\boldsymbol{e}_{x}, \\  \\boldsymbol{e}_{y}, \\  \\boldsymbol{e}_{z}\\right), \\  \\left( \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}, \\  \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z}, \\  \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}\\right), \\  \\left( \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}\\right)\\right)\\end{equation*}"
       ],
       "text/plain": [
        "((1,), (eₓ, e_y, e_z), (eₓ^e_y, eₓ^e_z, e_y^e_z), (eₓ^e_y^e_z,))"
@@ -427,7 +427,7 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle \\left(  \\mathbf{e}_{u}, \\   \\mathbf{e}_{x}, \\   \\mathbf{e}_{y}, \\   \\mathbf{e}_{z}\\right)$"
+       "\\begin{equation*}\\left(  \\mathbf{e}_{u}, \\   \\mathbf{e}_{x}, \\   \\mathbf{e}_{y}, \\   \\mathbf{e}_{z}\\right)\\end{equation*}"
       ],
       "text/plain": [
        "(e_u, e_x, e_y, e_z)"
@@ -451,7 +451,7 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle \\left( -10 \\mathbf{e}_{u} - e^{z} \\mathbf{e}_{y} + \\frac{2}{u} \\mathbf{e}_{z}, \\  \\frac{2 e^{- 4 z}}{u^{2}} \\mathbf{e}_{x}, \\  - e^{z} \\mathbf{e}_{u}, \\  \\frac{2}{u} \\mathbf{e}_{u} + \\frac{2}{u^{2}} \\mathbf{e}_{z}\\right)$"
+       "\\begin{equation*}\\left( -10 \\mathbf{e}_{u} - e^{z} \\mathbf{e}_{y} + \\frac{2}{u} \\mathbf{e}_{z}, \\  \\frac{2 e^{- 4 z}}{u^{2}} \\mathbf{e}_{x}, \\  - e^{z} \\mathbf{e}_{u}, \\  \\frac{2}{u} \\mathbf{e}_{u} + \\frac{2}{u^{2}} \\mathbf{e}_{z}\\right)\\end{equation*}"
       ],
       "text/plain": [
        "(-10*e_u - exp(z)*e_y + 2*e_z/u, 2*exp(-4*z)*e_x/u**2, -exp(z)*e_u, 2*e_u/u + \n",
@@ -476,7 +476,7 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle \\left( \\left( 1,\\right), \\  \\left( \\mathbf{e}_{u}, \\  \\mathbf{e}_{x}, \\  \\mathbf{e}_{y}, \\  \\mathbf{e}_{z}\\right), \\  \\left( \\mathbf{e}_{u}\\wedge \\mathbf{e}_{x}, \\  \\mathbf{e}_{u}\\wedge \\mathbf{e}_{y}, \\  \\mathbf{e}_{u}\\wedge \\mathbf{e}_{z}, \\  \\mathbf{e}_{x}\\wedge \\mathbf{e}_{y}, \\  \\mathbf{e}_{x}\\wedge \\mathbf{e}_{z}, \\  \\mathbf{e}_{y}\\wedge \\mathbf{e}_{z}\\right), \\  \\left( \\mathbf{e}_{u}\\wedge \\mathbf{e}_{x}\\wedge \\mathbf{e}_{y}, \\  \\mathbf{e}_{u}\\wedge \\mathbf{e}_{x}\\wedge \\mathbf{e}_{z}, \\  \\mathbf{e}_{u}\\wedge \\mathbf{e}_{y}\\wedge \\mathbf{e}_{z}, \\  \\mathbf{e}_{x}\\wedge \\mathbf{e}_{y}\\wedge \\mathbf{e}_{z}\\right), \\  \\left( \\mathbf{e}_{u}\\wedge \\mathbf{e}_{x}\\wedge \\mathbf{e}_{y}\\wedge \\mathbf{e}_{z},\\right)\\right)$"
+       "\\begin{equation*}\\left( \\left( 1\\right), \\  \\left( \\boldsymbol{e}_{u}, \\  \\boldsymbol{e}_{x}, \\  \\boldsymbol{e}_{y}, \\  \\boldsymbol{e}_{z}\\right), \\  \\left( \\boldsymbol{e}_{u}\\wedge \\boldsymbol{e}_{x}, \\  \\boldsymbol{e}_{u}\\wedge \\boldsymbol{e}_{y}, \\  \\boldsymbol{e}_{u}\\wedge \\boldsymbol{e}_{z}, \\  \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}, \\  \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z}, \\  \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}\\right), \\  \\left( \\boldsymbol{e}_{u}\\wedge \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}, \\  \\boldsymbol{e}_{u}\\wedge \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z}, \\  \\boldsymbol{e}_{u}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}, \\  \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}\\right), \\  \\left( \\boldsymbol{e}_{u}\\wedge \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}\\right)\\right)\\end{equation*}"
       ],
       "text/plain": [
        "((1,), (eᵤ, eₓ, e_y, e_z), (eᵤ^eₓ, eᵤ^e_y, eᵤ^e_z, eₓ^e_y, eₓ^e_z, e_y^e_z), (\n",
@@ -500,7 +500,7 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle \\mathbf{e}_{u}\\wedge \\mathbf{e}_{x}\\wedge \\mathbf{e}_{y}\\wedge \\mathbf{e}_{z}$"
+       "\\begin{equation*}\\boldsymbol{e}_{u}\\wedge \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}\\end{equation*}"
       ],
       "text/plain": [
        "eᵤ^eₓ^e_y^e_z"
@@ -523,7 +523,7 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle \\left( \\left( 1,\\right), \\  \\left( \\mathbf{e}_{u}, \\  \\mathbf{e}_{x}, \\  \\mathbf{e}_{y}, \\  \\mathbf{e}_{z}\\right), \\  \\left( \\mathbf{e}_{u}\\mathbf{e}_{x}, \\  \\mathbf{e}_{u}\\mathbf{e}_{y}, \\  \\mathbf{e}_{u}\\mathbf{e}_{z}, \\  \\mathbf{e}_{x}\\mathbf{e}_{y}, \\  \\mathbf{e}_{x}\\mathbf{e}_{z}, \\  \\mathbf{e}_{y}\\mathbf{e}_{z}\\right), \\  \\left( \\mathbf{e}_{u}\\mathbf{e}_{x}\\mathbf{e}_{y}, \\  \\mathbf{e}_{u}\\mathbf{e}_{x}\\mathbf{e}_{z}, \\  \\mathbf{e}_{u}\\mathbf{e}_{y}\\mathbf{e}_{z}, \\  \\mathbf{e}_{x}\\mathbf{e}_{y}\\mathbf{e}_{z}\\right), \\  \\left( \\mathbf{e}_{u}\\mathbf{e}_{x}\\mathbf{e}_{y}\\mathbf{e}_{z},\\right)\\right)$"
+       "\\begin{equation*}\\left( \\left( 1\\right), \\  \\left( \\boldsymbol{e}_{u}, \\  \\boldsymbol{e}_{x}, \\  \\boldsymbol{e}_{y}, \\  \\boldsymbol{e}_{z}\\right), \\  \\left( \\boldsymbol{e}_{u}\\boldsymbol{e}_{x}, \\  \\boldsymbol{e}_{u}\\boldsymbol{e}_{y}, \\  \\boldsymbol{e}_{u}\\boldsymbol{e}_{z}, \\  \\boldsymbol{e}_{x}\\boldsymbol{e}_{y}, \\  \\boldsymbol{e}_{x}\\boldsymbol{e}_{z}, \\  \\boldsymbol{e}_{y}\\boldsymbol{e}_{z}\\right), \\  \\left( \\boldsymbol{e}_{u}\\boldsymbol{e}_{x}\\boldsymbol{e}_{y}, \\  \\boldsymbol{e}_{u}\\boldsymbol{e}_{x}\\boldsymbol{e}_{z}, \\  \\boldsymbol{e}_{u}\\boldsymbol{e}_{y}\\boldsymbol{e}_{z}, \\  \\boldsymbol{e}_{x}\\boldsymbol{e}_{y}\\boldsymbol{e}_{z}\\right), \\  \\left( \\boldsymbol{e}_{u}\\boldsymbol{e}_{x}\\boldsymbol{e}_{y}\\boldsymbol{e}_{z}\\right)\\right)\\end{equation*}"
       ],
       "text/plain": [
        "((1,), (eᵤ, eₓ, e_y, e_z), (eᵤ*eₓ, eᵤ*e_y, eᵤ*e_z, eₓ*e_y, eₓ*e_z, e_y*e_z), (\n",

--- a/examples/ipython/verify_doc_python.ipynb
+++ b/examples/ipython/verify_doc_python.ipynb
@@ -70,7 +70,7 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle \\left[\\begin{matrix}\\left (\\mathbf{a}\\cdot \\mathbf{a}\\right )  & \\left (\\mathbf{a}\\cdot \\mathbf{b}\\right )  & \\left (\\mathbf{a}\\cdot \\mathbf{c}\\right )  & \\left (\\mathbf{a}\\cdot \\mathbf{d}\\right ) \\\\\\left (\\mathbf{a}\\cdot \\mathbf{b}\\right )  & \\left (\\mathbf{b}\\cdot \\mathbf{b}\\right )  & \\left (\\mathbf{b}\\cdot \\mathbf{c}\\right )  & \\left (\\mathbf{b}\\cdot \\mathbf{d}\\right ) \\\\\\left (\\mathbf{a}\\cdot \\mathbf{c}\\right )  & \\left (\\mathbf{b}\\cdot \\mathbf{c}\\right )  & \\left (\\mathbf{c}\\cdot \\mathbf{c}\\right )  & \\left (\\mathbf{c}\\cdot \\mathbf{d}\\right ) \\\\\\left (\\mathbf{a}\\cdot \\mathbf{d}\\right )  & \\left (\\mathbf{b}\\cdot \\mathbf{d}\\right )  & \\left (\\mathbf{c}\\cdot \\mathbf{d}\\right )  & \\left (\\mathbf{d}\\cdot \\mathbf{d}\\right ) \\end{matrix}\\right]$"
+       "\\begin{equation*}\\left[\\begin{array}{cccc}\\left (\\boldsymbol{a}\\cdot \\boldsymbol{a}\\right )  & \\left (\\boldsymbol{a}\\cdot \\boldsymbol{b}\\right )  & \\left (\\boldsymbol{a}\\cdot \\boldsymbol{c}\\right )  & \\left (\\boldsymbol{a}\\cdot \\boldsymbol{d}\\right ) \\\\\\left (\\boldsymbol{a}\\cdot \\boldsymbol{b}\\right )  & \\left (\\boldsymbol{b}\\cdot \\boldsymbol{b}\\right )  & \\left (\\boldsymbol{b}\\cdot \\boldsymbol{c}\\right )  & \\left (\\boldsymbol{b}\\cdot \\boldsymbol{d}\\right ) \\\\\\left (\\boldsymbol{a}\\cdot \\boldsymbol{c}\\right )  & \\left (\\boldsymbol{b}\\cdot \\boldsymbol{c}\\right )  & \\left (\\boldsymbol{c}\\cdot \\boldsymbol{c}\\right )  & \\left (\\boldsymbol{c}\\cdot \\boldsymbol{d}\\right ) \\\\\\left (\\boldsymbol{a}\\cdot \\boldsymbol{d}\\right )  & \\left (\\boldsymbol{b}\\cdot \\boldsymbol{d}\\right )  & \\left (\\boldsymbol{c}\\cdot \\boldsymbol{d}\\right )  & \\left (\\boldsymbol{d}\\cdot \\boldsymbol{d}\\right ) \\end{array}\\right]\\end{equation*}"
       ],
       "text/plain": [
        "Matrix([\n",
@@ -325,7 +325,7 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle \\left( t, \\  x, \\  y, \\  z\\right)$"
+       "\\begin{equation*}\\left( t, \\  x, \\  y, \\  z\\right)\\end{equation*}"
       ],
       "text/plain": [
        "(t, x, y, z)"
@@ -485,7 +485,7 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle m$"
+       "\\begin{equation*}m\\end{equation*}"
       ],
       "text/plain": [
        "m"
@@ -508,7 +508,7 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle e$"
+       "\\begin{equation*}e\\end{equation*}"
       ],
       "text/plain": [
        "e"

--- a/galgebra/printer.py
+++ b/galgebra/printer.py
@@ -856,7 +856,11 @@ def Format(Fmode: bool = True, Dmode: bool = True, inverse='full'):
         GaLatexPrinter.redirect()
 
         if isinteractive():
-            init_printing(use_latex='mathjax')
+            init_printing(
+                use_latex='mathjax',
+                latex_mode='equation*',
+                latex_printer=latex
+            )
 
     return
 

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
     license='BSD',
     packages=find_packages(),
     package_dir={'galgebra': 'galgebra'},
+    # Sympy 1.4 is needed for printing tests to pass, but 1.3 will still work
     install_requires=['sympy'],
     python_requires='>=3.5.*',
     long_description=long_description,


### PR DESCRIPTION
This makes the default `_repr_latex_` of all sympy objects use our printer, and does so in a way that is easy for the user to reconfigure.
We switch to `latex_mode="equation*"` because it is more consistent with our existing `_repr_latex_`.

---

Note that `latex_mode="equation*"` did not work before #439.

The main motivation here is dogfooding - our tutorial notebook already configures sympy in this way, so we should use it this way in our tests too.

Eventually, I'd envisage pushing `Format` to the status of a deprecated API, and encouraging users to call `sympy.init_printing()` directly or perhaps a new `galgebra.printer.init_printing()` which defaults an argument or two.