### PR TITLE
Fix python_requires argument

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     package_dir={'galgebra': 'galgebra'},
     # Sympy 1.4 is needed for printing tests to pass, but 1.3 will still work
     install_requires=['sympy'],
-    python_requires='>=3.6.*',
+    python_requires='>=3.6',
     long_description=long_description,
     long_description_content_type='text/markdown',
     classifiers=[


### PR DESCRIPTION
I get an error when trying to run `setup.py` with a current version of setuptools.  It was apparently a bug to allow the syntax '>=3.6.*': https://reviews.llvm.org/rLNT0476dede37838e2f765f50dd26734cfced9d90d9.