### PR TITLE
Drop Python 3.5, bump the sympy version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ defaults: &defaults
           # variables, so reassemble the list here
           PYTEST_ARGS=();
 
-          PYTEST_ARGS+=(-n 2 --dist loadscope);;
+          PYTEST_ARGS+=(-n 2 --dist loadscope);
 
           if [[ ! -z "$PYTEST_K_FILTER" ]]; then
             PYTEST_ARGS+=(-k "$PYTEST_K_FILTER");

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,10 +21,7 @@ defaults: &defaults
           # variables, so reassemble the list here
           PYTEST_ARGS=();
 
-          # xdist crashes on 3.5, https://github.com/pygae/galgebra/issues/438
-          if [[ "$CIRCLE_JOB" != "python-3.5" ]]; then
-            PYTEST_ARGS+=(-n 2 --dist loadscope);
-          fi;
+          PYTEST_ARGS+=(-n 2 --dist loadscope);;
 
           if [[ ! -z "$PYTEST_K_FILTER" ]]; then
             PYTEST_ARGS+=(-k "$PYTEST_K_FILTER");
@@ -94,6 +91,10 @@ jobs:
       - image: circleci/python:3.8
 
   # make sure to keep setup.py in sync with these
+  "python-3.9":
+    <<: *defaults
+    docker:
+      - image: circleci/python:3.9
   "python-3.8":
     <<: *defaults
     docker:
@@ -106,13 +107,6 @@ jobs:
     <<: *defaults
     docker:
       - image: circleci/python:3.6
-  "python-3.5":
-    <<: *defaults
-    environment:
-      # the tutorial uses Python 3.6 syntax, for convenience.
-      PYTEST_K_FILTER: not examples/ipython/tutorial_algebra.ipynb
-    docker:
-      - image: circleci/python:3.5
 
   "publish":
     docker:
@@ -133,16 +127,16 @@ workflows:
             tags:
               only: /^v.*$/
 
-      - "python-3.8":
+      - "python-3.9":
           filters:
             tags:
               only: /^v.*$/
           requires: ["flake8"]
+      - "python-3.8":
+          requires: ["flake8"]
       - "python-3.7":
           requires: ["flake8"]
       - "python-3.6":
-          requires: ["flake8"]
-      - "python-3.5":
           requires: ["flake8"]
       - "python-3.7-symengine":
           requires: ["flake8"]
@@ -153,7 +147,7 @@ workflows:
 
       - publish:
           requires:
-            - "python-3.8"
+            - "python-3.9"
           filters:
             branches:
               ignore: /.*/

--- a/examples/ipython/galgebra_ipython_helpers.py
+++ b/examples/ipython/galgebra_ipython_helpers.py
@@ -1,5 +1,6 @@
 import subprocess
 import sys
+import os
 from IPython.display import display_pretty
 
 
@@ -13,14 +14,17 @@ def check(name):
 
 
 def run(name):
+    # this makes Python < 3.9 behave like 3.9
+    abs_name = os.path.abspath(name)
     # stdout and stderr do not seem to go the right place in jupyter
     p = subprocess.run(
-        [sys.executable, '-Wdefault', name + '.py'],
+        [sys.executable, '-Wdefault', abs_name + '.py'],
         stdout=subprocess.PIPE, stderr=subprocess.PIPE,
         universal_newlines=True)
     sys.stdout.write(p.stdout)
     sys.stdout.flush()
-    sys.stderr.write(p.stderr)
+    # remove the absolute paths from deprecation warnings
+    sys.stderr.write(p.stderr.replace(abs_name, name))
     sys.stderr.flush()
 
     # this makes the error easier to read in nbval

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     package_dir={'galgebra': 'galgebra'},
     # Sympy 1.4 is needed for printing tests to pass, but 1.3 will still work
     install_requires=['sympy'],
-    python_requires='>=3.5.*',
+    python_requires='>=3.6.*',
     long_description=long_description,
     long_description_content_type='text/markdown',
     classifiers=[
@@ -33,10 +33,10 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Topic :: Scientific/Engineering :: Mathematics',
         'Topic :: Scientific/Engineering :: Physics',
     ],

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,5 +1,5 @@
 # requirements for CI
-sympy == 1.5
+sympy == 1.7
 pytest-cov
 ipython == 5.8.0; python_version == "2.7"
 nbval


### PR DESCRIPTION
Python 3.5 is well past its EOL, ad Python 3.9 has been out for 6 months or so. Rather than overloading CI, let's drop one and add the other.

While we're here, let's test on a newer sympy version (1.7).