### PR TITLE
Allow returning zero from `Lt` callable constructor

### DIFF
--- a/galgebra/lt.py
+++ b/galgebra/lt.py
@@ -362,7 +362,7 @@ class Lt(printer.GaPrintable):
             self.lt_dict = {}
             for base in self.Ga.basis:
                 out = F(mv.Mv(base, ga=self.Ga))
-                if not out.is_vector():
+                if not out.is_vector() and not out.is_zero():
                     raise ValueError('{} must return vectors'.format(F))
                 self.lt_dict[base] = out.obj
         else:


### PR DESCRIPTION
This is an immediate fix, but it might also be a good idea to more generally treat zero differently, since, strictly speaking, it doesn't have a well-defined grade, but it is currently treated as grade zero.