### PR TITLE
chore: bump version to 0.6.0

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -8,6 +8,8 @@ Changelog
   \newcommand {\es}[1] {\mathbf{e}_{#1}}
   \newcommand {\til}[1] {\widetilde{#1}}
 
+- :release:`0.6.0 <2026.04.01>`
+
 - :feature:`550` Added :func:`galgebra.interop.Cl` and :func:`galgebra.interop.kingdon.Cl` as a
   ``Cl(p, q, r)`` interface compatible with kingdon and ganja.js conventions, making it easier to
   port code between galgebra and other GA libraries. See :issue:`524`.

--- a/galgebra/_version.py
+++ b/galgebra/_version.py
@@ -5,4 +5,4 @@
 # 1) we don't load dependencies by storing it in __init__.py
 # 2) we can import it in setup.py for the same reason
 # 3) we can import it into your module
-__version__ = '0.6.0rc1'
+__version__ = '0.6.0'


### PR DESCRIPTION
## Summary

- Bumps `galgebra/_version.py` from `0.6.0rc1` to `0.6.0`
- Adds `:release:`0.6.0 <2026.04.01>`` marker to `doc/changelog.rst`

## Release plan (after this PR is merged)

1. Squash merge this PR to master
2. `gh release create v0.6.0 --title "v0.6.0" --notes "See [Changelog](https://galgebra.readthedocs.io/en/latest/changelog.html).\n\nhttps://pypi.org/project/galgebra/0.6.0/"`
3. CI publishes `0.6.0` to PyPI
4. Zenodo auto-archives (triggers on full releases, not pre-releases)
5. Close 0.6.0 milestone