### PR TITLE
feat(mv): add `__rtruediv__` to support `scalar/Mv` expressions

### DIFF
--- a/galgebra/mv.py
+++ b/galgebra/mv.py
@@ -589,6 +589,10 @@ class Mv(printer.GaPrintable):
         else:
             return self * (S.One/A)
 
+    def __rtruediv__(self, A):
+        """Allow expressions like ``1/mv`` or ``scalar/mv``."""
+        return Mv(A, ga=self.Ga) * self.inv()
+
     def __str__(self):
         return printer.GaPrinter()._print(self)
 

--- a/test/test_mv.py
+++ b/test/test_mv.py
@@ -357,6 +357,19 @@ class TestMv:
         assert result * v == ga.mv(2)
 
         # sympy scalar / Mv
-        from sympy import S
+        from sympy import S, symbols
         result = S(3) / I
         assert result * I == ga.mv(3)
+
+        # symbolic numerator
+        a = symbols('a')
+        result = a / I
+        assert result * I == ga.mv(a)
+
+        # non-Euclidean metric (Minkowski-like)
+        ga_m, e_t, e_x = Ga.build('e*t|x', g=[1, -1])
+        v = e_t + e_x
+        # v*v = 1 - 1 = 0 for null vector — skip (not invertible)
+        v2 = e_t + 2 * e_x  # v2*v2 = 1 - 4 = -3 (invertible)
+        result = 1 / v2
+        assert result * v2 == ga_m.mv(1)

--- a/test/test_mv.py
+++ b/test/test_mv.py
@@ -341,3 +341,22 @@ class TestMv:
             B = gn.mv('A', 'mv')
             Binv = inv_func(B)
             assert B * Binv == 1 + 0 * B
+
+    def test_rtruediv(self):
+        """Test that scalar/Mv works (issue 512)."""
+        ga, e_1, e_2, e_3 = Ga.build('e*1|2|3')
+        I = ga.I()
+
+        # 1/I should be the inverse of I
+        result = 1 / I
+        assert result * I == ga.mv(1)
+
+        # scalar / vector
+        v = e_1 + e_2
+        result = 2 / v
+        assert result * v == ga.mv(2)
+
+        # sympy scalar / Mv
+        from sympy import S
+        result = S(3) / I
+        assert result * I == ga.mv(3)


### PR DESCRIPTION
## Summary

Adds `__rtruediv__` to the `Mv` class so that expressions like `1/mv` and `scalar/mv` work as expected, computing `scalar * mv.inv()`.

Previously, `1/mv` would raise a `TypeError` because Python's `int.__truediv__` doesn't know how to handle `Mv` objects and `Mv` didn't implement `__rtruediv__`.

Fixes #512

## Changes

- `galgebra/mv.py`: Add `__rtruediv__` method that wraps the scalar as an `Mv` and multiplies by `self.inv()`
- `test/test_mv.py`: Add tests for `1/I`, `2/v`, and `S(3)/I`

## Test plan

- [x] `pytest test/ -v` passes
- [x] Full CI with nbval notebooks passes