### PR TITLE
Set up pypi publish with trusted-publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,12 @@ jobs:
         && !contains(github.event.head_commit.message, '[skip ci]')
         && !contains(github.event.head_commit.message, '[no release]')
     runs-on: ubuntu-latest
+    # https://github.com/pypa/gh-action-pypi-publish/tree/release/v1/?tab=readme-ov-file#trusted-publishing
+    permissions:
+      id-token: write
+    environment:
+      name: pypi
+      url: https://pypi.org/p/galgebra
     steps:
       - name: Check out code
         uses: actions/checkout@v3
@@ -79,12 +85,9 @@ jobs:
           python-version: "3.11"
       - name: Install wheel
         run: |
-          python -m pip install wheel
-      - name: Build and upload package
-        if: success()
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+          python -m pip install wheel packaging
+      - name: Build a binary wheel
         run: |
           python setup.py sdist bdist_wheel
-          twine upload dist/*
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/galgebra/_version.py
+++ b/galgebra/_version.py
@@ -5,4 +5,4 @@
 # 1) we don't load dependencies by storing it in __init__.py
 # 2) we can import it in setup.py for the same reason
 # 3) we can import it into your module
-__version__ = '0.5.0'
+__version__ = '0.5.1'


### PR DESCRIPTION
See

- https://github.com/pypa/gh-action-pypi-publish/tree/release/v1/?tab=readme-ov-file#trusted-publishing
- https://docs.pypi.org/trusted-publishers/adding-a-publisher/
- maintainers please check https://pypi.org/manage/project/galgebra/settings/publishing/ as I have set up the trusted publishing for pygae/galgebra there