### PR TITLE
test(printer): add regression test for extra \\cdot in LaTeX output

### DIFF
--- a/test/test_printer.py
+++ b/test/test_printer.py
@@ -131,3 +131,15 @@ def test_texify():
 
     # @@ was previously an internal marker
     assert _texify('@@ is safe') == r'@@ is safe'
+
+
+def test_no_extra_cdot():
+    """Regression test: no spurious \\cdot in latex output (issue 494)."""
+    from sympy import symbols
+    ga = Ga('e', g=[1, 1, 1], coords=symbols('x y z', real=True))
+    f = ga.mv('f', 'scalar', f=True)
+    grad = ga.grad
+    p = GaLatexPrinter()
+    latex_str = p.doprint(grad * f)
+    # There should be no \cdot in the gradient of a scalar field
+    assert r'\cdot' not in latex_str


### PR DESCRIPTION
## Summary

Adds a regression test ensuring no spurious `\cdot` appears in the LaTeX output of `grad * f` for a scalar field. The underlying bug was caused by a SymPy change in 1.10 and has been resolved since SymPy 1.12.

Fixes #494

## Changes

- `test/test_printer.py`: Add `test_no_extra_cdot` verifying the gradient of a scalar field contains no `\cdot`

## Test plan

- [x] Unit tests pass
- [x] Full CI with nbval notebooks passes