### PR TITLE
fix(lt): accept ImmutableDenseMatrix in Lt.__init__ (#567)

### DIFF
--- a/galgebra/lt.py
+++ b/galgebra/lt.py
@@ -13,6 +13,7 @@ from typing import Mapping
 from sympy import (
     expand, symbols, Matrix, Transpose, zeros, Symbol, Function, S, Add, Expr, simplify
 )
+from sympy.matrices import MatrixBase
 from sympy.printing.latex import LatexPrinter as _LatexPrinter
 from sympy.printing.str import StrPrinter as _StrPrinter
 
@@ -323,7 +324,7 @@ class Lt(printer.GaPrintable):
                     self.lt_dict[base1] = tmp
 
         # ## GSG code starts ###
-        elif isinstance(mat_rep, Matrix):    # Matrix input
+        elif isinstance(mat_rep, MatrixBase):    # Matrix input
             self.lt_dict = Matrix_to_dictionary(mat_rep, self.Ga.basis)
         # ## GSG code ends ###
 


### PR DESCRIPTION
Closes #567.

## Problem

`Lt.__init__` in `galgebra/lt.py` accepted only `Matrix` (`MutableDenseMatrix`) but not `ImmutableDenseMatrix`. In SymPy 1.13, operations such as `Lt.matrix()` and metric tensor multiplication now return `ImmutableDenseMatrix`, so passing the result back to `Ga.lt()` raised:

```
TypeError: Unsupported argument type <class 'sympy.matrices.immutable.ImmutableDenseMatrix'>
```

## Fix

Change `isinstance(mat_rep, Matrix)` → `isinstance(mat_rep, MatrixBase)` at `lt.py:326`. `MatrixBase` is the common abstract base for both mutable and immutable SymPy matrices.

## Test results

Passes with both `sympy==1.12` (current CI) and `sympy==1.13.3`. flake8 clean.