### PR TITLE
Add shirokov_inverse and hitzer_inverse

### DIFF
--- a/galgebra/mv.py
+++ b/galgebra/mv.py
@@ -2091,6 +2091,17 @@ def inv(A: Mv) -> Mv:
         raise ValueError('A = ' + str(A) + ' not a multivector in inv(A).')
     return A.inv()
 
+def shirokov_inverse(A: Mv) -> Mv:
+    """ Equivalent to :meth:`Mv.shirokov_inverse` """
+    if not isinstance(A, Mv):
+        raise ValueError('A = ' + str(A) + ' not a multivector in shirokov_inverse(A).')
+    return A.shirokov_inverse()
+
+def hitzer_inverse(A: Mv) -> Mv:
+    """ Equivalent to :meth:`Mv.hitzer_inverse` """
+    if not isinstance(A, Mv):
+        raise ValueError('A = ' + str(A) + ' not a multivector in hitzer_inverse(A).')
+    return A.hitzer_inverse()
 
 # ## GSG code starts ###
 def qform(A: Mv) -> Expr:

--- a/galgebra/mv.py
+++ b/galgebra/mv.py
@@ -1359,6 +1359,24 @@ class Mv(printer.GaPrintable):
             return (S.One/self_self_rev.obj) * self_rev
         raise TypeError('In inv() for self =' + str(self) + 'self, or self*self or self*self.rev() is not a scalar')
 
+    def shirokov_inverse(self) -> 'Mv':
+        """
+        Iterative algorithm for the inverse following
+        Theorem 4 (page 17) in https://arxiv.org/abs/2005.04015
+        """
+        n = self.Ga.n
+        exponent = (n + 1) // 2
+        N = 2**exponent
+        Uk = self
+        for k in range(1, N):
+            Ck = (N / k) * Uk.scalar()
+            adjU = Ck - Uk
+            Uk = -self * adjU
+        if Uk.scalar() == 0:
+            raise ValueError('Multivector has no inverse')
+        detU = -Uk.scalar()
+        return adjU / detU
+
     def func(self, fct) -> 'Mv':  # Apply function, fct, to each coefficient of multivector
         s = S.Zero
         for coef, base in metric.linear_expand_terms(self.obj):

--- a/test/test_mv.py
+++ b/test/test_mv.py
@@ -4,7 +4,7 @@ import pytest
 import sympy
 from sympy import symbols
 from galgebra.ga import Ga
-from galgebra.mv import proj, undual, g_invol, exp, norm, norm2, mag, mag2, ccon, rev, scalar, qform, sp
+from galgebra.mv import proj, undual, g_invol, exp, norm, norm2, mag, mag2, ccon, rev, scalar, qform, sp, inv, shirokov_inverse, hitzer_inverse
 
 
 class TestMv:
@@ -324,3 +324,20 @@ class TestMv:
         # not a multivector in sp(A, B)
         with pytest.raises(ValueError):
             sp(1, 1)
+
+    @pytest.mark.parametrize('inv_func', [inv, shirokov_inverse, hitzer_inverse])
+    @pytest.mark.parametrize('n', range(2, 5)) # tests are slow for larger n
+    def test_inv(self, inv_func, n):
+        gncoords = symbols(" ".join(f"x{i}" for i in range(n)), real=True)
+        gn = Ga('e', g=[1] * n, coords=gncoords)
+
+        # invert versors
+        A = gn.mv('A', 'vector')
+        Ainv = inv_func(A)
+        assert A * Ainv == 1 + 0 * A
+
+        # invert generic multivectors
+        if inv_func in [shirokov_inverse, hitzer_inverse] and n<4:
+            B = gn.mv('A', 'mv')
+            Binv = inv_func(B)
+            assert B * Binv == 1 + 0 * B


### PR DESCRIPTION
Add `shirokov_inverse` and `hitzer_inverse` functions, based on the `clifford` package implementation of the [shirokov_inverse](https://github.com/pygae/clifford/blob/master/clifford/_layout.py#L574) and [hitzer_inverse](https://github.com/pygae/clifford/blob/master/clifford/_layout.py#L592).

closes #529 