### PR TITLE
docs: fix DOI badge and citation metadata

### DIFF
--- a/CITATION.md
+++ b/CITATION.md
@@ -2,7 +2,7 @@ Citing This Library
 -------------------
 
 `galgebra` is published to zenodo.
-DOI [10.5281/zenodo.10902114](https://doi.org/10.5281/zenodo.10902114) refers to all versions of `galgebra`.
+DOI [10.5281/zenodo.3857096](https://doi.org/10.5281/zenodo.3857096) refers to all versions of `galgebra`.
 
 If you want to cite all releases, use:
 ```BibTeX

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Symbolic Geometric Algebra/Calculus package for SymPy.
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/galgebra.svg)](https://pypi.org/project/galgebra/)
 [![Python CI](https://github.com/pygae/galgebra/actions/workflows/ci.yml/badge.svg)](https://github.com/pygae/galgebra/actions/workflows/ci.yml)
 [![Documentation Status](https://readthedocs.org/projects/galgebra/badge/?version=latest)](https://galgebra.readthedocs.io/en/latest/?badge=latest)
-[![DOI](https://zenodo.org/badge/113447311.svg)](https://zenodo.org/badge/latestdoi/113447311)
+[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.3857096-blue.svg)](https://doi.org/10.5281/zenodo.3857096)
 
 ![](https://raw.githubusercontent.com/pygae/galgebra/master/doc/images/n_vector_positive_spherical.svg?sanitize=true)
 


### PR DESCRIPTION
Fixes the project DOI metadata in two places:

- Replaces the Zenodo-hosted README badge, which currently fails through GitHub's Camo proxy with an upstream 429, with a Shields-hosted badge for the permanent galgebra concept DOI.
- Corrects `CITATION.md`, where the version-specific v0.5.1rc2 DOI was incorrectly described as referring to all releases.

The README link, citation text, and existing BibTeX now consistently use concept DOI `10.5281/zenodo.3857096`.

Verified the GitHub-rendered Camo image and DOI target both return HTTP 200.
