### PR TITLE
chore: prepare 0.6.1rc4

### DIFF
--- a/galgebra/_version.py
+++ b/galgebra/_version.py
@@ -5,4 +5,4 @@
 # 1) we don't load dependencies by storing it in __init__.py
 # 2) we can import it in setup.py for the same reason
 # 3) we can import it into your module
-__version__ = '0.6.1rc3'
+__version__ = '0.6.1rc4'


### PR DESCRIPTION
Trying to make zenodo release work after updating webbook access token.

Bump from `0.6.1rc3` to `0.6.1rc4`.