### PR TITLE
Release 0.5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,15 @@ Star History
  </picture>
 </a>
 
+Contributors
+-------------------
+
+<a href="https://github.com/pygae/galgebra/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=pygae/galgebra" />
+</a>
+
+Made with [contrib.rocks](https://contrib.rocks).
+
 Citing This Library
 -------------------
 

--- a/README.md
+++ b/README.md
@@ -252,6 +252,17 @@ Note that in the [doc/books](https://github.com/pygae/galgebra/blob/master/doc/b
 
 <!-- end: bundled-resources -->
 
+Star History
+-------------------
+
+<a href="https://star-history.com/#pygae/galgebra&Date">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=pygae/galgebra&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=pygae/galgebra&type=Date" />
+   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=pygae/galgebra&type=Date" />
+ </picture>
+</a>
+
 Citing This Library
 -------------------
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+- :release:`0.5.2 <2024.05.01>`
+
+- :support:`517` Add citation info, star history, contributors to README, and fix zenodo citation issue for ``0.5.1``.
+
 - :release:`0.5.1 <2024.03.31>`
 
 - :bug:`495` ``MatrixFunction`` is broken since SymPy 1.11, which is required by initializing :class:`~galgebra.ga.Ga` with ``gsym`` and ``coords``, this is now fixed with a workaround (:issue:`507`).

--- a/galgebra/_version.py
+++ b/galgebra/_version.py
@@ -5,4 +5,4 @@
 # 1) we don't load dependencies by storing it in __init__.py
 # 2) we can import it in setup.py for the same reason
 # 3) we can import it into your module
-__version__ = '0.5.2rc1'
+__version__ = '0.5.2'

--- a/galgebra/_version.py
+++ b/galgebra/_version.py
@@ -5,4 +5,4 @@
 # 1) we don't load dependencies by storing it in __init__.py
 # 2) we can import it in setup.py for the same reason
 # 3) we can import it into your module
-__version__ = '0.5.1'
+__version__ = '0.5.2rc1'


### PR DESCRIPTION
This release is a maintenance release with no functionality changes, includes only some updates to README:

- citation info (716617a380a6eb5d5746b503db0baefcf6a66660...4607cdaf35958f5e955fe22e71155752ca7be230)
- star history
- contributors

This also fixes the issue that zenodo can't correctly refer to v0.5.1 due to how I messed up with releasing 0.5.1:

> I created release 0.5.1rc2 but the version number in `_version.py` is `0.5.1` so pypi release `0.5.1` and I can't release `0.5.1` again after that, so I modified the release on Github, but zenodo can only point to 0.5.1rc2.

Another things that I have messed up is that I forgot to use squash merge during 0.5.1 and 0.5.2. Since 0.6.0, this practice would be resumed.