### PR TITLE
Move the backport of sympy.Printable into its own file

### DIFF
--- a/galgebra/_utils/printable.py
+++ b/galgebra/_utils/printable.py
@@ -1,0 +1,55 @@
+__all__ = ['Printable']
+
+try:
+    from sympy.printing.defaults import Printable
+except ImportError:
+    # sympy < 1.7
+    from sympy import Basic
+
+    class _Trick_can_print_latex(set):
+        """
+        A class that tricks the `_can_print_latex` function in sympy < 1.7 into
+        returning True for our types, by subclassing a supported type.
+
+        In sympy >= 1.7, it already returns True for our types.
+        """
+        def __init__(self, value):
+            self.value = value
+
+        def __iter__(self):
+            return iter([])
+
+        def _latex(self, printer):
+            return printer._print(self.value)
+
+    class Printable:
+        """ Backport of `sympy.printing.defaults.Printable` """
+        def __str__(self):
+            from sympy.printing.str import sstr
+            return sstr(self, order=None)
+
+        __repr__ = __str__
+
+        def _repr_latex_(self):
+            f = None
+            try:
+                # This isn't perfect, in principle there could be multiple
+                # active IPython's with different configurations.
+                ip = get_ipython()
+            except NameError:
+                # Not in IPython
+                pass
+            else:
+                # Reuse the printer that was customized by init_printing, if
+                # present.
+                f = ip.display_formatter.formatters['text/latex'].type_printers.get(Basic)
+
+            if f is None:
+                # no customizations present or ipython not running
+                f = Basic._repr_latex_
+
+            if f is None:
+                # latex printing disabled
+                return None
+
+            return f(_Trick_can_print_latex(self))

--- a/galgebra/printer.py
+++ b/galgebra/printer.py
@@ -98,11 +98,6 @@ from sympy.core.operations import AssocOp
 from sympy import init_printing
 
 try:
-    from sympy.printing.defaults import Printable as SympyPrintable
-except ImportError:
-    # sympy < 1.7
-    SympyPrintable = object
-try:
     from IPython.display import display, Latex, Math, display_latex
 except ImportError:
     pass
@@ -114,6 +109,7 @@ except ImportError:
 from inspect import getouterframes, currentframe
 
 from ._utils import parser as _parser
+from ._utils.printable import Printable as SympyPrintable
 
 ZERO_STR = ' 0 '
 
@@ -367,24 +363,6 @@ class GaPrinter(StrPrinter):
         )
 
 
-if SympyPrintable is object:
-    class _Trick_can_print_latex(set):
-        """
-        A class that tricks the `_can_print_latex` function in sympy < 1.7 into
-        returning True for our types, by subclassing a supported type.
-
-        In sympy >= 1.7, it already returns True for our types.
-        """
-        def __init__(self, value):
-            self.value = value
-
-        def __iter__(self):
-            return iter([])
-
-        def _latex(self, printer):
-            return printer._print(self.value)
-
-
 # Inheriting from SympyPrintable ensure we take part in interactive printing
 # customization
 class GaPrintable(SympyPrintable):
@@ -398,37 +376,11 @@ class GaPrintable(SympyPrintable):
     def __repr__(self):
         return GaPrinter().doprint(self)
 
-    if SympyPrintable is object:
-        # this is all a workaround for sympy 1.6, to make it behave like 1.7.
-        def _repr_latex_(self):
-            f = None
-            try:
-                # This isn't perfect, in principle there could be multiple
-                # active IPython's with different configurations.
-                ip = get_ipython()
-            except NameError:
-                # Not in IPython
-                pass
-            else:
-                # Reuse the printer that was customized by init_printing, if
-                # present.
-                f = ip.display_formatter.formatters['text/latex'].type_printers.get(Basic)
-
-            if f is None:
-                # no customizations present or ipython not running
-                f = Basic._repr_latex_
-
-            if f is None:
-                # latex printing disabled
-                return None
-
-            return f(_Trick_can_print_latex(self))
-
 
 # Change sympy builtins to use our printer by default.
 # We do this because we always have done, and stopping now would break
 # compatibility.
-if SympyPrintable is not object:
+if issubclass(Basic, SympyPrintable):
     SympyPrintable.__ga_print_str__ = GaPrintable.__ga_print_str__
     SympyPrintable.__repr__ = GaPrintable.__repr__
 else:


### PR DESCRIPTION
Since this is a temporary solution until we drop sympy 1.6, putting it in its own file keeps it isolated.