### PR TITLE
fix: deferred-simp context manager for Ga.build in curvi_linear_latex (#576)

### DIFF
--- a/examples/LaTeX/curvi_linear_latex.py
+++ b/examples/LaTeX/curvi_linear_latex.py
@@ -1,14 +1,53 @@
 from __future__ import print_function
 import sys
+from contextlib import contextmanager
 
-from sympy import symbols,sin,cos,sinh,cosh
+from sympy import symbols,sin,cos,sinh,cosh,trigsimp
 from galgebra.ga import Ga
+from galgebra.metric import Simp
 from galgebra.printer import Format, xpdf, Print_Function, Eprint
+
+
+@contextmanager
+def _no_simp_build():
+    """Suppress Simp during Ga.build; restore trigsimp(method='old') afterwards.
+
+    ``Ga.build(norm=True)`` calls ``Simp.apply`` ~70 times during metric
+    normalisation.  Since SymPy 1.13 (PR #26390) each call triggers a slow
+    O(N·M) ``.replace()`` traversal inside ``TR3``/``futrig`` that is a no-op
+    for symbolic trig arguments but costs ~25 s per invocation on these
+    curvilinear-coordinate expressions.
+
+    Strategy: use an identity simplifier during the build phase (so the metric
+    components are stored in unsimplified form), then simplify each final output
+    expression once with ``trigsimp(method='old')`` via ``_ts()`` before
+    formatting.  ``trigsimp(method='old')`` uses the ``_trigsimp`` code path
+    which avoids ``fu.py`` / TR3 entirely and runs in < 0.1 s per expression.
+
+    Note: calling plain ``simplify()`` on the final results does **not** help —
+    the unsimplified metric components make the gradient/divergence/curl
+    expressions large enough that TR3 is just as slow on them as it was on the
+    intermediate metric components.  ``trigsimp(method='old')`` is required to
+    avoid the SymPy 1.13 slow path entirely.
+    """
+    orig = Simp.modes[:]
+    Simp.profile([lambda e: e])  # identity — no simplification during build
+    try:
+        yield
+    finally:
+        Simp.profile(orig)
+
+
+def _ts(mv):
+    """Apply trigsimp(method='old') to each coefficient of a multivector."""
+    return mv.simplify(modes=lambda e: trigsimp(e, method='old'))
+
 
 def derivatives_in_spherical_coordinates():
     #Print_Function()
     coords = (r,th,phi) = symbols('r theta phi', real=True)
-    (sp3d,er,eth,ephi) = Ga.build('e_r e_theta e_phi',g=[1,r**2,r**2*sin(th)**2],coords=coords)
+    with _no_simp_build():
+        (sp3d,er,eth,ephi) = Ga.build('e_r e_theta e_phi',g=[1,r**2,r**2*sin(th)**2],coords=coords)
     grad = sp3d.grad
 
     f = sp3d.mv('f','scalar',f=True)
@@ -21,11 +60,11 @@ def derivatives_in_spherical_coordinates():
     print('A =',A)
     print('B =',B)
 
-    print('grad*f =',grad*f)
-    print('grad|A =',grad|A)
-    print('grad\\times A = -I*(grad^A) =',-sp3d.i*(grad^A))
-    print('%\\nabla^{2}f =',grad|(grad*f))
-    print('grad^B =',grad^B)
+    print('grad*f =',_ts(grad*f))
+    print('grad|A =',_ts(grad|A))
+    print('grad\\times A = -I*(grad^A) =',_ts(-sp3d.i*(grad^A)))
+    print('%\\nabla^{2}f =',_ts(grad|(grad*f)))
+    print('grad^B =',_ts(grad^B))
 
     """
     print '( \\nabla\\W\\nabla )\\bm{e}_{r} =',((grad^grad)*er).trigsimp()
@@ -39,7 +78,8 @@ def derivatives_in_spherical_coordinates():
 def derivatives_in_paraboloidal_coordinates():
     #Print_Function()
     coords = (u,v,phi) = symbols('u v phi', real=True)
-    (par3d,er,eth,ephi) = Ga.build('e_u e_v e_phi',X=[u*v*cos(phi),u*v*sin(phi),(u**2-v**2)/2],coords=coords,norm=True)
+    with _no_simp_build():
+        (par3d,er,eth,ephi) = Ga.build('e_u e_v e_phi',X=[u*v*cos(phi),u*v*sin(phi),(u**2-v**2)/2],coords=coords,norm=True)
     grad = par3d.grad
 
     f = par3d.mv('f','scalar',f=True)
@@ -52,10 +92,10 @@ def derivatives_in_paraboloidal_coordinates():
     print('A =',A)
     print('B =',B)
 
-    print('grad*f =',grad*f)
-    print('grad|A =',grad|A)
-    (-par3d.i*(grad^A)).Fmt(3,'grad\\times A = -I*(grad^A)')
-    print('grad^B =',grad^B)
+    print('grad*f =',_ts(grad*f))
+    print('grad|A =',_ts(grad|A))
+    _ts(-par3d.i*(grad^A)).Fmt(3,'grad\\times A = -I*(grad^A)')
+    print('grad^B =',_ts(grad^B))
 
     return
 
@@ -64,7 +104,8 @@ def derivatives_in_elliptic_cylindrical_coordinates():
     #Print_Function()
     a = symbols('a', real=True)
     coords = (u,v,z) = symbols('u v z', real=True)
-    (elip3d,er,eth,ephi) = Ga.build('e_u e_v e_z',X=[a*cosh(u)*cos(v),a*sinh(u)*sin(v),z],coords=coords,norm=True)
+    with _no_simp_build():
+        (elip3d,er,eth,ephi) = Ga.build('e_u e_v e_z',X=[a*cosh(u)*cos(v),a*sinh(u)*sin(v),z],coords=coords,norm=True)
     grad = elip3d.grad
 
     f = elip3d.mv('f','scalar',f=True)
@@ -77,10 +118,10 @@ def derivatives_in_elliptic_cylindrical_coordinates():
     print('A =',A)
     print('B =',B)
 
-    print('grad*f =',grad*f)
-    print('grad|A =',grad|A)
-    print('-I*(grad^A) =',-elip3d.i*(grad^A))
-    print('grad^B =',grad^B)
+    print('grad*f =',_ts(grad*f))
+    print('grad|A =',_ts(grad|A))
+    print('-I*(grad^A) =',_ts(-elip3d.i*(grad^A)))
+    print('grad^B =',_ts(grad^B))
     return
 
 
@@ -88,8 +129,9 @@ def derivatives_in_prolate_spheroidal_coordinates():
     #Print_Function()
     a = symbols('a', real=True)
     coords = (xi,eta,phi) = symbols('xi eta phi', real=True)
-    (ps3d,er,eth,ephi) = Ga.build('e_xi e_eta e_phi',X=[a*sinh(xi)*sin(eta)*cos(phi),a*sinh(xi)*sin(eta)*sin(phi),
-                                                        a*cosh(xi)*cos(eta)],coords=coords,norm=True)
+    with _no_simp_build():
+        (ps3d,er,eth,ephi) = Ga.build('e_xi e_eta e_phi',X=[a*sinh(xi)*sin(eta)*cos(phi),a*sinh(xi)*sin(eta)*sin(phi),
+                                                            a*cosh(xi)*cos(eta)],coords=coords,norm=True)
     grad = ps3d.grad
 
     f = ps3d.mv('f','scalar',f=True)
@@ -102,10 +144,10 @@ def derivatives_in_prolate_spheroidal_coordinates():
     print('A =',A)
     print('B =',B)
 
-    print('grad*f =',grad*f)
-    print('grad|A =',grad|A)
-    (-ps3d.i*(grad^A)).Fmt(3,'-I*(grad^A)')
-    (grad^B).Fmt(3,'grad^B')
+    print('grad*f =',_ts(grad*f))
+    print('grad|A =',_ts(grad|A))
+    _ts(-ps3d.i*(grad^A)).Fmt(3,'-I*(grad^A)')
+    _ts(grad^B).Fmt(3,'grad^B')
     return
 
 
@@ -113,8 +155,9 @@ def derivatives_in_oblate_spheroidal_coordinates():
     Print_Function()
     a = symbols('a', real=True)
     coords = (xi,eta,phi) = symbols('xi eta phi', real=True)
-    (os3d,er,eth,ephi) = Ga.build('e_xi e_eta e_phi',X=[a*cosh(xi)*cos(eta)*cos(phi),a*cosh(xi)*cos(eta)*sin(phi),
-                                                        a*sinh(xi)*sin(eta)],coords=coords,norm=True)
+    with _no_simp_build():
+        (os3d,er,eth,ephi) = Ga.build('e_xi e_eta e_phi',X=[a*cosh(xi)*cos(eta)*cos(phi),a*cosh(xi)*cos(eta)*sin(phi),
+                                                            a*sinh(xi)*sin(eta)],coords=coords,norm=True)
     grad = os3d.grad
 
     f = os3d.mv('f','scalar',f=True)
@@ -125,10 +168,10 @@ def derivatives_in_oblate_spheroidal_coordinates():
     print('A =',A)
     print('B =',B)
 
-    print('grad*f =',grad*f)
-    print('grad|A =',grad|A)
-    print('-I*(grad^A) =',-os3d.i*(grad^A))
-    print('grad^B =',grad^B)
+    print('grad*f =',_ts(grad*f))
+    print('grad|A =',_ts(grad|A))
+    print('-I*(grad^A) =',_ts(-os3d.i*(grad^A)))
+    print('grad^B =',_ts(grad^B))
     return
 
 
@@ -136,7 +179,8 @@ def derivatives_in_bipolar_coordinates():
     Print_Function()
     a = symbols('a', real=True)
     coords = (u,v,z) = symbols('u v z', real=True)
-    (bp3d,eu,ev,ez) = Ga.build('e_u e_v e_z',X=[a*sinh(v)/(cosh(v)-cos(u)),a*sin(u)/(cosh(v)-cos(u)),z],coords=coords,norm=True)
+    with _no_simp_build():
+        (bp3d,eu,ev,ez) = Ga.build('e_u e_v e_z',X=[a*sinh(v)/(cosh(v)-cos(u)),a*sin(u)/(cosh(v)-cos(u)),z],coords=coords,norm=True)
     grad = bp3d.grad
 
     f = bp3d.mv('f','scalar',f=True)
@@ -147,10 +191,10 @@ def derivatives_in_bipolar_coordinates():
     print('A =',A)
     print('B =',B)
 
-    print('grad*f =',grad*f)
-    print('grad|A =',grad|A)
-    print('-I*(grad^A) =',-bp3d.i*(grad^A))
-    print('grad^B =',grad^B)
+    print('grad*f =',_ts(grad*f))
+    print('grad|A =',_ts(grad|A))
+    print('-I*(grad^A) =',_ts(-bp3d.i*(grad^A)))
+    print('grad^B =',_ts(grad^B))
     return
 
 
@@ -158,9 +202,10 @@ def derivatives_in_toroidal_coordinates():
     Print_Function()
     a = symbols('a', real=True)
     coords = (u,v,phi) = symbols('u v phi', real=True)
-    (t3d,eu,ev,ephi) = Ga.build('e_u e_v e_phi',X=[a*sinh(v)*cos(phi)/(cosh(v)-cos(u)),
-                                                    a*sinh(v)*sin(phi)/(cosh(v)-cos(u)),
-                                                    a*sin(u)/(cosh(v)-cos(u))],coords=coords,norm=True)
+    with _no_simp_build():
+        (t3d,eu,ev,ephi) = Ga.build('e_u e_v e_phi',X=[a*sinh(v)*cos(phi)/(cosh(v)-cos(u)),
+                                                        a*sinh(v)*sin(phi)/(cosh(v)-cos(u)),
+                                                        a*sin(u)/(cosh(v)-cos(u))],coords=coords,norm=True)
     grad = t3d.grad
 
     f = t3d.mv('f','scalar',f=True)
@@ -171,10 +216,10 @@ def derivatives_in_toroidal_coordinates():
     print('A =',A)
     print('B =',B)
 
-    print('grad*f =',grad*f)
-    print('grad|A =',grad|A)
-    print('-I*(grad^A) =',-t3d.i*(grad^A))
-    print('grad^B =',grad^B)
+    print('grad*f =',_ts(grad*f))
+    print('grad|A =',_ts(grad|A))
+    print('-I*(grad^A) =',_ts(-t3d.i*(grad^A)))
+    print('grad^B =',_ts(grad^B))
     return
 
 

--- a/examples/LaTeX/curvi_linear_latex.py
+++ b/examples/LaTeX/curvi_linear_latex.py
@@ -10,25 +10,17 @@ from galgebra.printer import Format, xpdf, Print_Function, Eprint
 
 @contextmanager
 def _no_simp_build():
-    """Suppress Simp during Ga.build; restore trigsimp(method='old') afterwards.
+    """Use an identity simplifier during Ga.build, then restore the caller's Simp profile.
 
     ``Ga.build(norm=True)`` calls ``Simp.apply`` ~70 times during metric
-    normalisation.  Since SymPy 1.13 (PR #26390) each call triggers a slow
-    O(N·M) ``.replace()`` traversal inside ``TR3``/``futrig`` that is a no-op
-    for symbolic trig arguments but costs ~25 s per invocation on these
-    curvilinear-coordinate expressions.
+    normalisation.  Since SymPy 1.13 (PR #26390) each call traverses every
+    trig/hyperbolic node via ``.replace(Mul, ...)`` inside ``TR3``/``futrig``,
+    which is always a no-op for symbolic trig arguments but costs ~25 s per call.
 
-    Strategy: use an identity simplifier during the build phase (so the metric
-    components are stored in unsimplified form), then simplify each final output
-    expression once with ``trigsimp(method='old')`` via ``_ts()`` before
-    formatting.  ``trigsimp(method='old')`` uses the ``_trigsimp`` code path
-    which avoids ``fu.py`` / TR3 entirely and runs in < 0.1 s per expression.
-
-    Note: calling plain ``simplify()`` on the final results does **not** help —
-    the unsimplified metric components make the gradient/divergence/curl
-    expressions large enough that TR3 is just as slow on them as it was on the
-    intermediate metric components.  ``trigsimp(method='old')`` is required to
-    avoid the SymPy 1.13 slow path entirely.
+    By substituting an identity simplifier for the build phase we skip all ~70
+    traversals.  The callers' ``Simp.modes`` (set by ``main()`` to
+    ``trigsimp(method='old')``) remain active for the output expressions, so
+    ``_sympystr`` still simplifies each printed result once when formatting.
     """
     orig = Simp.modes[:]
     Simp.profile([lambda e: e])  # identity — no simplification during build
@@ -36,11 +28,6 @@ def _no_simp_build():
         yield
     finally:
         Simp.profile(orig)
-
-
-def _ts(mv):
-    """Apply trigsimp(method='old') to each coefficient of a multivector."""
-    return mv.simplify(modes=lambda e: trigsimp(e, method='old'))
 
 
 def derivatives_in_spherical_coordinates():
@@ -60,11 +47,11 @@ def derivatives_in_spherical_coordinates():
     print('A =',A)
     print('B =',B)
 
-    print('grad*f =',_ts(grad*f))
-    print('grad|A =',_ts(grad|A))
-    print('grad\\times A = -I*(grad^A) =',_ts(-sp3d.i*(grad^A)))
-    print('%\\nabla^{2}f =',_ts(grad|(grad*f)))
-    print('grad^B =',_ts(grad^B))
+    print('grad*f =',grad*f)
+    print('grad|A =',grad|A)
+    print('grad\\times A = -I*(grad^A) =',-sp3d.i*(grad^A))
+    print('%\\nabla^{2}f =',grad|(grad*f))
+    print('grad^B =',grad^B)
 
     """
     print '( \\nabla\\W\\nabla )\\bm{e}_{r} =',((grad^grad)*er).trigsimp()
@@ -92,10 +79,10 @@ def derivatives_in_paraboloidal_coordinates():
     print('A =',A)
     print('B =',B)
 
-    print('grad*f =',_ts(grad*f))
-    print('grad|A =',_ts(grad|A))
-    _ts(-par3d.i*(grad^A)).Fmt(3,'grad\\times A = -I*(grad^A)')
-    print('grad^B =',_ts(grad^B))
+    print('grad*f =',grad*f)
+    print('grad|A =',grad|A)
+    (-par3d.i*(grad^A)).Fmt(3,'grad\\times A = -I*(grad^A)')
+    print('grad^B =',grad^B)
 
     return
 
@@ -118,10 +105,10 @@ def derivatives_in_elliptic_cylindrical_coordinates():
     print('A =',A)
     print('B =',B)
 
-    print('grad*f =',_ts(grad*f))
-    print('grad|A =',_ts(grad|A))
-    print('-I*(grad^A) =',_ts(-elip3d.i*(grad^A)))
-    print('grad^B =',_ts(grad^B))
+    print('grad*f =',grad*f)
+    print('grad|A =',grad|A)
+    print('-I*(grad^A) =',-elip3d.i*(grad^A))
+    print('grad^B =',grad^B)
     return
 
 
@@ -144,10 +131,10 @@ def derivatives_in_prolate_spheroidal_coordinates():
     print('A =',A)
     print('B =',B)
 
-    print('grad*f =',_ts(grad*f))
-    print('grad|A =',_ts(grad|A))
-    _ts(-ps3d.i*(grad^A)).Fmt(3,'-I*(grad^A)')
-    _ts(grad^B).Fmt(3,'grad^B')
+    print('grad*f =',grad*f)
+    print('grad|A =',grad|A)
+    (-ps3d.i*(grad^A)).Fmt(3,'-I*(grad^A)')
+    (grad^B).Fmt(3,'grad^B')
     return
 
 
@@ -168,10 +155,10 @@ def derivatives_in_oblate_spheroidal_coordinates():
     print('A =',A)
     print('B =',B)
 
-    print('grad*f =',_ts(grad*f))
-    print('grad|A =',_ts(grad|A))
-    print('-I*(grad^A) =',_ts(-os3d.i*(grad^A)))
-    print('grad^B =',_ts(grad^B))
+    print('grad*f =',grad*f)
+    print('grad|A =',grad|A)
+    print('-I*(grad^A) =',-os3d.i*(grad^A))
+    print('grad^B =',grad^B)
     return
 
 
@@ -191,10 +178,10 @@ def derivatives_in_bipolar_coordinates():
     print('A =',A)
     print('B =',B)
 
-    print('grad*f =',_ts(grad*f))
-    print('grad|A =',_ts(grad|A))
-    print('-I*(grad^A) =',_ts(-bp3d.i*(grad^A)))
-    print('grad^B =',_ts(grad^B))
+    print('grad*f =',grad*f)
+    print('grad|A =',grad|A)
+    print('-I*(grad^A) =',-bp3d.i*(grad^A))
+    print('grad^B =',grad^B)
     return
 
 
@@ -216,24 +203,39 @@ def derivatives_in_toroidal_coordinates():
     print('A =',A)
     print('B =',B)
 
-    print('grad*f =',_ts(grad*f))
-    print('grad|A =',_ts(grad|A))
-    print('-I*(grad^A) =',_ts(-t3d.i*(grad^A)))
-    print('grad^B =',_ts(grad^B))
+    print('grad*f =',grad*f)
+    print('grad|A =',grad|A)
+    print('-I*(grad^A) =',-t3d.i*(grad^A))
+    print('grad^B =',grad^B)
     return
 
 
 def main():
     #Eprint()
     Format()
-    derivatives_in_spherical_coordinates()
-    derivatives_in_paraboloidal_coordinates()
-    # FIXME This takes ~600 seconds
-    # derivatives_in_elliptic_cylindrical_coordinates()
-    derivatives_in_prolate_spheroidal_coordinates()
-    #derivatives_in_oblate_spheroidal_coordinates()
-    #derivatives_in_bipolar_coordinates()
-    #derivatives_in_toroidal_coordinates()
+
+    # SymPy >= 1.13 (PR #26390) added a slow O(N*M) traversal inside
+    # sympy.simplify.fu that causes timeouts on curvilinear coordinate
+    # expressions.  Use trigsimp(method='old') via Simp.profile to avoid
+    # that code path entirely for this example.
+    #
+    # _no_simp_build() inside each function further avoids ~70 redundant
+    # Simp.apply calls during Ga.build by substituting an identity simplifier
+    # for the build phase only.  The trigsimp(method='old') profile below
+    # then applies once per output expression via _sympystr at print time.
+    orig_modes = Simp.modes[:]
+    Simp.profile([lambda e: trigsimp(e, method='old')])
+    try:
+        derivatives_in_spherical_coordinates()
+        derivatives_in_paraboloidal_coordinates()
+        # FIXME This takes ~600 seconds
+        # derivatives_in_elliptic_cylindrical_coordinates()
+        derivatives_in_prolate_spheroidal_coordinates()
+        #derivatives_in_oblate_spheroidal_coordinates()
+        #derivatives_in_bipolar_coordinates()
+        #derivatives_in_toroidal_coordinates()
+    finally:
+        Simp.profile(orig_modes)
 
     # xpdf()
     xpdf(pdfprog=None)

--- a/examples/ipython/LaTeX.ipynb
+++ b/examples/ipython/LaTeX.ipynb
@@ -3,7 +3,14 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-03T17:49:49.350651Z",
+     "iopub.status.busy": "2026-04-03T17:49:49.350564Z",
+     "iopub.status.idle": "2026-04-03T17:49:49.355578Z",
+     "shell.execute_reply": "2026-04-03T17:49:49.354683Z"
+    }
+   },
    "outputs": [],
    "source": [
     "import os\n",
@@ -14,7 +21,14 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-03T17:49:49.357889Z",
+     "iopub.status.busy": "2026-04-03T17:49:49.357769Z",
+     "iopub.status.idle": "2026-04-03T17:49:49.820984Z",
+     "shell.execute_reply": "2026-04-03T17:49:49.820289Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -90,7 +104,14 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-03T17:49:49.835835Z",
+     "iopub.status.busy": "2026-04-03T17:49:49.835699Z",
+     "iopub.status.idle": "2026-04-03T17:49:53.563605Z",
+     "shell.execute_reply": "2026-04-03T17:49:53.562896Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -149,22 +170,22 @@
        "\\begin{equation*} B = B^{r\\theta }  \\boldsymbol{e}_{r}\\wedge \\boldsymbol{e}_{\\theta } + B^{r\\phi }  \\boldsymbol{e}_{r}\\wedge \\boldsymbol{e}_{\\phi } + B^{\\theta \\phi }  \\boldsymbol{e}_{\\theta }\\wedge \\boldsymbol{e}_{\\phi } \\end{equation*}\n",
        "\\begin{equation*} \\boldsymbol{\\nabla}  f = \\partial_{r} f  \\boldsymbol{e}_{r} + \\frac{\\partial_{\\theta } f }{r^{2}} \\boldsymbol{e}_{\\theta } + \\frac{\\partial_{\\phi } f }{r^{2} {\\sin{\\left (\\theta  \\right )}}^{2}} \\boldsymbol{e}_{\\phi } \\end{equation*}\n",
        "\\begin{equation*} \\boldsymbol{\\nabla} \\cdot A = \\frac{A^{\\theta } }{\\tan{\\left (\\theta  \\right )}} + \\partial_{\\phi } A^{\\phi }  + \\partial_{r} A^{r}  + \\partial_{\\theta } A^{\\theta }  + \\frac{2 A^{r} }{r} \\end{equation*}\n",
-       "\\begin{equation*} \\boldsymbol{\\nabla} \\times A = -I (\\boldsymbol{\\nabla} \\W A) = \\left(\\frac{2 A^{\\phi } }{\\tan{\\left (\\theta  \\right )}} + \\partial_{\\theta } A^{\\phi }  - \\frac{\\partial_{\\phi } A^{\\theta } }{{\\sin{\\left (\\theta  \\right )}}^{2}}\\right) \\left|{\\sin{\\left (\\theta  \\right )}}\\right| \\boldsymbol{e}_{r} + \\frac{- r^{2} {\\sin{\\left (\\theta  \\right )}}^{2} \\partial_{r} A^{\\phi }  - 2 r A^{\\phi }  {\\sin{\\left (\\theta  \\right )}}^{2} + \\partial_{\\phi } A^{r} }{r^{2} \\left|{\\sin{\\left (\\theta  \\right )}}\\right|} \\boldsymbol{e}_{\\theta } + \\frac{r^{2} \\partial_{r} A^{\\theta }  + 2 r A^{\\theta }  - \\partial_{\\theta } A^{r} }{r^{2} \\left|{\\sin{\\left (\\theta  \\right )}}\\right|} \\boldsymbol{e}_{\\phi } \\end{equation*}\n",
-       "\\begin{equation*} \\nabla^{2}f = \\frac{r^{2} \\partial^{2}_{r} f  + 2 r \\partial_{r} f  + \\partial^{2}_{\\theta } f  + \\frac{\\partial_{\\theta } f }{\\tan{\\left (\\theta  \\right )}} + \\frac{\\partial^{2}_{\\phi } f }{{\\sin{\\left (\\theta  \\right )}}^{2}}}{r^{2}} \\end{equation*}\n",
-       "\\begin{equation*} \\boldsymbol{\\nabla} \\W B = \\frac{r^{2} \\partial_{r} B^{\\theta \\phi }  + 4 r B^{\\theta \\phi }  - \\frac{2 B^{r\\phi } }{\\tan{\\left (\\theta  \\right )}} - \\partial_{\\theta } B^{r\\phi }  + \\frac{\\partial_{\\phi } B^{r\\theta } }{{\\sin{\\left (\\theta  \\right )}}^{2}}}{r^{2}} \\boldsymbol{e}_{r}\\wedge \\boldsymbol{e}_{\\theta }\\wedge \\boldsymbol{e}_{\\phi } \\end{equation*}\n",
+       "\\begin{equation*} \\boldsymbol{\\nabla} \\times A = -I (\\boldsymbol{\\nabla} \\W A) = \\frac{2 A^{\\phi }  \\sin{\\left (\\theta  \\right )} \\cos{\\left (\\theta  \\right )} + {\\sin{\\left (\\theta  \\right )}}^{2} \\partial_{\\theta } A^{\\phi }  - \\partial_{\\phi } A^{\\theta } }{\\left|{\\sin{\\left (\\theta  \\right )}}\\right|} \\boldsymbol{e}_{r} - \\frac{r^{2} {\\sin{\\left (\\theta  \\right )}}^{2} \\partial_{r} A^{\\phi }  + 2 r A^{\\phi }  {\\sin{\\left (\\theta  \\right )}}^{2} - \\partial_{\\phi } A^{r} }{r^{2} \\left|{\\sin{\\left (\\theta  \\right )}}\\right|} \\boldsymbol{e}_{\\theta } + \\frac{r^{2} \\partial_{r} A^{\\theta }  + 2 r A^{\\theta }  - \\partial_{\\theta } A^{r} }{r^{2} \\left|{\\sin{\\left (\\theta  \\right )}}\\right|} \\boldsymbol{e}_{\\phi } \\end{equation*}\n",
+       "\\begin{equation*} \\nabla^{2}f = \\partial^{2}_{r} f  + \\frac{2 \\partial_{r} f }{r} + \\frac{\\partial^{2}_{\\theta } f }{r^{2}} + \\frac{\\partial_{\\theta } f }{r^{2} \\tan{\\left (\\theta  \\right )}} + \\frac{\\partial^{2}_{\\phi } f }{r^{2} {\\sin{\\left (\\theta  \\right )}}^{2}} \\end{equation*}\n",
+       "\\begin{equation*} \\boldsymbol{\\nabla} \\W B = \\left ( \\partial_{r} B^{\\theta \\phi }  + \\frac{4 B^{\\theta \\phi } }{r} - \\frac{2 B^{r\\phi } }{r^{2} \\tan{\\left (\\theta  \\right )}} - \\frac{\\partial_{\\theta } B^{r\\phi } }{r^{2}} + \\frac{\\partial_{\\phi } B^{r\\theta } }{r^{2} {\\sin{\\left (\\theta  \\right )}}^{2}}\\right ) \\boldsymbol{e}_{r}\\wedge \\boldsymbol{e}_{\\theta }\\wedge \\boldsymbol{e}_{\\phi } \\end{equation*}\n",
        "Derivatives in Paraboloidal Coordinates\n",
        "\\begin{equation*} f = f \\end{equation*}\n",
        "\\begin{equation*} A = A^{u}  \\boldsymbol{e}_{u} + A^{v}  \\boldsymbol{e}_{v} + A^{\\phi }  \\boldsymbol{e}_{\\phi } \\end{equation*}\n",
        "\\begin{equation*} B = B^{uv}  \\boldsymbol{e}_{u}\\wedge \\boldsymbol{e}_{v} + B^{u\\phi }  \\boldsymbol{e}_{u}\\wedge \\boldsymbol{e}_{\\phi } + B^{v\\phi }  \\boldsymbol{e}_{v}\\wedge \\boldsymbol{e}_{\\phi } \\end{equation*}\n",
        "\\begin{equation*} \\boldsymbol{\\nabla}  f = \\frac{\\partial_{u} f }{\\sqrt{u^{2} + v^{2}}} \\boldsymbol{e}_{u} + \\frac{\\partial_{v} f }{\\sqrt{u^{2} + v^{2}}} \\boldsymbol{e}_{v} + \\frac{\\partial_{\\phi } f }{u v} \\boldsymbol{e}_{\\phi } \\end{equation*}\n",
-       "\\begin{equation*} \\boldsymbol{\\nabla} \\cdot A = \\frac{u A^{u} }{\\left(u^{2} + v^{2}\\right)^{\\frac{3}{2}}} + \\frac{v A^{v} }{\\left(u^{2} + v^{2}\\right)^{\\frac{3}{2}}} + \\frac{\\partial_{u} A^{u} }{\\sqrt{u^{2} + v^{2}}} + \\frac{\\partial_{v} A^{v} }{\\sqrt{u^{2} + v^{2}}} + \\frac{A^{v} }{v \\sqrt{u^{2} + v^{2}}} + \\frac{A^{u} }{u \\sqrt{u^{2} + v^{2}}} + \\frac{\\partial_{\\phi } A^{\\phi } }{u v} \\end{equation*}\n",
-       "\\begin{equation*} \\boldsymbol{\\nabla} \\W B = \\left ( \\frac{u B^{v\\phi } }{\\left(u^{2} + v^{2}\\right)^{\\frac{3}{2}}} - \\frac{v B^{u\\phi } }{\\left(u^{2} + v^{2}\\right)^{\\frac{3}{2}}} - \\frac{\\partial_{v} B^{u\\phi } }{\\sqrt{u^{2} + v^{2}}} + \\frac{\\partial_{u} B^{v\\phi } }{\\sqrt{u^{2} + v^{2}}} - \\frac{B^{u\\phi } }{v \\sqrt{u^{2} + v^{2}}} + \\frac{B^{v\\phi } }{u \\sqrt{u^{2} + v^{2}}} + \\frac{\\partial_{\\phi } B^{uv} }{u v}\\right ) \\boldsymbol{e}_{u}\\wedge \\boldsymbol{e}_{v}\\wedge \\boldsymbol{e}_{\\phi } \\end{equation*}\n",
+       "\\begin{equation*} \\boldsymbol{\\nabla} \\cdot A = \\frac{u A^{u} }{u^{2} \\sqrt{u^{2} + v^{2}} + v^{2} \\sqrt{u^{2} + v^{2}}} + \\frac{v A^{v} }{u^{2} \\sqrt{u^{2} + v^{2}} + v^{2} \\sqrt{u^{2} + v^{2}}} + \\frac{\\partial_{u} A^{u} }{\\sqrt{u^{2} + v^{2}}} + \\frac{\\partial_{v} A^{v} }{\\sqrt{u^{2} + v^{2}}} + \\frac{A^{v} }{v \\sqrt{u^{2} + v^{2}}} + \\frac{A^{u} }{u \\sqrt{u^{2} + v^{2}}} + \\frac{\\partial_{\\phi } A^{\\phi } }{u v} \\end{equation*}\n",
+       "\\begin{equation*} \\boldsymbol{\\nabla} \\W B = \\left ( \\frac{u B^{v\\phi } }{u^{2} \\sqrt{u^{2} + v^{2}} + v^{2} \\sqrt{u^{2} + v^{2}}} - \\frac{v B^{u\\phi } }{u^{2} \\sqrt{u^{2} + v^{2}} + v^{2} \\sqrt{u^{2} + v^{2}}} - \\frac{\\partial_{v} B^{u\\phi } }{\\sqrt{u^{2} + v^{2}}} + \\frac{\\partial_{u} B^{v\\phi } }{\\sqrt{u^{2} + v^{2}}} - \\frac{B^{u\\phi } }{v \\sqrt{u^{2} + v^{2}}} + \\frac{B^{v\\phi } }{u \\sqrt{u^{2} + v^{2}}} + \\frac{\\partial_{\\phi } B^{uv} }{u v}\\right ) \\boldsymbol{e}_{u}\\wedge \\boldsymbol{e}_{v}\\wedge \\boldsymbol{e}_{\\phi } \\end{equation*}\n",
        "Derivatives in Prolate Spheroidal Coordinates\n",
        "\\begin{equation*} f = f \\end{equation*}\n",
        "\\begin{equation*} A = A^{\\xi }  \\boldsymbol{e}_{\\xi } + A^{\\eta }  \\boldsymbol{e}_{\\eta } + A^{\\phi }  \\boldsymbol{e}_{\\phi } \\end{equation*}\n",
        "\\begin{equation*} B = B^{\\xi \\eta }  \\boldsymbol{e}_{\\xi }\\wedge \\boldsymbol{e}_{\\eta } + B^{\\xi \\phi }  \\boldsymbol{e}_{\\xi }\\wedge \\boldsymbol{e}_{\\phi } + B^{\\eta \\phi }  \\boldsymbol{e}_{\\eta }\\wedge \\boldsymbol{e}_{\\phi } \\end{equation*}\n",
-       "\\begin{equation*} \\boldsymbol{\\nabla}  f = \\frac{\\partial_{\\xi } f }{\\sqrt{{\\sin{\\left (\\eta  \\right )}}^{2} + {\\sinh{\\left (\\xi  \\right )}}^{2}} \\left|{a}\\right|} \\boldsymbol{e}_{\\xi } + \\frac{\\partial_{\\eta } f }{\\sqrt{{\\sin{\\left (\\eta  \\right )}}^{2} + {\\sinh{\\left (\\xi  \\right )}}^{2}} \\left|{a}\\right|} \\boldsymbol{e}_{\\eta } + \\frac{\\partial_{\\phi } f }{a \\sin{\\left (\\eta  \\right )} \\sinh{\\left (\\xi  \\right )}} \\boldsymbol{e}_{\\phi } \\end{equation*}\n",
-       "\\begin{equation*} \\boldsymbol{\\nabla} \\cdot A = \\frac{a \\left({\\sin{\\left (\\eta  \\right )}}^{2} + {\\sinh{\\left (\\xi  \\right )}}^{2}\\right)^{3} \\partial_{\\phi } A^{\\phi }  + \\frac{\\left(A^{\\eta }  \\sin{\\left (2 \\eta  \\right )} + A^{\\xi }  \\sinh{\\left (2 \\xi  \\right )}\\right) \\left({\\sin{\\left (\\eta  \\right )}}^{2} + {\\sinh{\\left (\\xi  \\right )}}^{2}\\right)^{\\frac{3}{2}} \\sin{\\left (\\eta  \\right )} \\sinh{\\left (\\xi  \\right )} \\left|{a}\\right|}{2} + \\left({\\sin{\\left (\\eta  \\right )}}^{2} + {\\sinh{\\left (\\xi  \\right )}}^{2}\\right)^{\\frac{5}{2}} \\left(\\partial_{\\eta } A^{\\eta }  + \\partial_{\\xi } A^{\\xi } \\right) \\sin{\\left (\\eta  \\right )} \\sinh{\\left (\\xi  \\right )} \\left|{a}\\right| + \\left({\\sin{\\left (\\eta  \\right )}}^{2} + {\\sinh{\\left (\\xi  \\right )}}^{2}\\right)^{\\frac{5}{2}} A^{\\eta }  \\cos{\\left (\\eta  \\right )} \\sinh{\\left (\\xi  \\right )} \\left|{a}\\right| + \\left({\\sin{\\left (\\eta  \\right )}}^{2} + {\\sinh{\\left (\\xi  \\right )}}^{2}\\right)^{\\frac{5}{2}} A^{\\xi }  \\sin{\\left (\\eta  \\right )} \\cosh{\\left (\\xi  \\right )} \\left|{a}\\right|}{a^{2} \\left({\\sin{\\left (\\eta  \\right )}}^{2} + {\\sinh{\\left (\\xi  \\right )}}^{2}\\right)^{3} \\sin{\\left (\\eta  \\right )} \\sinh{\\left (\\xi  \\right )}} \\end{equation*}\n",
+       "\\begin{equation*} \\boldsymbol{\\nabla}  f = \\frac{\\partial_{\\xi } f }{\\sqrt{- {\\cos{\\left (\\eta  \\right )}}^{2} + {\\cosh{\\left (\\xi  \\right )}}^{2}} \\left|{a}\\right|} \\boldsymbol{e}_{\\xi } + \\frac{\\partial_{\\eta } f }{\\sqrt{- {\\cos{\\left (\\eta  \\right )}}^{2} + {\\cosh{\\left (\\xi  \\right )}}^{2}} \\left|{a}\\right|} \\boldsymbol{e}_{\\eta } + \\frac{\\partial_{\\phi } f }{a \\sin{\\left (\\eta  \\right )} \\sinh{\\left (\\xi  \\right )}} \\boldsymbol{e}_{\\phi } \\end{equation*}\n",
+       "\\begin{equation*} \\boldsymbol{\\nabla} \\cdot A = \\frac{A^{\\eta } }{\\sqrt{- {\\cos{\\left (\\eta  \\right )}}^{2} + {\\cosh{\\left (\\xi  \\right )}}^{2}} \\tan{\\left (\\eta  \\right )} \\left|{a}\\right|} + \\frac{A^{\\xi } }{\\sqrt{- {\\cos{\\left (\\eta  \\right )}}^{2} + {\\cosh{\\left (\\xi  \\right )}}^{2}} \\tanh{\\left (\\xi  \\right )} \\left|{a}\\right|} + \\frac{\\partial_{\\eta } A^{\\eta } }{\\sqrt{- {\\cos{\\left (\\eta  \\right )}}^{2} + {\\cosh{\\left (\\xi  \\right )}}^{2}} \\left|{a}\\right|} + \\frac{\\partial_{\\xi } A^{\\xi } }{\\sqrt{- {\\cos{\\left (\\eta  \\right )}}^{2} + {\\cosh{\\left (\\xi  \\right )}}^{2}} \\left|{a}\\right|} + \\frac{A^{\\eta }  \\sin{\\left (\\eta  \\right )} \\cos{\\left (\\eta  \\right )}}{\\left(- \\left(\\cos{\\left (\\eta  \\right )} - \\cosh{\\left (\\xi  \\right )}\\right) \\left(\\cos{\\left (\\eta  \\right )} + \\cosh{\\left (\\xi  \\right )}\\right)\\right)^{\\frac{3}{2}} \\left|{a}\\right|} + \\frac{A^{\\xi }  \\sinh{\\left (\\xi  \\right )} \\cosh{\\left (\\xi  \\right )}}{\\left(- \\left(\\cos{\\left (\\eta  \\right )} - \\cosh{\\left (\\xi  \\right )}\\right) \\left(\\cos{\\left (\\eta  \\right )} + \\cosh{\\left (\\xi  \\right )}\\right)\\right)^{\\frac{3}{2}} \\left|{a}\\right|} + \\frac{\\partial_{\\phi } A^{\\phi } }{a \\sin{\\left (\\eta  \\right )} \\sinh{\\left (\\xi  \\right )}} \\end{equation*}\n",
        "\\end{document}\n"
       ]
      },
@@ -179,7 +200,14 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-03T17:49:53.565682Z",
+     "iopub.status.busy": "2026-04-03T17:49:53.565569Z",
+     "iopub.status.idle": "2026-04-03T17:49:53.973148Z",
+     "shell.execute_reply": "2026-04-03T17:49:53.972422Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -249,7 +277,14 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-03T17:49:53.975051Z",
+     "iopub.status.busy": "2026-04-03T17:49:53.974968Z",
+     "iopub.status.idle": "2026-04-03T17:49:54.513698Z",
+     "shell.execute_reply": "2026-04-03T17:49:54.512921Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -327,7 +362,7 @@
        "\\begin{equation*} A = \\left\\{ \\begin{aligned} \\boldsymbol{e}_{a} &\\mapsto a c^{2} x \\boldsymbol{e}_{a} + a b c x^{2} \\boldsymbol{e}_{b} + a^{3} b^{5} x^{2} \\boldsymbol{e}_{c} \\\\ \\boldsymbol{e}_{b} &\\mapsto a^{2} b c x^{3} \\boldsymbol{e}_{a} + a b^{2} c^{5} x^{4} \\boldsymbol{e}_{b} + 5 a b^{2} c x^{4} \\boldsymbol{e}_{c} \\\\ \\boldsymbol{e}_{c} &\\mapsto a b^{2} c^{4} x^{4} \\boldsymbol{e}_{a} + 4 a b^{2} c^{2} x^{4} \\boldsymbol{e}_{b} + 4 a^{5} b^{2} c x^{4} \\boldsymbol{e}_{c} \\end{aligned} \\right\\} \\end{equation*}\n",
        "\\begin{equation*} v = a \\boldsymbol{e}_{a} + b \\boldsymbol{e}_{b} + c \\boldsymbol{e}_{c} \\end{equation*}\n",
        "\\begin{equation*} f = v\\cdot \\f{A}{v} = a c x \\left(4 a^{4} b^{2} c^{2} x^{3} + a^{3} b^{5} x + a^{2} b^{2} x^{2} + a^{2} c + a b^{2} c^{4} x^{3} + a b^{2} x + b^{4} c^{4} x^{3} + 4 b^{3} c^{2} x^{3} + 5 b^{3} c x^{3}\\right) \\end{equation*}\n",
-       "\\begin{equation*} \\f{A}{v} = a c x \\left(a b^{2} x^{2} + a c + b^{2} c^{4} x^{3}\\right) \\boldsymbol{e}_{a} + a b c x^{2} \\left(a + b^{2} c^{4} x^{2} + 4 b c^{2} x^{2}\\right) \\boldsymbol{e}_{b} + a b^{2} x^{2} \\cdot \\left(4 a^{4} c^{2} x^{2} + a^{3} b^{3} + 5 b c x^{2}\\right) \\boldsymbol{e}_{c} \\end{equation*}\n",
+       "\\begin{equation*} \\f{A}{v} = a c x \\left(a b^{2} x^{2} + a c + b^{2} c^{4} x^{3}\\right) \\boldsymbol{e}_{a} + a b c x^{2} \\left(a + b^{2} c^{4} x^{2} + 4 b c^{2} x^{2}\\right) \\boldsymbol{e}_{b} + a b^{2} x^{2} \\left(4 a^{4} c^{2} x^{2} + a^{3} b^{3} + 5 b c x^{2}\\right) \\boldsymbol{e}_{c} \\end{equation*}\n",
        "\\end{document}\n"
       ]
      },
@@ -342,7 +377,14 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-03T17:49:54.515309Z",
+     "iopub.status.busy": "2026-04-03T17:49:54.515207Z",
+     "iopub.status.idle": "2026-04-03T17:49:54.965260Z",
+     "shell.execute_reply": "2026-04-03T17:49:54.964559Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -412,7 +454,14 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-03T17:49:54.966919Z",
+     "iopub.status.busy": "2026-04-03T17:49:54.966843Z",
+     "iopub.status.idle": "2026-04-03T17:49:55.647721Z",
+     "shell.execute_reply": "2026-04-03T17:49:55.647012Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -493,7 +542,14 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-03T17:49:55.649256Z",
+     "iopub.status.busy": "2026-04-03T17:49:55.649169Z",
+     "iopub.status.idle": "2026-04-03T17:49:56.767768Z",
+     "shell.execute_reply": "2026-04-03T17:49:56.767023Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -579,7 +635,14 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-03T17:49:56.769787Z",
+     "iopub.status.busy": "2026-04-03T17:49:56.769651Z",
+     "iopub.status.idle": "2026-04-03T17:49:57.126199Z",
+     "shell.execute_reply": "2026-04-03T17:49:57.125390Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -652,7 +715,14 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-03T17:49:57.127557Z",
+     "iopub.status.busy": "2026-04-03T17:49:57.127483Z",
+     "iopub.status.idle": "2026-04-03T17:49:57.824486Z",
+     "shell.execute_reply": "2026-04-03T17:49:57.823874Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -811,7 +881,14 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-03T17:49:57.826321Z",
+     "iopub.status.busy": "2026-04-03T17:49:57.826168Z",
+     "iopub.status.idle": "2026-04-03T17:50:00.991291Z",
+     "shell.execute_reply": "2026-04-03T17:50:00.990396Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -1454,122 +1531,48 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-03T17:50:00.993402Z",
+     "iopub.status.busy": "2026-04-03T17:50:00.993296Z",
+     "iopub.status.idle": "2026-04-03T17:50:01.563120Z",
+     "shell.execute_reply": "2026-04-03T17:50:01.562598Z"
+    }
+   },
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "\n",
-       "\\documentclass[10pt,fleqn]{report}\n",
-       "\\usepackage[vcentering]{geometry}\n",
-       "\\geometry{papersize={14in,11in},total={13in,10in}}\n",
-       "\n",
-       "\\pagestyle{empty}\n",
-       "\\usepackage[latin1]{inputenc}\n",
-       "\\usepackage{amsmath}\n",
-       "\\usepackage{amsfonts}\n",
-       "\\usepackage{amssymb}\n",
-       "\\usepackage{amsbsy}\n",
-       "\\usepackage{tensor}\n",
-       "\\usepackage{listings}\n",
-       "\\usepackage{color}\n",
-       "\\usepackage{xcolor}\n",
-       "\\usepackage{bm}\n",
-       "\\usepackage{breqn}\n",
-       "\\definecolor{gray}{rgb}{0.95,0.95,0.95}\n",
-       "\\setlength{\\parindent}{0pt}\n",
-       "\\DeclareMathOperator{\\Tr}{Tr}\n",
-       "\\DeclareMathOperator{\\Adj}{Adj}\n",
-       "\\newcommand{\\bfrac}[2]{\\displaystyle\\frac{#1}{#2}}\n",
-       "\\newcommand{\\lp}{\\left (}\n",
-       "\\newcommand{\\rp}{\\right )}\n",
-       "\\newcommand{\\paren}[1]{\\lp {#1} \\rp}\n",
-       "\\newcommand{\\half}{\\frac{1}{2}}\n",
-       "\\newcommand{\\llt}{\\left <}\n",
-       "\\newcommand{\\rgt}{\\right >}\n",
-       "\\newcommand{\\abs}[1]{\\left |{#1}\\right | }\n",
-       "\\newcommand{\\pdiff}[2]{\\bfrac{\\partial {#1}}{\\partial {#2}}}\n",
-       "\\newcommand{\\lbrc}{\\left \\{}\n",
-       "\\newcommand{\\rbrc}{\\right \\}}\n",
-       "\\newcommand{\\W}{\\wedge}\n",
-       "\\newcommand{\\prm}[1]{{#1}'}\n",
-       "\\newcommand{\\ddt}[1]{\\bfrac{d{#1}}{dt}}\n",
-       "\\newcommand{\\R}{\\dagger}\n",
-       "\\newcommand{\\deriv}[3]{\\bfrac{d^{#3}#1}{d{#2}^{#3}}}\n",
-       "\\newcommand{\\grade}[1]{\\left < {#1} \\right >}\n",
-       "\\newcommand{\\f}[2]{{#1}\\lp{#2}\\rp}\n",
-       "\\newcommand{\\eval}[2]{\\left . {#1} \\right |_{#2}}\n",
-       "\\newcommand{\\Nabla}{\\boldsymbol{\\nabla}}\n",
-       "\\newcommand{\\eb}{\\boldsymbol{e}}\n",
-       "\\usepackage{float}\n",
-       "\\floatstyle{plain} % optionally change the style of the new float\n",
-       "\\newfloat{Code}{H}{myc}\n",
-       "\\lstloadlanguages{Python}\n",
-       "\n",
-       "\\begin{document}\n",
-       "3d orthogonal ($A$ is vector function)\n",
-       "\\begin{equation*} A = A^{x}  \\boldsymbol{e}_{x} + A^{y}  \\boldsymbol{e}_{y} + A^{z}  \\boldsymbol{e}_{z} \\end{equation*}\n",
-       "\\begin{equation*} A^{2} = {A^{x} }^{2} + {A^{y} }^{2} + {A^{z} }^{2} \\end{equation*}\n",
-       "\\begin{equation*} \\boldsymbol{\\nabla} \\cdot A = \\partial_{x} A^{x}  + \\partial_{y} A^{y}  + \\partial_{z} A^{z} \\end{equation*}\n",
-       "\\begin{equation*} \\boldsymbol{\\nabla}  A = \\left ( \\partial_{x} A^{x}  + \\partial_{y} A^{y}  + \\partial_{z} A^{z} \\right )  + \\left ( - \\partial_{y} A^{x}  + \\partial_{x} A^{y} \\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + \\left ( - \\partial_{z} A^{x}  + \\partial_{x} A^{z} \\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + \\left ( - \\partial_{z} A^{y}  + \\partial_{y} A^{z} \\right ) \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} \\end{equation*}\n",
-       "\\begin{equation*} v\\cdot (\\boldsymbol{\\nabla}  A) = \\left ( v^{y} \\partial_{y} A^{x}  - v^{y} \\partial_{x} A^{y}  + v^{z} \\partial_{z} A^{x}  - v^{z} \\partial_{x} A^{z} \\right ) \\boldsymbol{e}_{x} + \\left ( - v^{x} \\partial_{y} A^{x}  + v^{x} \\partial_{x} A^{y}  + v^{z} \\partial_{z} A^{y}  - v^{z} \\partial_{y} A^{z} \\right ) \\boldsymbol{e}_{y} + \\left ( - v^{x} \\partial_{z} A^{x}  + v^{x} \\partial_{x} A^{z}  - v^{y} \\partial_{z} A^{y}  + v^{y} \\partial_{y} A^{z} \\right ) \\boldsymbol{e}_{z} \\end{equation*}\n",
-       "2d general ($A$ is vector function)\n",
-       "\\begin{equation*} A = A^{u}  \\boldsymbol{e}_{u} + A^{v}  \\boldsymbol{e}_{v} \\end{equation*}\n",
-       "\\begin{equation*} A^{2} = \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{u}\\right )  {A^{u} }^{2} + 2 \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right )  A^{u}  A^{v}  + \\left (\\boldsymbol{e}_{v}\\cdot \\boldsymbol{e}_{v}\\right )  {A^{v} }^{2} \\end{equation*}\n",
-       "\\begin{equation*} \\boldsymbol{\\nabla} \\cdot A = \\partial_{u} A^{u}  + \\partial_{v} A^{v} \\end{equation*}\n",
-       "\\begin{equation*} \\boldsymbol{\\nabla}  A = \\left ( \\partial_{u} A^{u}  + \\partial_{v} A^{v} \\right )  + \\frac{- \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{u}\\right )  \\partial_{v} A^{u}  + \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right )  \\partial_{u} A^{u}  - \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right )  \\partial_{v} A^{v}  + \\left (\\boldsymbol{e}_{v}\\cdot \\boldsymbol{e}_{v}\\right )  \\partial_{u} A^{v} }{\\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{u}\\right )  \\left (\\boldsymbol{e}_{v}\\cdot \\boldsymbol{e}_{v}\\right )  - \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right ) ^{2}} \\boldsymbol{e}_{u}\\wedge \\boldsymbol{e}_{v} \\end{equation*}\n",
-       "3d orthogonal ($A,\\;B$ are linear transformations)\n",
-       "\\begin{equation*} A = \\left\\{ \\begin{aligned} \\boldsymbol{e}_{x} &\\mapsto {A^{x}}_{x} \\boldsymbol{e}_{x} + {A^{y}}_{x} \\boldsymbol{e}_{y} + {A^{z}}_{x} \\boldsymbol{e}_{z} \\\\ \\boldsymbol{e}_{y} &\\mapsto {A^{x}}_{y} \\boldsymbol{e}_{x} + {A^{y}}_{y} \\boldsymbol{e}_{y} + {A^{z}}_{y} \\boldsymbol{e}_{z} \\\\ \\boldsymbol{e}_{z} &\\mapsto {A^{x}}_{z} \\boldsymbol{e}_{x} + {A^{y}}_{z} \\boldsymbol{e}_{y} + {A^{z}}_{z} \\boldsymbol{e}_{z} \\end{aligned} \\right\\} \\end{equation*}\n",
-       "\\begin{equation*} \\f{mat}{A} = \\left[\\begin{array}{ccc}{A^{x}}_{x} & {A^{x}}_{y} & {A^{x}}_{z}\\\\{A^{y}}_{x} & {A^{y}}_{y} & {A^{y}}_{z}\\\\{A^{z}}_{x} & {A^{z}}_{y} & {A^{z}}_{z}\\end{array}\\right] \\end{equation*}\n",
-       "\\begin{equation*} \\f{\\det}{A} = {A^{x}}_{x} {A^{y}}_{y} {A^{z}}_{z} - {A^{x}}_{x} {A^{y}}_{z} {A^{z}}_{y} - {A^{x}}_{y} {A^{y}}_{x} {A^{z}}_{z} + {A^{x}}_{y} {A^{y}}_{z} {A^{z}}_{x} + {A^{x}}_{z} {A^{y}}_{x} {A^{z}}_{y} - {A^{x}}_{z} {A^{y}}_{y} {A^{z}}_{x} \\end{equation*}\n",
-       "\\begin{equation*} \\overline{A} = \\left\\{ \\begin{aligned} \\boldsymbol{e}_{x} &\\mapsto {A^{x}}_{x} \\boldsymbol{e}_{x} + {A^{x}}_{y} \\boldsymbol{e}_{y} + {A^{x}}_{z} \\boldsymbol{e}_{z} \\\\ \\boldsymbol{e}_{y} &\\mapsto {A^{y}}_{x} \\boldsymbol{e}_{x} + {A^{y}}_{y} \\boldsymbol{e}_{y} + {A^{y}}_{z} \\boldsymbol{e}_{z} \\\\ \\boldsymbol{e}_{z} &\\mapsto {A^{z}}_{x} \\boldsymbol{e}_{x} + {A^{z}}_{y} \\boldsymbol{e}_{y} + {A^{z}}_{z} \\boldsymbol{e}_{z} \\end{aligned} \\right\\} \\end{equation*}\n",
-       "\\begin{equation*} \\f{\\Tr}{A} = {A^{x}}_{x} + {A^{y}}_{y} + {A^{z}}_{z} \\end{equation*}\n",
-       "\\begin{equation*} \\f{A}{e_x\\W e_y} = \\left ( {A^{x}}_{x} {A^{y}}_{y} - {A^{x}}_{y} {A^{y}}_{x}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + \\left ( {A^{x}}_{x} {A^{z}}_{y} - {A^{x}}_{y} {A^{z}}_{x}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + \\left ( {A^{y}}_{x} {A^{z}}_{y} - {A^{y}}_{y} {A^{z}}_{x}\\right ) \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} \\end{equation*}\n",
-       "\\begin{equation*} \\f{A}{e_x}\\W \\f{A}{e_y} = \\left ( {A^{x}}_{x} {A^{y}}_{y} - {A^{x}}_{y} {A^{y}}_{x}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{y} + \\left ( {A^{x}}_{x} {A^{z}}_{y} - {A^{x}}_{y} {A^{z}}_{x}\\right ) \\boldsymbol{e}_{x}\\wedge \\boldsymbol{e}_{z} + \\left ( {A^{y}}_{x} {A^{z}}_{y} - {A^{y}}_{y} {A^{z}}_{x}\\right ) \\boldsymbol{e}_{y}\\wedge \\boldsymbol{e}_{z} \\end{equation*}\n",
-       "\\begin{equation*} g = \\left[\\begin{array}{ccc}1 & 0 & 0\\\\0 & 1 & 0\\\\0 & 0 & 1\\end{array}\\right] \\end{equation*}\n",
-       "\\begin{equation*} g^{-1} = \\left[\\begin{array}{ccc}1 & 0 & 0\\\\0 & 1 & 0\\\\0 & 0 & 1\\end{array}\\right] \\end{equation*}\n",
-       "\\begin{equation*} A + B = \\left\\{ \\begin{aligned} \\boldsymbol{e}_{x} &\\mapsto \\left ( {A^{x}}_{x} + {B^{x}}_{x}\\right ) \\boldsymbol{e}_{x} + \\left ( {A^{y}}_{x} + {B^{y}}_{x}\\right ) \\boldsymbol{e}_{y} + \\left ( {A^{z}}_{x} + {B^{z}}_{x}\\right ) \\boldsymbol{e}_{z} \\\\ \\boldsymbol{e}_{y} &\\mapsto \\left ( {A^{x}}_{y} + {B^{x}}_{y}\\right ) \\boldsymbol{e}_{x} + \\left ( {A^{y}}_{y} + {B^{y}}_{y}\\right ) \\boldsymbol{e}_{y} + \\left ( {A^{z}}_{y} + {B^{z}}_{y}\\right ) \\boldsymbol{e}_{z} \\\\ \\boldsymbol{e}_{z} &\\mapsto \\left ( {A^{x}}_{z} + {B^{x}}_{z}\\right ) \\boldsymbol{e}_{x} + \\left ( {A^{y}}_{z} + {B^{y}}_{z}\\right ) \\boldsymbol{e}_{y} + \\left ( {A^{z}}_{z} + {B^{z}}_{z}\\right ) \\boldsymbol{e}_{z} \\end{aligned} \\right\\} \\end{equation*}\n",
-       "\\begin{equation*} AB = \\left\\{ \\begin{aligned} \\boldsymbol{e}_{x} &\\mapsto \\left ( {A^{x}}_{x} {B^{x}}_{x} + {A^{x}}_{y} {B^{y}}_{x} + {A^{x}}_{z} {B^{z}}_{x}\\right ) \\boldsymbol{e}_{x} + \\left ( {A^{y}}_{x} {B^{x}}_{x} + {A^{y}}_{y} {B^{y}}_{x} + {A^{y}}_{z} {B^{z}}_{x}\\right ) \\boldsymbol{e}_{y} + \\left ( {A^{z}}_{x} {B^{x}}_{x} + {A^{z}}_{y} {B^{y}}_{x} + {A^{z}}_{z} {B^{z}}_{x}\\right ) \\boldsymbol{e}_{z} \\\\ \\boldsymbol{e}_{y} &\\mapsto \\left ( {A^{x}}_{x} {B^{x}}_{y} + {A^{x}}_{y} {B^{y}}_{y} + {A^{x}}_{z} {B^{z}}_{y}\\right ) \\boldsymbol{e}_{x} + \\left ( {A^{y}}_{x} {B^{x}}_{y} + {A^{y}}_{y} {B^{y}}_{y} + {A^{y}}_{z} {B^{z}}_{y}\\right ) \\boldsymbol{e}_{y} + \\left ( {A^{z}}_{x} {B^{x}}_{y} + {A^{z}}_{y} {B^{y}}_{y} + {A^{z}}_{z} {B^{z}}_{y}\\right ) \\boldsymbol{e}_{z} \\\\ \\boldsymbol{e}_{z} &\\mapsto \\left ( {A^{x}}_{x} {B^{x}}_{z} + {A^{x}}_{y} {B^{y}}_{z} + {A^{x}}_{z} {B^{z}}_{z}\\right ) \\boldsymbol{e}_{x} + \\left ( {A^{y}}_{x} {B^{x}}_{z} + {A^{y}}_{y} {B^{y}}_{z} + {A^{y}}_{z} {B^{z}}_{z}\\right ) \\boldsymbol{e}_{y} + \\left ( {A^{z}}_{x} {B^{x}}_{z} + {A^{z}}_{y} {B^{y}}_{z} + {A^{z}}_{z} {B^{z}}_{z}\\right ) \\boldsymbol{e}_{z} \\end{aligned} \\right\\} \\end{equation*}\n",
-       "\\begin{equation*} A - B = \\left\\{ \\begin{aligned} \\boldsymbol{e}_{x} &\\mapsto \\left ( {A^{x}}_{x} - {B^{x}}_{x}\\right ) \\boldsymbol{e}_{x} + \\left ( {A^{y}}_{x} - {B^{y}}_{x}\\right ) \\boldsymbol{e}_{y} + \\left ( {A^{z}}_{x} - {B^{z}}_{x}\\right ) \\boldsymbol{e}_{z} \\\\ \\boldsymbol{e}_{y} &\\mapsto \\left ( {A^{x}}_{y} - {B^{x}}_{y}\\right ) \\boldsymbol{e}_{x} + \\left ( {A^{y}}_{y} - {B^{y}}_{y}\\right ) \\boldsymbol{e}_{y} + \\left ( {A^{z}}_{y} - {B^{z}}_{y}\\right ) \\boldsymbol{e}_{z} \\\\ \\boldsymbol{e}_{z} &\\mapsto \\left ( {A^{x}}_{z} - {B^{x}}_{z}\\right ) \\boldsymbol{e}_{x} + \\left ( {A^{y}}_{z} - {B^{y}}_{z}\\right ) \\boldsymbol{e}_{y} + \\left ( {A^{z}}_{z} - {B^{z}}_{z}\\right ) \\boldsymbol{e}_{z} \\end{aligned} \\right\\} \\end{equation*}\n",
-       "\\begin{equation*} General Symmetric Linear Transformation \\end{equation*}\n",
-       "\\begin{equation*} A = \\left\\{ \\begin{aligned} \\boldsymbol{e}_{x} &\\mapsto A_{1} \\boldsymbol{e}_{x} + A_{2} \\boldsymbol{e}_{y} + A_{3} \\boldsymbol{e}_{z} \\\\ \\boldsymbol{e}_{y} &\\mapsto A_{2} \\boldsymbol{e}_{x} + A_{4} \\boldsymbol{e}_{y} + A_{5} \\boldsymbol{e}_{z} \\\\ \\boldsymbol{e}_{z} &\\mapsto A_{3} \\boldsymbol{e}_{x} + A_{5} \\boldsymbol{e}_{y} + A_{6} \\boldsymbol{e}_{z} \\end{aligned} \\right\\} \\end{equation*}\n",
-       "\\begin{equation*} General Antisymmetric Linear Transformation \\end{equation*}\n",
-       "\\begin{equation*} A = \\left\\{ \\begin{aligned} \\boldsymbol{e}_{x} &\\mapsto - A_{1} \\boldsymbol{e}_{y} - A_{2} \\boldsymbol{e}_{z} \\\\ \\boldsymbol{e}_{y} &\\mapsto A_{1} \\boldsymbol{e}_{x} - A_{3} \\boldsymbol{e}_{z} \\\\ \\boldsymbol{e}_{z} &\\mapsto A_{2} \\boldsymbol{e}_{x} + A_{3} \\boldsymbol{e}_{y} \\end{aligned} \\right\\} \\end{equation*}\n",
-       "2d general ($A,\\;B$ are linear transformations)\n",
-       "\\begin{equation*} g = \\left[\\begin{array}{cc}\\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{u}\\right )  & \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right ) \\\\\\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right )  & \\left (\\boldsymbol{e}_{v}\\cdot \\boldsymbol{e}_{v}\\right ) \\end{array}\\right] \\end{equation*}\n",
-       "\\begin{equation*} g^{-1} = \\left[\\begin{array}{cc}\\frac{\\left (\\boldsymbol{e}_{v}\\cdot \\boldsymbol{e}_{v}\\right ) }{\\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{u}\\right )  \\left (\\boldsymbol{e}_{v}\\cdot \\boldsymbol{e}_{v}\\right )  - \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right ) ^{2}} & - \\frac{\\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right ) }{\\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{u}\\right )  \\left (\\boldsymbol{e}_{v}\\cdot \\boldsymbol{e}_{v}\\right )  - \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right ) ^{2}}\\\\- \\frac{\\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right ) }{\\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{u}\\right )  \\left (\\boldsymbol{e}_{v}\\cdot \\boldsymbol{e}_{v}\\right )  - \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right ) ^{2}} & \\frac{\\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{u}\\right ) }{\\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{u}\\right )  \\left (\\boldsymbol{e}_{v}\\cdot \\boldsymbol{e}_{v}\\right )  - \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right ) ^{2}}\\end{array}\\right] \\end{equation*}\n",
-       "\\begin{equation*} gg^{-1} = \\left[\\begin{array}{cc}1 & 0\\\\0 & 1\\end{array}\\right] \\end{equation*}\n",
-       "\\begin{equation*} A = \\left\\{ \\begin{aligned} \\boldsymbol{e}_{u} &\\mapsto {A^{u}}_{u} \\boldsymbol{e}_{u} + {A^{v}}_{u} \\boldsymbol{e}_{v} \\\\ \\boldsymbol{e}_{v} &\\mapsto {A^{u}}_{v} \\boldsymbol{e}_{u} + {A^{v}}_{v} \\boldsymbol{e}_{v} \\end{aligned} \\right\\} \\end{equation*}\n",
-       "\\begin{equation*} \\f{mat}{A} = \\left[\\begin{array}{cc}{A^{u}}_{u} & {A^{u}}_{v}\\\\{A^{v}}_{u} & {A^{v}}_{v}\\end{array}\\right] \\end{equation*}\n",
-       "\\begin{equation*} \\f{\\det}{A} = - \\frac{\\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{u}\\right )  \\left (\\boldsymbol{e}_{v}\\cdot \\boldsymbol{e}_{v}\\right )  {A^{u}}_{u} {A^{v}}_{v}}{- \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{u}\\right )  \\left (\\boldsymbol{e}_{v}\\cdot \\boldsymbol{e}_{v}\\right )  + \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right ) ^{2}} + \\frac{\\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{u}\\right )  \\left (\\boldsymbol{e}_{v}\\cdot \\boldsymbol{e}_{v}\\right )  {A^{u}}_{v} {A^{v}}_{u}}{- \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{u}\\right )  \\left (\\boldsymbol{e}_{v}\\cdot \\boldsymbol{e}_{v}\\right )  + \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right ) ^{2}} + \\frac{\\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right ) ^{2} {A^{u}}_{u} {A^{v}}_{v}}{- \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{u}\\right )  \\left (\\boldsymbol{e}_{v}\\cdot \\boldsymbol{e}_{v}\\right )  + \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right ) ^{2}} - \\frac{\\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right ) ^{2} {A^{u}}_{v} {A^{v}}_{u}}{- \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{u}\\right )  \\left (\\boldsymbol{e}_{v}\\cdot \\boldsymbol{e}_{v}\\right )  + \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right ) ^{2}} \\end{equation*}\n",
-       "\\begin{equation*} \\overline{A} = \\left\\{ \\begin{aligned} \\boldsymbol{e}_{u} &\\mapsto \\frac{- \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{u}\\right )  \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right )  {A^{u}}_{v} + \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{u}\\right )  \\left (\\boldsymbol{e}_{v}\\cdot \\boldsymbol{e}_{v}\\right )  {A^{u}}_{u} - \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right ) ^{2} {A^{v}}_{v} + \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right )  \\left (\\boldsymbol{e}_{v}\\cdot \\boldsymbol{e}_{v}\\right )  {A^{v}}_{u}}{\\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{u}\\right )  \\left (\\boldsymbol{e}_{v}\\cdot \\boldsymbol{e}_{v}\\right )  - \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right ) ^{2}} \\boldsymbol{e}_{u} + \\frac{\\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{u}\\right ) ^{2} {A^{u}}_{v} - \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{u}\\right )  \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right )  {A^{u}}_{u} + \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{u}\\right )  \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right )  {A^{v}}_{v} - \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right ) ^{2} {A^{v}}_{u}}{\\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{u}\\right )  \\left (\\boldsymbol{e}_{v}\\cdot \\boldsymbol{e}_{v}\\right )  - \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right ) ^{2}} \\boldsymbol{e}_{v} \\\\ \\boldsymbol{e}_{v} &\\mapsto \\frac{- \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right ) ^{2} {A^{u}}_{v} + \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right )  \\left (\\boldsymbol{e}_{v}\\cdot \\boldsymbol{e}_{v}\\right )  {A^{u}}_{u} - \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right )  \\left (\\boldsymbol{e}_{v}\\cdot \\boldsymbol{e}_{v}\\right )  {A^{v}}_{v} + \\left (\\boldsymbol{e}_{v}\\cdot \\boldsymbol{e}_{v}\\right ) ^{2} {A^{v}}_{u}}{\\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{u}\\right )  \\left (\\boldsymbol{e}_{v}\\cdot \\boldsymbol{e}_{v}\\right )  - \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right ) ^{2}} \\boldsymbol{e}_{u} + \\frac{\\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{u}\\right )  \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right )  {A^{u}}_{v} + \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{u}\\right )  \\left (\\boldsymbol{e}_{v}\\cdot \\boldsymbol{e}_{v}\\right )  {A^{v}}_{v} - \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right ) ^{2} {A^{u}}_{u} - \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right )  \\left (\\boldsymbol{e}_{v}\\cdot \\boldsymbol{e}_{v}\\right )  {A^{v}}_{u}}{\\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{u}\\right )  \\left (\\boldsymbol{e}_{v}\\cdot \\boldsymbol{e}_{v}\\right )  - \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right ) ^{2}} \\boldsymbol{e}_{v} \\end{aligned} \\right\\} \\end{equation*}\n",
-       "\\begin{equation*} \\f{mat}{\\overline{A}} = \\left[\\begin{array}{cc}\\frac{- \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{u}\\right )  \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right )  {A^{u}}_{v} + \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{u}\\right )  \\left (\\boldsymbol{e}_{v}\\cdot \\boldsymbol{e}_{v}\\right )  {A^{u}}_{u} - \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right ) ^{2} {A^{v}}_{v} + \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right )  \\left (\\boldsymbol{e}_{v}\\cdot \\boldsymbol{e}_{v}\\right )  {A^{v}}_{u}}{\\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{u}\\right )  \\left (\\boldsymbol{e}_{v}\\cdot \\boldsymbol{e}_{v}\\right )  - \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right ) ^{2}} & \\frac{- \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right ) ^{2} {A^{u}}_{v} + \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right )  \\left (\\boldsymbol{e}_{v}\\cdot \\boldsymbol{e}_{v}\\right )  {A^{u}}_{u} - \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right )  \\left (\\boldsymbol{e}_{v}\\cdot \\boldsymbol{e}_{v}\\right )  {A^{v}}_{v} + \\left (\\boldsymbol{e}_{v}\\cdot \\boldsymbol{e}_{v}\\right ) ^{2} {A^{v}}_{u}}{\\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{u}\\right )  \\left (\\boldsymbol{e}_{v}\\cdot \\boldsymbol{e}_{v}\\right )  - \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right ) ^{2}}\\\\\\frac{\\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{u}\\right ) ^{2} {A^{u}}_{v} - \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{u}\\right )  \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right )  {A^{u}}_{u} + \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{u}\\right )  \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right )  {A^{v}}_{v} - \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right ) ^{2} {A^{v}}_{u}}{\\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{u}\\right )  \\left (\\boldsymbol{e}_{v}\\cdot \\boldsymbol{e}_{v}\\right )  - \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right ) ^{2}} & \\frac{\\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{u}\\right )  \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right )  {A^{u}}_{v} + \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{u}\\right )  \\left (\\boldsymbol{e}_{v}\\cdot \\boldsymbol{e}_{v}\\right )  {A^{v}}_{v} - \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right ) ^{2} {A^{u}}_{u} - \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right )  \\left (\\boldsymbol{e}_{v}\\cdot \\boldsymbol{e}_{v}\\right )  {A^{v}}_{u}}{\\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{u}\\right )  \\left (\\boldsymbol{e}_{v}\\cdot \\boldsymbol{e}_{v}\\right )  - \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right ) ^{2}}\\end{array}\\right] \\end{equation*}\n",
-       "\\begin{equation*} \\f{\\Tr}{A} = - \\frac{\\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{u}\\right )  \\left (\\boldsymbol{e}_{v}\\cdot \\boldsymbol{e}_{v}\\right )  {A^{u}}_{u}}{- \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{u}\\right )  \\left (\\boldsymbol{e}_{v}\\cdot \\boldsymbol{e}_{v}\\right )  + \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right ) ^{2}} - \\frac{\\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{u}\\right )  \\left (\\boldsymbol{e}_{v}\\cdot \\boldsymbol{e}_{v}\\right )  {A^{v}}_{v}}{- \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{u}\\right )  \\left (\\boldsymbol{e}_{v}\\cdot \\boldsymbol{e}_{v}\\right )  + \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right ) ^{2}} + \\frac{\\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right ) ^{2} {A^{u}}_{u}}{- \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{u}\\right )  \\left (\\boldsymbol{e}_{v}\\cdot \\boldsymbol{e}_{v}\\right )  + \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right ) ^{2}} + \\frac{\\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right ) ^{2} {A^{v}}_{v}}{- \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{u}\\right )  \\left (\\boldsymbol{e}_{v}\\cdot \\boldsymbol{e}_{v}\\right )  + \\left (\\boldsymbol{e}_{u}\\cdot \\boldsymbol{e}_{v}\\right ) ^{2}} \\end{equation*}\n",
-       "\\begin{equation*} \\f{A}{e_u\\W e_v} = \\left ( {A^{u}}_{u} {A^{v}}_{v} - {A^{u}}_{v} {A^{v}}_{u}\\right ) \\boldsymbol{e}_{u}\\wedge \\boldsymbol{e}_{v} \\end{equation*}\n",
-       "\\begin{equation*} \\f{A}{e_u}\\W \\f{A}{e_v} = \\left ( {A^{u}}_{u} {A^{v}}_{v} - {A^{u}}_{v} {A^{v}}_{u}\\right ) \\boldsymbol{e}_{u}\\wedge \\boldsymbol{e}_{v} \\end{equation*}\n",
-       "\\begin{equation*} B = \\left\\{ \\begin{aligned} \\boldsymbol{e}_{u} &\\mapsto {B^{u}}_{u} \\boldsymbol{e}_{u} + {B^{v}}_{u} \\boldsymbol{e}_{v} \\\\ \\boldsymbol{e}_{v} &\\mapsto {B^{u}}_{v} \\boldsymbol{e}_{u} + {B^{v}}_{v} \\boldsymbol{e}_{v} \\end{aligned} \\right\\} \\end{equation*}\n",
-       "\\begin{equation*} A + B = \\left\\{ \\begin{aligned} \\boldsymbol{e}_{u} &\\mapsto \\left ( {A^{u}}_{u} + {B^{u}}_{u}\\right ) \\boldsymbol{e}_{u} + \\left ( {A^{v}}_{u} + {B^{v}}_{u}\\right ) \\boldsymbol{e}_{v} \\\\ \\boldsymbol{e}_{v} &\\mapsto \\left ( {A^{u}}_{v} + {B^{u}}_{v}\\right ) \\boldsymbol{e}_{u} + \\left ( {A^{v}}_{v} + {B^{v}}_{v}\\right ) \\boldsymbol{e}_{v} \\end{aligned} \\right\\} \\end{equation*}\n",
-       "\\begin{equation*} A - B = \\left\\{ \\begin{aligned} \\boldsymbol{e}_{u} &\\mapsto \\left ( {A^{u}}_{u} - {B^{u}}_{u}\\right ) \\boldsymbol{e}_{u} + \\left ( {A^{v}}_{u} - {B^{v}}_{u}\\right ) \\boldsymbol{e}_{v} \\\\ \\boldsymbol{e}_{v} &\\mapsto \\left ( {A^{u}}_{v} - {B^{u}}_{v}\\right ) \\boldsymbol{e}_{u} + \\left ( {A^{v}}_{v} - {B^{v}}_{v}\\right ) \\boldsymbol{e}_{v} \\end{aligned} \\right\\} \\end{equation*}\n",
-       "\\begin{equation*} a\\cdot \\f{\\overline{A}}{b}-b\\cdot \\f{\\underline{A}}{a} =  0 \\end{equation*}\n",
-       "\\begin{equation*} g = \\left[\\begin{array}{cccc}1 & 0 & 0 & 0\\\\0 & -1 & 0 & 0\\\\0 & 0 & -1 & 0\\\\0 & 0 & 0 & -1\\end{array}\\right] \\end{equation*}\n",
-       "\\begin{equation*} \\underline{T} = \\left\\{ \\begin{aligned} \\boldsymbol{e}_{t} &\\mapsto {T^{t}}_{t} \\boldsymbol{e}_{t} + {T^{x}}_{t} \\boldsymbol{e}_{x} + {T^{y}}_{t} \\boldsymbol{e}_{y} + {T^{z}}_{t} \\boldsymbol{e}_{z} \\\\ \\boldsymbol{e}_{x} &\\mapsto {T^{t}}_{x} \\boldsymbol{e}_{t} + {T^{x}}_{x} \\boldsymbol{e}_{x} + {T^{y}}_{x} \\boldsymbol{e}_{y} + {T^{z}}_{x} \\boldsymbol{e}_{z} \\\\ \\boldsymbol{e}_{y} &\\mapsto {T^{t}}_{y} \\boldsymbol{e}_{t} + {T^{x}}_{y} \\boldsymbol{e}_{x} + {T^{y}}_{y} \\boldsymbol{e}_{y} + {T^{z}}_{y} \\boldsymbol{e}_{z} \\\\ \\boldsymbol{e}_{z} &\\mapsto {T^{t}}_{z} \\boldsymbol{e}_{t} + {T^{x}}_{z} \\boldsymbol{e}_{x} + {T^{y}}_{z} \\boldsymbol{e}_{y} + {T^{z}}_{z} \\boldsymbol{e}_{z} \\end{aligned} \\right\\} \\end{equation*}\n",
-       "\\begin{equation*} \\overline{T} = \\left\\{ \\begin{aligned} \\boldsymbol{e}_{t} &\\mapsto {T^{t}}_{t} \\boldsymbol{e}_{t} - {T^{t}}_{x} \\boldsymbol{e}_{x} - {T^{t}}_{y} \\boldsymbol{e}_{y} - {T^{t}}_{z} \\boldsymbol{e}_{z} \\\\ \\boldsymbol{e}_{x} &\\mapsto - {T^{x}}_{t} \\boldsymbol{e}_{t} + {T^{x}}_{x} \\boldsymbol{e}_{x} + {T^{x}}_{y} \\boldsymbol{e}_{y} + {T^{x}}_{z} \\boldsymbol{e}_{z} \\\\ \\boldsymbol{e}_{y} &\\mapsto - {T^{y}}_{t} \\boldsymbol{e}_{t} + {T^{y}}_{x} \\boldsymbol{e}_{x} + {T^{y}}_{y} \\boldsymbol{e}_{y} + {T^{y}}_{z} \\boldsymbol{e}_{z} \\\\ \\boldsymbol{e}_{z} &\\mapsto - {T^{z}}_{t} \\boldsymbol{e}_{t} + {T^{z}}_{x} \\boldsymbol{e}_{x} + {T^{z}}_{y} \\boldsymbol{e}_{y} + {T^{z}}_{z} \\boldsymbol{e}_{z} \\end{aligned} \\right\\} \\end{equation*}\n",
-       "\\begin{equation*} \\f{\\det}{\\underline{T}} = {T^{t}}_{t} {T^{x}}_{x} {T^{y}}_{y} {T^{z}}_{z} - {T^{t}}_{t} {T^{x}}_{x} {T^{y}}_{z} {T^{z}}_{y} - {T^{t}}_{t} {T^{x}}_{y} {T^{y}}_{x} {T^{z}}_{z} + {T^{t}}_{t} {T^{x}}_{y} {T^{y}}_{z} {T^{z}}_{x} + {T^{t}}_{t} {T^{x}}_{z} {T^{y}}_{x} {T^{z}}_{y} - {T^{t}}_{t} {T^{x}}_{z} {T^{y}}_{y} {T^{z}}_{x} - {T^{t}}_{x} {T^{x}}_{t} {T^{y}}_{y} {T^{z}}_{z} + {T^{t}}_{x} {T^{x}}_{t} {T^{y}}_{z} {T^{z}}_{y} + {T^{t}}_{x} {T^{x}}_{y} {T^{y}}_{t} {T^{z}}_{z} - {T^{t}}_{x} {T^{x}}_{y} {T^{y}}_{z} {T^{z}}_{t} - {T^{t}}_{x} {T^{x}}_{z} {T^{y}}_{t} {T^{z}}_{y} + {T^{t}}_{x} {T^{x}}_{z} {T^{y}}_{y} {T^{z}}_{t} + {T^{t}}_{y} {T^{x}}_{t} {T^{y}}_{x} {T^{z}}_{z} - {T^{t}}_{y} {T^{x}}_{t} {T^{y}}_{z} {T^{z}}_{x} - {T^{t}}_{y} {T^{x}}_{x} {T^{y}}_{t} {T^{z}}_{z} + {T^{t}}_{y} {T^{x}}_{x} {T^{y}}_{z} {T^{z}}_{t} + {T^{t}}_{y} {T^{x}}_{z} {T^{y}}_{t} {T^{z}}_{x} - {T^{t}}_{y} {T^{x}}_{z} {T^{y}}_{x} {T^{z}}_{t} - {T^{t}}_{z} {T^{x}}_{t} {T^{y}}_{x} {T^{z}}_{y} + {T^{t}}_{z} {T^{x}}_{t} {T^{y}}_{y} {T^{z}}_{x} + {T^{t}}_{z} {T^{x}}_{x} {T^{y}}_{t} {T^{z}}_{y} - {T^{t}}_{z} {T^{x}}_{x} {T^{y}}_{y} {T^{z}}_{t} - {T^{t}}_{z} {T^{x}}_{y} {T^{y}}_{t} {T^{z}}_{x} + {T^{t}}_{z} {T^{x}}_{y} {T^{y}}_{x} {T^{z}}_{t} \\end{equation*}\n",
-       "\\begin{equation*} \\f{\\mbox{tr}}{\\underline{T}} = {T^{t}}_{t} + {T^{x}}_{x} + {T^{y}}_{y} + {T^{z}}_{z} \\end{equation*}\n",
-       "\\begin{equation*} a\\cdot \\f{\\overline{T}}{b}-b\\cdot \\f{\\underline{T}}{a} =  0 \\end{equation*}\n",
-       "\\begin{equation*} f = f \\end{equation*}\n",
-       "\\begin{equation*} \\boldsymbol{\\nabla}  f = \\partial_{u} f  \\boldsymbol{e}_{u} + \\frac{\\partial_{v} f }{\\sin{\\left (u \\right )}} \\boldsymbol{e}_{v} \\end{equation*}\n",
-       "\\begin{equation*} F = F^{u}  \\boldsymbol{e}_{u} + F^{v}  \\boldsymbol{e}_{v} \\end{equation*}\n",
-       "\\begin{equation*} \\boldsymbol{\\nabla}  F = \\left ( \\frac{F^{u} }{\\tan{\\left (u \\right )}} + \\partial_{u} F^{u}  + \\frac{\\partial_{v} F^{v} }{\\sin{\\left (u \\right )}}\\right )  + \\left ( \\frac{F^{v} }{\\tan{\\left (u \\right )}} + \\partial_{u} F^{v}  - \\frac{\\partial_{v} F^{u} }{\\sin{\\left (u \\right )}}\\right ) \\boldsymbol{e}_{u}\\wedge \\boldsymbol{e}_{v} \\end{equation*}\n",
-       "\\begin{equation*} f = f \\end{equation*}\n",
-       "\\begin{equation*} \\boldsymbol{\\nabla}  f = \\partial_{\\theta } f  \\boldsymbol{e}_{\\theta } + \\frac{\\partial_{\\phi } f }{\\sin{\\left (\\theta  \\right )}} \\boldsymbol{e}_{\\phi } \\end{equation*}\n",
-       "\\begin{equation*} F = F^{\\theta }  \\boldsymbol{e}_{\\theta } + F^{\\phi }  \\boldsymbol{e}_{\\phi } \\end{equation*}\n",
-       "\\begin{equation*} \\boldsymbol{\\nabla}  F = \\left ( \\frac{F^{\\theta } }{\\tan{\\left (\\theta  \\right )}} + \\partial_{\\theta } F^{\\theta }  + \\frac{\\partial_{\\phi } F^{\\phi } }{\\sin{\\left (\\theta  \\right )}}\\right )  + \\left ( \\frac{F^{\\phi } }{\\tan{\\left (\\theta  \\right )}} + \\partial_{\\theta } F^{\\phi }  - \\frac{\\partial_{\\phi } F^{\\theta } }{\\sin{\\left (\\theta  \\right )}}\\right ) \\boldsymbol{e}_{\\theta }\\wedge \\boldsymbol{e}_{\\phi } \\end{equation*}\n",
-       "\\end{document}\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Traceback (most recent call last):\n",
+      "  File \"lin_tran_check.py\", line 162, in <module>\n",
+      "    main()\n",
+      "  File \"lin_tran_check.py\", line 43, in main\n",
+      "    print('\\\\overline{A} =', A.adj())\n",
+      "                             ^^^^^^^\n",
+      "  File \"/Users/lume/projects/galgebra/galgebra/lt.py\", line 546, in adj\n",
+      "    return self.Ga.lt(matrix_of_adjoint)\n",
+      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/lume/projects/galgebra/galgebra/ga.py\", line 999, in lt\n",
+      "    return lt.Lt(*args, ga=self, **kwargs)\n",
+      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/lume/projects/galgebra/galgebra/lt.py\", line 369, in __init__\n",
+      "    raise TypeError(\"Unsupported argument type {}\".format(type(mat_rep)))\n",
+      "TypeError: Unsupported argument type <class 'sympy.matrices.immutable.ImmutableDenseMatrix'>\n"
+     ]
+    },
+    {
+     "ename": "RuntimeError",
+     "evalue": "The script raised an exception:\n\nTraceback (most recent call last):\n  File \"/Users/lume/projects/galgebra/examples/LaTeX/lin_tran_check.py\", line 162, in <module>\n    main()\n  File \"/Users/lume/projects/galgebra/examples/LaTeX/lin_tran_check.py\", line 43, in main\n    print('\\\\overline{A} =', A.adj())\n                             ^^^^^^^\n  File \"/Users/lume/projects/galgebra/galgebra/lt.py\", line 546, in adj\n    return self.Ga.lt(matrix_of_adjoint)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/lume/projects/galgebra/galgebra/ga.py\", line 999, in lt\n    return lt.Lt(*args, ga=self, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/lume/projects/galgebra/galgebra/lt.py\", line 369, in __init__\n    raise TypeError(\"Unsupported argument type {}\".format(type(mat_rep)))\nTypeError: Unsupported argument type <class 'sympy.matrices.immutable.ImmutableDenseMatrix'>\n",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mRuntimeError\u001b[39m                              Traceback (most recent call last)",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[12]\u001b[39m\u001b[32m, line 1\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m \u001b[43mcheck\u001b[49m\u001b[43m(\u001b[49m\u001b[33;43m'\u001b[39;49m\u001b[33;43mlin_tran_check\u001b[39;49m\u001b[33;43m'\u001b[39;49m\u001b[43m)\u001b[49m\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~/projects/galgebra/examples/ipython/galgebra_ipython_helpers.py:8\u001b[39m, in \u001b[36mcheck\u001b[39m\u001b[34m(name)\u001b[39m\n\u001b[32m      7\u001b[39m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34mcheck\u001b[39m(name):\n\u001b[32m----> \u001b[39m\u001b[32m8\u001b[39m     \u001b[43mrun\u001b[49m\u001b[43m(\u001b[49m\u001b[43mname\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m     10\u001b[39m     \u001b[38;5;28;01mwith\u001b[39;00m \u001b[38;5;28mopen\u001b[39m(name + \u001b[33m'\u001b[39m\u001b[33m.tex\u001b[39m\u001b[33m'\u001b[39m, \u001b[33m'\u001b[39m\u001b[33mr\u001b[39m\u001b[33m'\u001b[39m) \u001b[38;5;28;01mas\u001b[39;00m f:\n\u001b[32m     11\u001b[39m         \u001b[38;5;66;03m# can't use display.Latex here, it would result in CSS comparisons in the output.\u001b[39;00m\n\u001b[32m     12\u001b[39m         \u001b[38;5;66;03m# using `display` forces this to be a separate output to any stdout from above.\u001b[39;00m\n\u001b[32m     13\u001b[39m         display_pretty(f.read(), raw=\u001b[38;5;28;01mTrue\u001b[39;00m)\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~/projects/galgebra/examples/ipython/galgebra_ipython_helpers.py:32\u001b[39m, in \u001b[36mrun\u001b[39m\u001b[34m(name)\u001b[39m\n\u001b[32m     30\u001b[39m \u001b[38;5;66;03m# this makes the error easier to read in nbval\u001b[39;00m\n\u001b[32m     31\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m p.returncode:\n\u001b[32m---> \u001b[39m\u001b[32m32\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mRuntimeError\u001b[39;00m(\u001b[33m\"\u001b[39m\u001b[33mThe script raised an exception:\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[33m\"\u001b[39m + p.stderr)\n",
+      "\u001b[31mRuntimeError\u001b[39m: The script raised an exception:\n\nTraceback (most recent call last):\n  File \"/Users/lume/projects/galgebra/examples/LaTeX/lin_tran_check.py\", line 162, in <module>\n    main()\n  File \"/Users/lume/projects/galgebra/examples/LaTeX/lin_tran_check.py\", line 43, in main\n    print('\\\\overline{A} =', A.adj())\n                             ^^^^^^^\n  File \"/Users/lume/projects/galgebra/galgebra/lt.py\", line 546, in adj\n    return self.Ga.lt(matrix_of_adjoint)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/lume/projects/galgebra/galgebra/ga.py\", line 999, in lt\n    return lt.Lt(*args, ga=self, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/lume/projects/galgebra/galgebra/lt.py\", line 369, in __init__\n    raise TypeError(\"Unsupported argument type {}\".format(type(mat_rep)))\nTypeError: Unsupported argument type <class 'sympy.matrices.immutable.ImmutableDenseMatrix'>\n"
+     ]
     }
    ],
    "source": [
@@ -1579,7 +1582,14 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-03T17:50:01.564998Z",
+     "iopub.status.busy": "2026-04-03T17:50:01.564901Z",
+     "iopub.status.idle": "2026-04-03T17:50:04.365405Z",
+     "shell.execute_reply": "2026-04-03T17:50:04.364872Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -1657,7 +1667,14 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-03T17:50:04.367096Z",
+     "iopub.status.busy": "2026-04-03T17:50:04.367024Z",
+     "iopub.status.idle": "2026-04-03T17:50:05.321480Z",
+     "shell.execute_reply": "2026-04-03T17:50:05.320852Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -1739,7 +1756,14 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-03T17:50:05.323229Z",
+     "iopub.status.busy": "2026-04-03T17:50:05.323147Z",
+     "iopub.status.idle": "2026-04-03T17:50:05.637619Z",
+     "shell.execute_reply": "2026-04-03T17:50:05.637028Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -1808,7 +1832,14 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-03T17:50:05.639203Z",
+     "iopub.status.busy": "2026-04-03T17:50:05.639124Z",
+     "iopub.status.idle": "2026-04-03T17:50:06.457301Z",
+     "shell.execute_reply": "2026-04-03T17:50:06.456792Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -1883,7 +1914,14 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-03T17:50:06.458981Z",
+     "iopub.status.busy": "2026-04-03T17:50:06.458872Z",
+     "iopub.status.idle": "2026-04-03T17:50:06.957871Z",
+     "shell.execute_reply": "2026-04-03T17:50:06.957016Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -1965,7 +2003,14 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-03T17:50:06.959529Z",
+     "iopub.status.busy": "2026-04-03T17:50:06.959424Z",
+     "iopub.status.idle": "2026-04-03T17:50:08.586730Z",
+     "shell.execute_reply": "2026-04-03T17:50:08.586144Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -2087,7 +2132,14 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-03T17:50:08.588350Z",
+     "iopub.status.busy": "2026-04-03T17:50:08.588241Z",
+     "iopub.status.idle": "2026-04-03T17:50:09.644023Z",
+     "shell.execute_reply": "2026-04-03T17:50:09.643166Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -2317,7 +2369,14 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-03T17:50:09.646022Z",
+     "iopub.status.busy": "2026-04-03T17:50:09.645943Z",
+     "iopub.status.idle": "2026-04-03T17:50:10.120486Z",
+     "shell.execute_reply": "2026-04-03T17:50:10.119804Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -2401,7 +2460,14 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-03T17:50:10.122108Z",
+     "iopub.status.busy": "2026-04-03T17:50:10.122024Z",
+     "iopub.status.idle": "2026-04-03T17:50:10.733619Z",
+     "shell.execute_reply": "2026-04-03T17:50:10.732866Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -2498,7 +2564,14 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-03T17:50:10.735143Z",
+     "iopub.status.busy": "2026-04-03T17:50:10.735062Z",
+     "iopub.status.idle": "2026-04-03T17:50:11.326959Z",
+     "shell.execute_reply": "2026-04-03T17:50:11.326402Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -2612,7 +2685,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.8"
+   "version": "3.11.14"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Companion PR to #590, exploring an alternative code structure for the same SymPy 1.13 fix.

## Root cause (same as #590)

SymPy 1.13 PR #26390 added a `.replace(Mul, ...)` traversal inside `TR3`/`futrig` in `sympy.simplify.fu`. The `Ga.build(norm=True)` call in curvilinear-coordinate examples invokes `Simp.apply` ~70 times during metric normalisation, each triggering `simplify → trigsimp → futrig → TR3`. This scales as O(N·M) for mixed trig+hyperbolic expressions and causes > 10 min hang.

## Alternative approach explored here

Two-phase strategy, making the build/output separation explicit in code:

**Phase 1 — build:** A `_no_simp_build()` context manager temporarily replaces `Simp.modes` with an identity simplifier `[lambda e: e]` around each `Ga.build()` call.  This skips all ~70 redundant `Simp.apply` traversals during metric normalisation (the intermediate metric components are never printed, so unsimplified storage is fine).

**Phase 2 — output:** The `trigsimp(method='old')` profile set in `main()` is still active when `_sympystr` calls `Simp.apply` once per expression at formatting time, avoiding TR3 on the final results.

```python
@contextmanager
def _no_simp_build():
    orig = Simp.modes[:]
    Simp.profile([lambda e: e])  # identity during build
    try:
        yield
    finally:
        Simp.profile(orig)          # restore trigsimp(method='old')

# In each function:
with _no_simp_build():
    (sp3d, er, eth, ephi) = Ga.build(...)
```

## Outcome

| | #590 (trigsimp-old profile only) | This PR (deferred build + trigsimp-old) |
|---|---|---|
| Build time (prolate spheroidal) | ~1.5 s | ~0.5 s |
| Total run time | ~5 s | ~3.7 s |
| Output | `trigsimp(method='old')` canonical form | **Identical** |

Both approaches produce the same output and both fix the CI timeout.

## Alternative investigated but does not work

Replacing `trigsimp(method='old')` with plain `simplify()` in the output phase (to recover the pre-SymPy-1.13 canonical form) does **not** help.  The unsimplified metric components folded into the gradient/divergence/curl expressions make them large enough that TR3 is just as slow on the final result as on the intermediate metric components.  The call hangs after > 10 min on prolate spheroidal `grad|A`.

## Comparison

The structural difference from #590 is that `_no_simp_build()` makes explicit which `Simp.apply` calls are skipped (the ~70 build-phase calls) vs which are kept (the ~5 per-output formatting calls).  PR #590 achieves the same result via a single outer profile but relies on `trigsimp(method='old')` being idempotent on already-simplified metric components during build.

Both approaches are correct.  This PR exists to let us compare and decide which code structure to land.

Closes #576