### PR TITLE
feat(mv): add components() method for extracting multivector coordinates

### DIFF
--- a/galgebra/mv.py
+++ b/galgebra/mv.py
@@ -1038,6 +1038,23 @@ class Mv(printer.GaPrintable):
                 coef_lst.append(S.Zero)
         return coef_lst
 
+    def components(self) -> 'Dict[Mv, Expr]':
+        """
+        Return a dictionary mapping each basis blade (as an :class:`Mv`) to
+        its scalar coefficient.  Only non-zero components are included.
+
+        Example: if ``v = 1*e_1 + 2*e_2 + 3*e_3`` then
+        ``v.components()`` returns ``{e_1: 1, e_2: 2, e_3: 3}``.
+
+        This is useful for extracting individual coordinates for further
+        processing.
+        """
+        result = {}
+        for coef, base in metric.linear_expand_terms(self.obj):
+            if coef != S.Zero:
+                result[Mv(base, ga=self.Ga)] = coef
+        return result
+
     def proj(self, bases_lst: List['Mv']) -> 'Mv':
         """
         Project multivector onto a given list of bases.  That is find the

--- a/test/test_mv.py
+++ b/test/test_mv.py
@@ -55,6 +55,26 @@ class TestMv:
         with pytest.raises(ValueError):
             (e_1 ^ e_2).get_coefs(3)
 
+    def test_components(self):
+        """Test the components() method (issue 483)."""
+        _g3d, e_1, e_2, e_3 = Ga.build('e*1|2|3')
+
+        v = e_1 + 2 * e_2 + 3 * e_3
+        comps = v.components()
+        assert comps[e_1] == 1
+        assert comps[e_2] == 2
+        assert comps[e_3] == 3
+        assert len(comps) == 3
+
+        # mixed-grade multivector
+        m = 5 + e_1 + 2 * (e_1 ^ e_2)
+        comps = m.components()
+        assert len(comps) == 3
+
+        # zero multivector has no components
+        z = 0 * e_1
+        assert z.components() == {}
+
     def test_blade_coefs(self):
         """
         Various tests on several multivectors.


### PR DESCRIPTION
## Summary

Adds `Mv.components()` that returns a dict mapping basis blades to their scalar coefficients, making it easy to extract coordinates from a multivector.

Fixes #483

## Changes

- `galgebra/mv.py`: Add `components()` method that iterates over blade expansion and returns `{blade_symbol: coefficient}` dict
- `test/test_mv.py`: Add tests for scalar, vector, and general multivector decomposition

## Example

```python
ga, ex, ey, ez = Ga.build('e*x|y|z')
v = 2*ex + 3*ey - ez
v.components()
# {e_x: 2, e_y: 3, e_z: -1}
```

## Test plan

- [x] Unit tests pass
- [x] Full CI with nbval notebooks passes