### PR TITLE
feat(lt): implement Mlt component-expression constructor

### DIFF
--- a/galgebra/lt.py
+++ b/galgebra/lt.py
@@ -843,11 +843,12 @@ class Mlt(printer.GaPrintable):
                 Mlt.increment_slots(self.nargs, Ga)
                 self.fvalue = f(*tuple(Ga._mlt_a[0:self.nargs]))
             else:  # Tensor defined by component expression
-                raise NotImplementedError
-                # self.f = None
-                # self.nargs = len(args)  # args isn't defined, which is why we raise NotImplementedError
-                # Mlt.increment_slots(self.nargs, Ga)
-                # self.fvalue = f
+                if nargs is None:
+                    raise TypeError("nargs must be provided when f is a component expression")
+                self.f = None
+                self.nargs = nargs
+                Mlt.increment_slots(nargs, Ga)
+                self.fvalue = f
 
     def __call__(self, *args):
         """

--- a/test/test_lt.py
+++ b/test/test_lt.py
@@ -179,6 +179,27 @@ class TestMlt(unittest.TestCase):
             Tyy * a1y * a2y
         )
 
+    def test_from_component_expression(self):
+        """Mlt constructed from a pre-built component expression (issue #578)."""
+        coords = symbols('x y', real=True)
+        g, e1, e2 = Ga.build('e*1|2', coords=coords, g=[1, 1])
+
+        a1 = g.mv('a1', 'vector')
+        a2 = g.mv('a2', 'vector')
+
+        # Build the same rank-2 tensor as test_from_str but pass the
+        # fvalue expression directly instead of a string name.
+        T_str = Mlt('T', g, nargs=2)
+        fvalue = T_str.fvalue  # sympy expression in slot variables
+
+        # Reconstruct using the component-expression path
+        T_expr = Mlt(fvalue, g, nargs=2)
+        assert T_expr(a1, a2) == T_str(a1, a2)
+
+        # nargs is required for component expressions
+        with pytest.raises(TypeError):
+            Mlt(fvalue, g)
+
     def test_deprecations(self):
         g = Ga('e*a|b', g=[1, 1])
         with pytest.warns(DeprecationWarning):


### PR DESCRIPTION
## Summary

- The `else` branch in `Mlt.__init__` raised `NotImplementedError` when `f` is a pre-built sympy expression (component expression path)
- Fixed by using the already-present `nargs` parameter to determine slot count; raises `TypeError` if `nargs` is omitted
- Added `TestMlt.test_from_component_expression` to cover the new path

## Details

The original stub (and the reference in `GAfiles.zip`) contained `self.nargs = len(args)` — but `args` is never defined in that branch. The fix uses `nargs` (already in the signature) as the required input.

Closes #578