### PR TITLE
chore: bump version to 0.6.1rc1

### DIFF
--- a/galgebra/_version.py
+++ b/galgebra/_version.py
@@ -5,4 +5,4 @@
 # 1) we don't load dependencies by storing it in __init__.py
 # 2) we can import it in setup.py for the same reason
 # 3) we can import it into your module
-__version__ = '0.6.0'
+__version__ = '0.6.1rc1'


### PR DESCRIPTION
## Summary

- Bumps `galgebra/_version.py` from `0.6.0` to `0.6.1rc1`

## Notes

- `test/.nbval_sanitize.cfg` already covers `rc\d+` suffix — no change needed
- Changelog already has the final `:release:`0.6.1 <2026.04.04>`` marker (per runbook: no RC marker in changelog)
- `_version.py` must exactly match the tag (lesson from #517)

## Release plan (after this PR is merged)

1. Squash merge to master
2. Run:
   ```bash
   gh release create v0.6.1rc1 \
       --prerelease \
       --target master \
       --title "v0.6.1rc1" \
       --notes "Release candidate for 0.6.1. See the [changelog](https://galgebra.readthedocs.io/en/latest/changelog.html) for details."
   ```
3. CI triggers from the tag and publishes `0.6.1rc1` to PyPI
4. Validate: PyPI, RTD, install smoke test
5. Then open the final version bump PR (`0.6.1rc1` → `0.6.1`)