### PR TITLE
chore: bump version to 0.6.0rc1

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -8,8 +8,6 @@ Changelog
   \newcommand {\es}[1] {\mathbf{e}_{#1}}
   \newcommand {\til}[1] {\widetilde{#1}}
 
-- :release:`0.6.0rc1 <2026.04.01>`
-
 - :feature:`550` Added :func:`galgebra.interop.Cl` and :func:`galgebra.interop.kingdon.Cl` as a
   ``Cl(p, q, r)`` interface compatible with kingdon and ganja.js conventions, making it easier to
   port code between galgebra and other GA libraries. See :issue:`524`.

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -8,6 +8,8 @@ Changelog
   \newcommand {\es}[1] {\mathbf{e}_{#1}}
   \newcommand {\til}[1] {\widetilde{#1}}
 
+- :release:`0.6.0rc1 <2026.04.01>`
+
 - :feature:`550` Added :func:`galgebra.interop.Cl` and :func:`galgebra.interop.kingdon.Cl` as a
   ``Cl(p, q, r)`` interface compatible with kingdon and ganja.js conventions, making it easier to
   port code between galgebra and other GA libraries. See :issue:`524`.

--- a/galgebra/_version.py
+++ b/galgebra/_version.py
@@ -5,4 +5,4 @@
 # 1) we don't load dependencies by storing it in __init__.py
 # 2) we can import it in setup.py for the same reason
 # 3) we can import it into your module
-__version__ = '0.6.0-dev'
+__version__ = '0.6.0rc1'

--- a/test/.nbval_sanitize.cfg
+++ b/test/.nbval_sanitize.cfg
@@ -54,5 +54,5 @@ replace: {Python }
 regex: \{SymPy \}(\d+\.\d+(\.\d+)?(\.dev)?)
 replace: {SymPy }
 # \text{GAlgebra }0.5.0
-regex: \{GAlgebra \}(\d+\.\d+(\.\d+)?(-dev)?)
+regex: \{GAlgebra \}(\d+\.\d+(\.\d+)?(rc\d+|-dev)?)
 replace: {GAlgebra }


### PR DESCRIPTION
## Summary

- Bumps `galgebra/_version.py` from `0.6.0-dev` to `0.6.0rc1`
- Adds `:release:`0.6.0rc1 <2026.04.01>`` marker to `doc/changelog.rst`

## Release plan (after this PR is merged)

1. Squash merge this PR to master
2. Run: `gh release create v0.6.0rc1 --prerelease --title "v0.6.0rc1" --notes "See [Changelog](https://galgebra.readthedocs.io/en/latest/changelog.html).\n\nhttps://pypi.org/project/galgebra/0.6.0rc1/"`
3. This creates the `v0.6.0rc1` tag + GitHub pre-release simultaneously
4. CI triggers from the tag and publishes `0.6.0rc1` to PyPI

## Notes

- `_version.py` must match the tag name (lesson from 0.5.1 release: if `_version.py` says `0.5.1` and you tag `v0.5.1rc2`, PyPI gets `0.5.1` not `0.5.1rc2`)
- After the final 0.6.0 release: update `:release:`0.6.0rc1`` → `:release:`0.6.0`` in changelog and bump `_version.py` to `0.6.0`