### PR TITLE
Deprecate lt.coords and lt.X

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+- :support:`454` The ``l.coords`` and ``l.X`` attributes of :class:`galgebra.lt.Lt` objects are deprecated in favor of using ``l.Ga.coords`` and ``l.Ga.coord_vec``.
+
+- :feature:`454` :class:`galgebra.lt.Lt` objects can now be used with :class:`~galgebra.ga.Ga`\ s that are not constructed with a ``coords`` argument.
+
 - :feature:`450` ANSI printing can now be turned off with ``Eprint(deriv=None, fct=None, base=None)``.
 
 - :support:`450` Many undocumented parts of :func:`galgebra.printer.Eprint` have been removed:

--- a/galgebra/lt.py
+++ b/galgebra/lt.py
@@ -169,6 +169,22 @@ class Lt(printer.GaPrintable):
     def format(mat_fmt=False):
         Lt.mat_fmt = mat_fmt
 
+    @property
+    def coords(self):
+        # galgebra 0.6.0
+        warnings.warn(
+            "lt.coords is deprecated, use `lt.Ga.coords` instead.",
+            DeprecationWarning, stacklevel=2)
+        return self.Ga.coords
+
+    @property
+    def X(self):
+        # galgebra 0.6.0
+        warnings.warn(
+            "lt.X is deprecated, use `lt.Ga.coord_vec` instead.",
+            DeprecationWarning, stacklevel=2)
+        return self.Ga.coord_vec
+
     def __init__(self, *args, ga, f=False, mode='g'):
         """
         Parameters
@@ -184,8 +200,6 @@ class Lt(printer.GaPrintable):
         self.fct_flg = f
         self.mode = mode
         self.Ga = ga
-        self.coords = ga.coords
-        self.X = ga.coord_vec
         self.spinor = False
         self.rho_sq = None
 

--- a/test/test_lt.py
+++ b/test/test_lt.py
@@ -17,6 +17,14 @@ class TestLt(unittest.TestCase):
         assert str(A) == 'Lt(a) = a + b\nLt(b) = 2*a - b'
         assert str(A.matrix()) == 'Matrix([[1, 2], [1, -1]])'
 
+    def test_deprecations(self):
+        base = Ga('a b', g=[1, 1], coords=symbols('x, y', real=True))
+        l = base.lt([[1, 2], [3, 4]])
+        with pytest.warns(DeprecationWarning):
+            assert l.X == l.Ga.coord_vec
+        with pytest.warns(DeprecationWarning):
+            assert l.coords == l.Ga.coords
+
 
 class TestMlt(unittest.TestCase):
 


### PR DESCRIPTION
These properties aren't used, and their existance makes it impossible to use the `Lt` class on coord-less `GA` objects.