### PR TITLE
chore: prepare 0.6.1rc3

### DIFF
--- a/galgebra/_version.py
+++ b/galgebra/_version.py
@@ -5,4 +5,4 @@
 # 1) we don't load dependencies by storing it in __init__.py
 # 2) we can import it in setup.py for the same reason
 # 3) we can import it into your module
-__version__ = '0.6.1rc2'
+__version__ = '0.6.1rc3'


### PR DESCRIPTION
## Summary

- bump the package version from `0.6.1rc2` to `0.6.1rc3`
- leave the changelog and final-release marker unchanged

## Motivation

`v0.6.1rc2` validated GitHub Actions, PyPI trusted publishing, installation, and Read the Docs, but it did not produce a Zenodo record. After reconnecting the GitHub–Zenodo integration, rc3 provides a fresh immutable tag and package version for another end-to-end release-pipeline check.

## Verification

- package version assertion: `0.6.1rc3`
- sdist and wheel build successfully with rc3 filenames
- `git diff --check` passes

Refs #588.