### PR TITLE
BUG: metric: Do not skip normalization just because `de is None`

### DIFF
--- a/galgebra/metric.py
+++ b/galgebra/metric.py
@@ -567,35 +567,32 @@ class Metric(object):
 
     def normalize_metric(self):
 
-        if self.de is None:
-            return
+        # normalize derivatives
+        if self.de is not None:
+            # Generate mapping for renormalizing reciprocal basis vectors
+            renorm = [
+                (self.r_symbols[ib], self.r_symbols[ib] / self.e_norm[ib])
+                for ib in self.n_range  # e^{ib} --> e^{ib}/|e_{ib}|
+            ]
 
-        #  Generate mapping for renormalizing reciprocal basis vectors
-        renorm = [
-            (self.r_symbols[ib], self.r_symbols[ib] / self.e_norm[ib])
-            for ib in self.n_range  # e^{ib} --> e^{ib}/|e_{ib}|
-        ]
-
-        # Normalize derivatives of basis vectors
-
-        for x_i in self.n_range:
-            for jb in self.n_range:
-                self.de[x_i][jb] = Simp.apply((((self.de[x_i][jb].subs(renorm)
-                                              - diff(self.e_norm[jb], self.coords[x_i]) *
-                                              self.basis[jb]) / self.e_norm[jb])))
-        if self.debug:
+            # Normalize derivatives of basis vectors
             for x_i in self.n_range:
                 for jb in self.n_range:
-                    print(r'\partial_{' + str(self.coords[x_i]) + r'}\hat{e}_{' + str(self.coords[jb]) + '} =', self.de[x_i][jb])
+                    self.de[x_i][jb] = Simp.apply((((self.de[x_i][jb].subs(renorm)
+                                                  - diff(self.e_norm[jb], self.coords[x_i]) *
+                                                  self.basis[jb]) / self.e_norm[jb])))
+            if self.debug:
+                printer.oprint('e^{i}->e^{i}/|e_{i}|', renorm)
+                for x_i in self.n_range:
+                    for jb in self.n_range:
+                        print(r'\partial_{' + str(self.coords[x_i]) + r'}\hat{e}_{' + str(self.coords[jb]) + '} =', self.de[x_i][jb])
 
         # Normalize metric tensor
-
         for ib in self.n_range:
             for jb in self.n_range:
                 self.g[ib, jb] = Simp.apply(self.g[ib, jb] / (self.e_norm[ib] * self.e_norm[jb]))
 
         if self.debug:
-            printer.oprint('e^{i}->e^{i}/|e_{i}|', renorm)
             printer.oprint('renorm(g)', self.g)
 
     def signature(self):

--- a/galgebra/metric.py
+++ b/galgebra/metric.py
@@ -788,24 +788,18 @@ class Metric(object):
             if i < j
         )
 
-        if self.coords is not None:
-            if self.norm:  # normalize basis, metric, and derivatives of normalized basis
-                if not self.is_ortho:
-                    raise ValueError('!!!!Basis normalization only implemented for orthogonal basis!!!!')
-                self.e_norm = [
-                    square_root_of_expr(self.g[i, i])
-                    for i in self.n_range
-                ]
-                if debug:
-                    printer.oprint('|e_{i}|', self.e_norm)
-            else:
-                self.e_norm = None
-
-        if self.norm:
-            if self.is_ortho:
-                self.normalize_metric()
-            else:
+        if self.norm:  # normalize basis, metric, and derivatives of normalized basis
+            if not self.is_ortho:
                 raise ValueError('!!!!Basis normalization only implemented for orthogonal basis!!!!')
+            self.e_norm = [
+                square_root_of_expr(self.g[i, i])
+                for i in self.n_range
+            ]
+            if debug:
+                printer.oprint('|e_{i}|', self.e_norm)
+            self.normalize_metric()
+        else:
+            self.e_norm = None
 
         if not self.g_is_numeric:
             self.signature()

--- a/test/test_test.py
+++ b/test/test_test.py
@@ -1,6 +1,6 @@
 import sys
 import pytest
-from sympy import symbols, sin, cos, Rational, expand, collect, simplify, Symbol, Add, S
+from sympy import symbols, sin, cos, Rational, expand, collect, simplify, Symbol, Add, S, eye
 from galgebra.printer import Format, Eprint, latex, GaPrinter
 from galgebra.ga import Ga
 from galgebra.mv import Mv, Nga
@@ -157,6 +157,27 @@ class TestTest:
         assert latex(B|(eth^ephi)) == r'- B^{\theta \phi } {\left (r,\theta ,\phi  \right )}'
 
         assert str(grad^B) == '(r*D{r}B__thetaphi - B__rphi/tan(theta) + 2*B__thetaphi - D{theta}B__rphi + D{phi}B__rtheta/sin(theta))*e_r^e_theta^e_phi/r'
+
+    def test_norm_flag(self):
+        # gh-466
+        rho = symbols('rho', positive=True)
+        theta, phi = symbols('theta phi', real=True)
+        sph_coords = (rho, theta, phi)
+
+        p = (rho*sin(theta)*cos(phi), rho*sin(theta)*sin(phi), rho*cos(theta))
+        g_sph = Ga('e', coords=sph_coords, X=p, norm=True)
+        assert g_sph.g == eye(3)
+
+    def test_norm_flag_subspace(self):
+        # gh-466
+        # the coordinates here describe a submanifold
+        R = symbols('R', positive=True)
+        theta, z = symbols('theta z', real=True)
+        cyl2_coords = (theta, z)
+
+        p = (R*cos(theta), R*sin(theta), z)
+        g_cyl2 = Ga('e', coords=cyl2_coords, X=p, norm=True)
+        assert g_cyl2.g == eye(2)
 
     def test_rounding_numerical_components(self):
 


### PR DESCRIPTION
The intent here was likely to just avoid normalizing `de` if `de is None`, and this change brings the implementation in line with the intent.

Fixes #466, cc @greg1950