### PR TITLE
Add DeepWiki badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ GAlgebra
 
 Symbolic Geometric Algebra/Calculus package for SymPy.
 
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/pygae/galgebra)
 [![PyPI](https://img.shields.io/pypi/v/galgebra.svg)](https://pypi.org/project/galgebra/)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/galgebra.svg)](https://pypi.org/project/galgebra/)
 [![Python CI](https://github.com/pygae/galgebra/actions/workflows/ci.yml/badge.svg)](https://github.com/pygae/galgebra/actions/workflows/ci.yml)


### PR DESCRIPTION
This will:

1. allow users to have access to AI generated wiki that evolves with and benefits from both doc and code.
2. enable auto refresh the wiki weekly with the latest code

For 2, see:

<img width="374" alt="image" src="https://github.com/user-attachments/assets/c0c6dfff-7336-4e80-b4fd-64cb35d7d717" />

It's a way to observe how current doc and code can provide information on different aspects of GAlgebra. If AI could not pick it up using DeepResearch, how could we expect users to learn it in the haystack of doc, notebooks, tests, and code?

This is also a reaction to the fact that GAlgebra contains docs from different times and by different authors, and may not be coherent. I don't have time to sort all out, but it's at least useful to observe to what extent AI could be confused (or not, hopefully).