### PR TITLE
fix(lt): reject zero-vector output in Lt callable constructor

### DIFF
--- a/galgebra/lt.py
+++ b/galgebra/lt.py
@@ -362,7 +362,7 @@ class Lt(printer.GaPrintable):
             self.lt_dict = {}
             for base in self.Ga.basis:
                 out = F(mv.Mv(base, ga=self.Ga))
-                if not out.is_vector() and not out.is_zero():
+                if not out.is_vector():
                     raise ValueError('{} must return vectors'.format(F))
                 self.lt_dict[base] = out.obj
         else:


### PR DESCRIPTION
Discovered during code audit in https://github.com/pygae/galgebra/issues/575.

## Change

Removes the `and not out.is_zero()` exemption added in #510, restoring the upstream Macdonald behavior where `F(basis_vector)` must return a proper vector.

**Before** (galgebra):
```python
if not out.is_vector() and not out.is_zero():
    raise ValueError('{} must return vectors'.format(F))
```

**After** (matches upstream zip):
```python
if not out.is_vector():
    raise ValueError('{} must return vectors'.format(F))
```

## Rationale

A linear transform that maps any basis vector to zero is singular. Accepting it silently allows constructing an `Lt` that will produce incorrect results (e.g. wrong determinant, inverse undefined). Making the error explicit at construction time is safer.