### PR TITLE
test(lt): cover Mlt arithmetic on string-constructed tensors

### DIFF
--- a/test/test_lt.py
+++ b/test/test_lt.py
@@ -179,6 +179,21 @@ class TestMlt(unittest.TestCase):
             Tyy * a1y * a2y
         )
 
+    def test_str_arithmetic(self):
+        """Mlt arithmetic on string-constructed tensors routes through the
+        component-expression constructor and must not raise NotImplementedError."""
+        coords = symbols('x y', real=True)
+        g, e1, e2 = Ga.build('e*1|2', coords=coords, g=[1, 1])
+
+        a1 = g.mv('a1', 'vector')
+        a2 = g.mv('a2', 'vector')
+
+        S = Mlt('S', g, nargs=2)
+        T = Mlt('T', g, nargs=2)
+
+        assert (S + T)(a1, a2) == S(a1, a2) + T(a1, a2)
+        assert (S - T)(a1, a2) == S(a1, a2) - T(a1, a2)
+
     def test_from_component_expression(self):
         """Mlt constructed from a pre-built component expression (issue #578)."""
         coords = symbols('x y', real=True)


### PR DESCRIPTION
## Summary

- `Mlt.__add__` and `__sub__` produce a new `Mlt` from a sympy scalar `fvalue`, routing through the component-expression constructor
- This path was silently broken before #578 (would raise `NotImplementedError`) but had no dedicated test
- Adds `test_str_arithmetic` to exercise `S + T` and `S - T` for string-constructed tensors

Closes the gap noted in the review of #578.