### PR TITLE
ci: fix concurrency group causing master badge to show cancelled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
 
 concurrency:
-  group: test-${{ github.head_ref }}
+  group: test-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
## Problem

`github.head_ref` is only populated for `pull_request` events — it is empty for `push` (branch or tag) events. When two push events occur in quick succession (e.g. a merge commit to master followed immediately by a release tag), both land in the same concurrency group `test-` and the second run cancels the first.

This is what happened after #594 merged and the `v0.6.1rc1` tag was created 7 seconds later: the tag run cancelled the master run, leaving the master branch badge showing `cancelled` even though all checks actually passed.

## Fix

```yaml
concurrency:
  group: test-${{ github.head_ref || github.ref }}
  cancel-in-progress: true
```

`github.head_ref || github.ref` gives each branch/tag its own concurrency group:
- PRs: `github.head_ref` = the PR's head branch name (unique per PR) — cancel-in-progress still works
- Push to master: `github.ref` = `refs/heads/master`
- Tag push: `github.ref` = `refs/tags/v0.6.1rc1`

No more cross-event cancellations.

## References

Discovered during the 0.6.1rc1 release (see #588).