### PR TITLE
docs: add 0.6.0 changelog entries

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -34,6 +34,10 @@ Changelog
   grade-involution sandwich maps every basis vector to a vector. Handles degenerate metrics
   (e.g. PGA ``G(2,0,1)``) correctly. See :issue:`533`.
 
+- :bug:`540` :meth:`~galgebra.lt.Lt` callable constructor now accepts the zero multivector as
+  a return value, so projection maps (e.g. ``lambda x: (x | e1) * e1``) no longer raise
+  ``ValueError``.
+
 - :support:`549` Added examples validating galgebra against Russell Goyder's sundial analysis
   and geometric algebra cheat sheet (:issue:`506`):
 
@@ -63,10 +67,6 @@ Changelog
     logic (:issue:`140`).
   * ``ReciprocalFrame`` loop rewritten with a cleaner index convention matching the sign formula
     in the reference text (:issue:`249`).
-
-- :bug:`560` :meth:`~galgebra.lt.Lt` callable constructor now accepts the zero multivector as
-  a return value, so projection maps (e.g. ``lambda x: (x | e1) * e1``) no longer raise
-  ``ValueError``. Closes :issue:`540`.
 
 - :support:`535` Fixed CI and linting issues.
 


### PR DESCRIPTION
Adds changelog entries for all PRs merged since 0.6.0-dev began (after 0.5.2), grouped by theme. Does not include the `:release:` marker or version bump — those will come in a separate PR once remaining 0.6.0 PRs land.

**New features**
- #550 `Cl(p,q,r)` kingdon-compatible interface (closes #524)
- #543 `Mv.__rtruediv__` for `scalar/Mv` (closes #512)
- #530 `shirokov_inverse`, `hitzer_inverse`

**Bug fixes**
- #556 interop dual mode contamination (closes #555)
- #554 `norm()` wrapped in `Abs` (closes #522)
- #536 `is_versor()` improvement (closes #533)

**Examples and docs**
- #549 + #557 sundial example + cheatsheet tests (closes #506)
- #551 coordinates tutorial
- #548 README operations docs (closes #523)

**Tests and maintenance**
- #558 `lt.matrix()` regression tests (closes #461)
- #545 extra `\cdot` regression test
- #552 + #553 `er_blade` and `ReciprocalFrame` refactors
- #535 CI fix