### PR TITLE
feat(examples): validate galgebra against Goyder cheat sheet (#506)

### DIFF
--- a/test/test_cheatsheet.py
+++ b/test/test_cheatsheet.py
@@ -7,7 +7,7 @@ products, bivector identities, commutator product, pseudoscalar,
 outermorphism/rotation, and adjoint.
 """
 import pytest
-from sympy import symbols, cos, sin, S, simplify, trigsimp, Symbol, Matrix
+from sympy import symbols, cos, sin, S, simplify, trigsimp
 
 from galgebra.ga import Ga
 


### PR DESCRIPTION
Closes #506

Adds `examples/Terminal/cheatsheet_validation.py` validating galgebra against Russell Goyder's [geometric algebra cheat sheet](https://russellgoyder.github.io/geometric-algebra-cheat-sheet/), covering all 7 sections:

1. geometric product decomposition: `ab = a·b + a∧b`, symmetric/antisymmetric parts
2. vector-multivector grade raising/lowering: `a*B = a<B + a∧B`
3. bivector identities: `a·(b∧c) = (a·b)c - (a·c)b`, `(a∧b)·(c∧d)` scalar formula
4. commutator product: `B×v = B·v`, grade-preserving on bivectors, Jacobi identity
5. pseudoscalar: `I²=-1`, centrality in 3D, dual via `I⁻¹`
6. outermorphism: rotor normalization, rotation sandwich, `det(rotation)=1`
7. adjoint: `a·F̄(b) = F(a)·b`, `det(FG) = det(F)·det(G)`