### PR TITLE
docs(examples): add tutorial for extracting coordinates from multivectors

### DIFF
--- a/examples/Terminal/extracting_coords.py
+++ b/examples/Terminal/extracting_coords.py
@@ -73,7 +73,7 @@ def main():
     # Evaluate at a specific angle
     vals = [c.subs(theta, pi / 4) for c in coefs]
     print('at theta=pi/4:', vals)
-    print('numeric:', [float(v) for v in vals])
+    print('numeric:', [float(val) for val in vals])
 
 
 if __name__ == '__main__':

--- a/examples/ipython/tutorial_algebra.ipynb
+++ b/examples/ipython/tutorial_algebra.ipynb
@@ -25,7 +25,14 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-30T12:54:24.730117Z",
+     "iopub.status.busy": "2026-03-30T12:54:24.729933Z",
+     "iopub.status.idle": "2026-03-30T12:54:25.084110Z",
+     "shell.execute_reply": "2026-03-30T12:54:25.082794Z"
+    }
+   },
    "outputs": [],
    "source": [
     "import sympy\n",
@@ -49,7 +56,14 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-30T12:54:25.086518Z",
+     "iopub.status.busy": "2026-03-30T12:54:25.086315Z",
+     "iopub.status.idle": "2026-03-30T12:54:25.095475Z",
+     "shell.execute_reply": "2026-03-30T12:54:25.093991Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -80,7 +94,14 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-30T12:54:25.120465Z",
+     "iopub.status.busy": "2026-03-30T12:54:25.120279Z",
+     "iopub.status.idle": "2026-03-30T12:54:25.125056Z",
+     "shell.execute_reply": "2026-03-30T12:54:25.123936Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -112,7 +133,14 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-30T12:54:25.127124Z",
+     "iopub.status.busy": "2026-03-30T12:54:25.127018Z",
+     "iopub.status.idle": "2026-03-30T12:54:25.157428Z",
+     "shell.execute_reply": "2026-03-30T12:54:25.156644Z"
+    }
+   },
    "outputs": [],
    "source": [
     "xyz = (x, y, z) = sympy.symbols('x y z', real=True)\n",
@@ -130,7 +158,14 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-30T12:54:25.159857Z",
+     "iopub.status.busy": "2026-03-30T12:54:25.159723Z",
+     "iopub.status.idle": "2026-03-30T12:54:25.164109Z",
+     "shell.execute_reply": "2026-03-30T12:54:25.163040Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -167,7 +202,14 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-30T12:54:25.166496Z",
+     "iopub.status.busy": "2026-03-30T12:54:25.166405Z",
+     "iopub.status.idle": "2026-03-30T12:54:25.170536Z",
+     "shell.execute_reply": "2026-03-30T12:54:25.169909Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -190,7 +232,14 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-30T12:54:25.172908Z",
+     "iopub.status.busy": "2026-03-30T12:54:25.172762Z",
+     "iopub.status.idle": "2026-03-30T12:54:25.177646Z",
+     "shell.execute_reply": "2026-03-30T12:54:25.176885Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -213,7 +262,14 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-30T12:54:25.179977Z",
+     "iopub.status.busy": "2026-03-30T12:54:25.179843Z",
+     "iopub.status.idle": "2026-03-30T12:54:25.184822Z",
+     "shell.execute_reply": "2026-03-30T12:54:25.183610Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -236,7 +292,14 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-30T12:54:25.187211Z",
+     "iopub.status.busy": "2026-03-30T12:54:25.187068Z",
+     "iopub.status.idle": "2026-03-30T12:54:25.191640Z",
+     "shell.execute_reply": "2026-03-30T12:54:25.190525Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -266,7 +329,14 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-30T12:54:25.194444Z",
+     "iopub.status.busy": "2026-03-30T12:54:25.194324Z",
+     "iopub.status.idle": "2026-03-30T12:54:25.199440Z",
+     "shell.execute_reply": "2026-03-30T12:54:25.198102Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -305,7 +375,14 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-30T12:54:25.202257Z",
+     "iopub.status.busy": "2026-03-30T12:54:25.202121Z",
+     "iopub.status.idle": "2026-03-30T12:54:25.209494Z",
+     "shell.execute_reply": "2026-03-30T12:54:25.208317Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -340,7 +417,14 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-30T12:54:25.211992Z",
+     "iopub.status.busy": "2026-03-30T12:54:25.211884Z",
+     "iopub.status.idle": "2026-03-30T12:54:25.411032Z",
+     "shell.execute_reply": "2026-03-30T12:54:25.410119Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -383,7 +467,14 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-30T12:54:25.414041Z",
+     "iopub.status.busy": "2026-03-30T12:54:25.413881Z",
+     "iopub.status.idle": "2026-03-30T12:54:25.419183Z",
+     "shell.execute_reply": "2026-03-30T12:54:25.417862Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -407,7 +498,14 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-30T12:54:25.423590Z",
+     "iopub.status.busy": "2026-03-30T12:54:25.423411Z",
+     "iopub.status.idle": "2026-03-30T12:54:25.544979Z",
+     "shell.execute_reply": "2026-03-30T12:54:25.543343Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -461,7 +559,14 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-30T12:54:25.547949Z",
+     "iopub.status.busy": "2026-03-30T12:54:25.547768Z",
+     "iopub.status.idle": "2026-03-30T12:54:25.570473Z",
+     "shell.execute_reply": "2026-03-30T12:54:25.567246Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -503,7 +608,14 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-30T12:54:25.577003Z",
+     "iopub.status.busy": "2026-03-30T12:54:25.576385Z",
+     "iopub.status.idle": "2026-03-30T12:54:25.594042Z",
+     "shell.execute_reply": "2026-03-30T12:54:25.590029Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -527,7 +639,14 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-30T12:54:25.600256Z",
+     "iopub.status.busy": "2026-03-30T12:54:25.600077Z",
+     "iopub.status.idle": "2026-03-30T12:54:25.633025Z",
+     "shell.execute_reply": "2026-03-30T12:54:25.629514Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -567,6 +686,184 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Extracting coordinates\n",
+    "\n",
+    "To extract scalar coefficients from a multivector, use `blade_coefs()` with a list of basis blades.\n",
+    "This returns a list of SymPy expressions that can be used for further symbolic or numeric computation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-30T12:54:25.637284Z",
+     "iopub.status.busy": "2026-03-30T12:54:25.637114Z",
+     "iopub.status.idle": "2026-03-30T12:54:25.650223Z",
+     "shell.execute_reply": "2026-03-30T12:54:25.647187Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \n",
+       "\\begin{align}\n",
+       "    v &= 3 \\boldsymbol{e}_{x} -2 \\boldsymbol{e}_{y} + 5 \\boldsymbol{e}_{z} \\\\\n",
+       "    \\text{coefs along } e_x, e_y, e_z &= \\left[ 3, \\  \\left(-1\\right) 2, \\  5\\right]\n",
+       "\\end{align}\n",
+       "$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "v = 3*ex - 2*ey + 5*ez\n",
+    "coefs = v.blade_coefs([ex, ey, ez])\n",
+    "Math(fr'''\n",
+    "\\begin{{align}}\n",
+    "    v &= {latex(v)} \\\\\n",
+    "    \\text{{coefs along }} e_x, e_y, e_z &= {latex(coefs)}\n",
+    "\\end{{align}}\n",
+    "''')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For numeric work, call `float()` on the SymPy expressions:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-30T12:54:25.653601Z",
+     "iopub.status.busy": "2026-03-30T12:54:25.653351Z",
+     "iopub.status.idle": "2026-03-30T12:54:25.657930Z",
+     "shell.execute_reply": "2026-03-30T12:54:25.656638Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\left[ 3.0, \\  -2.0, \\  5.0\\right]$"
+      ],
+      "text/plain": [
+       "[3.0, -2.0, 5.0]"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "[float(c) for c in coefs]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`components()` splits a multivector into a list of single-blade terms:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-30T12:54:25.660891Z",
+     "iopub.status.busy": "2026-03-30T12:54:25.660618Z",
+     "iopub.status.idle": "2026-03-30T12:54:25.670885Z",
+     "shell.execute_reply": "2026-03-30T12:54:25.669691Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\left[ 3 \\boldsymbol{e}_{x}, \\  -2 \\boldsymbol{e}_{y}, \\  5 \\boldsymbol{e}_{z}\\right]$"
+      ],
+      "text/plain": [
+       "[3*e_x, -2*e_y, 5*e_z]"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "v.components()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For a general multivector, `blade_coefs()` without arguments returns coefficients for all basis blades,\n",
+    "and `grade(k)` extracts the grade-$k$ part:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-30T12:54:25.673254Z",
+     "iopub.status.busy": "2026-03-30T12:54:25.672987Z",
+     "iopub.status.idle": "2026-03-30T12:54:25.679736Z",
+     "shell.execute_reply": "2026-03-30T12:54:25.678234Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \n",
+       "\\begin{align}\n",
+       "    M &= M  + M^{x} \\boldsymbol{e}_{x} + M^{y} \\boldsymbol{e}_{y} + M^{z} \\boldsymbol{e}_{z} + M^{xy} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + M^{xz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + M^{yz} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} + M^{xyz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} \\\\\n",
+       "    \\text{all coefs} &= \\left[ M, \\  M^{x}, \\  M^{y}, \\  M^{z}, \\  M^{xy}, \\  M^{xz}, \\  M^{yz}, \\  M^{xyz}\\right] \\\\\n",
+       "    \\text{scalar part} &= M \\\\\n",
+       "    \\left<M\\right>_2 &= M^{xy} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + M^{xz} \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + M^{yz} \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z}\n",
+       "\\end{align}\n",
+       "$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Math(fr'''\n",
+    "\\begin{{align}}\n",
+    "    M &= {latex(M)} \\\\\n",
+    "    \\text{{all coefs}} &= {latex(M.blade_coefs())} \\\\\n",
+    "    \\text{{scalar part}} &= {latex(M.scalar())} \\\\\n",
+    "    \\left<M\\right>_2 &= {latex(M.grade(2))}\n",
+    "\\end{{align}}\n",
+    "''')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## More printing options"
    ]
   },
@@ -579,8 +876,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {},
+   "execution_count": 22,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-30T12:54:25.683051Z",
+     "iopub.status.busy": "2026-03-30T12:54:25.682805Z",
+     "iopub.status.idle": "2026-03-30T12:54:25.690630Z",
+     "shell.execute_reply": "2026-03-30T12:54:25.689550Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -591,7 +895,7 @@
        "M + M__x*e_x + M__y*e_y + M__z*e_z + M__xy*e_x^e_y + M__xz*e_x^e_z + M__yz*e_y^e_z + M__xyz*e_x^e_y^e_z"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -602,8 +906,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {},
+   "execution_count": 23,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-30T12:54:25.693149Z",
+     "iopub.status.busy": "2026-03-30T12:54:25.692977Z",
+     "iopub.status.idle": "2026-03-30T12:54:25.699024Z",
+     "shell.execute_reply": "2026-03-30T12:54:25.697251Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -617,7 +928,7 @@
        " + M__xyz*e_x^e_y^e_z"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -628,8 +939,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
-   "metadata": {},
+   "execution_count": 24,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-30T12:54:25.703663Z",
+     "iopub.status.busy": "2026-03-30T12:54:25.703300Z",
+     "iopub.status.idle": "2026-03-30T12:54:25.711856Z",
+     "shell.execute_reply": "2026-03-30T12:54:25.710798Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -647,7 +965,7 @@
        " + M__xyz*e_x^e_y^e_z"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -673,7 +991,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.0"
+   "version": "3.11.14"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary

Adds a tutorial example showing the various ways to extract scalar coefficients from a multivector, addressing the question in issue 483.

Replaces the closed PR 547 which incorrectly added a new method shadowing the existing `components()`.

Fixes #483

## Methods demonstrated

- `blade_coefs(blade_list)`: get coefficients for specific basis blades (the primary tool for numeric work)
- `components()`: split into single-blade Mv objects
- `get_coefs(grade)`: coefficients of all blades of a specific grade
- `scalar()` / `get_grade(r)`: extract specific grades
- Symbolic coordinates with `subs()` and `float()` for numeric conversion

## Changes

- `examples/Terminal/extracting_coords.py`: New tutorial example

## Test plan

- [x] `python examples/Terminal/extracting_coords.py` runs without errors
- [x] No code changes, example only